### PR TITLE
chore: run format:check with useful message in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,10 @@
 echo "🔍 Running pre-commit checks..."
 
 echo "✨ Formatting code..."
-npm run format
+if ! npm run format:check; then
+  echo "❌ Code formatting check failed. Run \`npm run format\` to fix formatting issues then add changes and commit again."
+  exit 1
+fi
 
 echo "🧪 Running tests..."
 npm run test


### PR DESCRIPTION
**Problem**: When pre-commit runs and there is a lint failure, it fixes it without staging the changes for this commit. This means the commit will fail same check server-side in CI unless you add the new staged files and commit again before pushing.

**Solution:** Run `format:check` in the pre-commit hook instead with a message on failure explaining what to do. Auto-adding files is not always ideal here so dev must select them manually and re-commit.