### PR TITLE
feat: add Toggle component with Storybook stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@storybook/addon-a11y": "^9.1.8",
     "@storybook/addon-docs": "^9.1.8",
     "@storybook/addon-vitest": "^9.1.8",
+    "@storybook/nextjs-vite": "^9.1.8",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -59,6 +60,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.5.0",
+    "@vitest/browser": "3.2.4",
     "@vitest/coverage-v8": "3.2.4",
     "cypress": "^14.4.0",
     "eslint": "^9",
@@ -67,6 +69,7 @@
     "fake-indexeddb": "^6.0.1",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
+    "playwright": "^1.55.1",
     "prettier": "^3.2.5",
     "storybook": "^9.1.8",
     "tailwindcss": "^4",
@@ -74,9 +77,6 @@
     "tw-animate-css": "^1.3.0",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.2.4",
-    "@storybook/nextjs-vite": "^9.1.8",
-    "@vitest/browser": "3.2.4",
-    "playwright": "^1.55.1"
+    "vitest": "^3.2.4"
   }
 }

--- a/src/components/atoms/Toggle/Toggle.tsx
+++ b/src/components/atoms/Toggle/Toggle.tsx
@@ -7,12 +7,12 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/libs';
 
 const toggleVariants = cva(
-  'cursor-pointer inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'cursor-pointer inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors bg-transparent hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-transparent',
-        outline: 'border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground',
+        default: '',
+        outline: 'border border-input shadow-sm hover:bg-accent hover:text-accent-foreground',
       },
       size: {
         default: 'h-9 px-2 min-w-9',
@@ -28,10 +28,10 @@ const toggleVariants = cva(
 );
 
 const Toggle = React.forwardRef<
-  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentRef<typeof TogglePrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
 >(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root ref={ref} className={cn(toggleVariants({ variant, size, className }))} {...props} />
+  <TogglePrimitive.Root ref={ref} className={cn(toggleVariants({ variant, size }), className)} {...props} />
 ));
 
 Toggle.displayName = TogglePrimitive.Root.displayName;

--- a/src/stories/Atoms/Toggle.stories.tsx
+++ b/src/stories/Atoms/Toggle.stories.tsx
@@ -1,0 +1,252 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Toggle } from '@/components/atoms/Toggle/Toggle';
+import { Home, Settings, Heart, Star } from 'lucide-react';
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Atoms/Toggle',
+  component: Toggle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'A toggle component built on Radix UI primitives with customizable variants and sizes.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'outline'],
+      description: 'The visual style variant of the toggle',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg'],
+      description: 'The size of the toggle',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the toggle is disabled',
+    },
+    pressed: {
+      control: 'boolean',
+      description: 'Whether the toggle is in pressed/on state',
+    },
+    children: {
+      control: 'text',
+      description: 'The content inside the toggle',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Default story
+export const Default: Story = {
+  args: {
+    children: 'Toggle',
+  },
+};
+
+// Variants
+export const DefaultVariant: Story = {
+  args: {
+    children: 'Default Toggle',
+    variant: 'default',
+  },
+};
+
+export const OutlineVariant: Story = {
+  args: {
+    children: 'Outline Toggle',
+    variant: 'outline',
+  },
+};
+
+// Sizes
+export const Small: Story = {
+  args: {
+    children: 'Small',
+    size: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    children: 'Large Toggle',
+    size: 'lg',
+  },
+};
+
+// States
+export const Pressed: Story = {
+  args: {
+    children: 'Pressed Toggle',
+    pressed: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled Toggle',
+    disabled: true,
+  },
+};
+
+export const DisabledPressed: Story = {
+  args: {
+    children: 'Disabled Pressed',
+    disabled: true,
+    pressed: true,
+  },
+};
+
+// With Icons
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <Home className="size-4" />
+        Home
+      </>
+    ),
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    children: <Settings className="size-4" />,
+    'aria-label': 'Settings',
+  },
+};
+
+export const WithIconPressed: Story = {
+  args: {
+    children: (
+      <>
+        <Heart className="size-4" />
+        Liked
+      </>
+    ),
+    pressed: true,
+  },
+};
+
+// Interactive examples
+export const Interactive: Story = {
+  args: {
+    children: 'Click me',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'An interactive toggle that you can click to see state changes.',
+      },
+    },
+  },
+};
+
+// All variants showcase
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Toggle variant="default">Default</Toggle>
+        <Toggle variant="default" pressed>
+          Default Pressed
+        </Toggle>
+      </div>
+      <div className="flex gap-2">
+        <Toggle variant="outline">Outline</Toggle>
+        <Toggle variant="outline" pressed>
+          Outline Pressed
+        </Toggle>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'All available variants in both normal and pressed states.',
+      },
+    },
+  },
+};
+
+// All sizes showcase
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Toggle size="sm">Small</Toggle>
+      <Toggle size="default">Default</Toggle>
+      <Toggle size="lg">Large</Toggle>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'All available sizes for comparison.',
+      },
+    },
+  },
+};
+
+// Icon showcase
+export const IconShowcase: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <Toggle aria-label="Home">
+        <Home className="size-4" />
+      </Toggle>
+      <Toggle aria-label="Settings">
+        <Settings className="size-4" />
+      </Toggle>
+      <Toggle aria-label="Like">
+        <Heart className="size-4" />
+      </Toggle>
+      <Toggle aria-label="Star">
+        <Star className="size-4" />
+      </Toggle>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Icon-only toggles with proper accessibility labels.',
+      },
+    },
+  },
+};
+
+// Accessibility example
+export const AccessibilityExample: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div>
+        <label htmlFor="notifications" className="block text-sm font-medium mb-2">
+          Notifications
+        </label>
+        <Toggle id="notifications" aria-label="Toggle notifications">
+          <Settings className="size-4" />
+        </Toggle>
+      </div>
+      <div>
+        <label htmlFor="dark-mode" className="block text-sm font-medium mb-2">
+          Dark Mode
+        </label>
+        <Toggle id="dark-mode" aria-label="Toggle dark mode">
+          Dark Mode
+        </Toggle>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Examples showing proper accessibility with labels and ARIA attributes.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
- Add comprehensive Storybook stories for Toggle component
- Fix ElementRef deprecation by replacing with React.ComponentRef
- Fix className parameter handling in toggleVariants
- Remove overlapping bg-transparent classes by moving to base classes
- Install missing @radix-ui/react-toggle dependency
- Fix Storybook import to use @storybook/nextjs-vite framework