### PR TITLE
bug: post models ids wrong

### DIFF
--- a/src/core/models/post/details/postDetails.schema.ts
+++ b/src/core/models/post/details/postDetails.schema.ts
@@ -1,13 +1,14 @@
 import * as Core from '@/core';
 
-export type PostDetailsModelSchema = Core.NexusPostDetails;
+// The id of the model is composed of the author and the id
+// authorId:postId
+export type PostDetailsModelSchema = Omit<Core.NexusPostDetails, 'author'>;
 
 // Primary and compound indexes for Dexie
 export const postDetailsTableSchema = `
   &id,
   content,
   indexed_at,
-  author,
   kind,
   uri,
   attachments

--- a/src/core/models/post/details/postDetails.test.ts
+++ b/src/core/models/post/details/postDetails.test.ts
@@ -10,6 +10,7 @@ describe('PostDetailsModel', () => {
   const testPostId2 = 'post-test-2';
   const testAuthor = 'test-author-pubky';
 
+  // Mock data that simulates the API response (includes author)
   const MOCK_NEXUS_POST_DETAILS: Omit<Core.NexusPostDetails, 'id'> = {
     content: 'This is a test post content',
     indexed_at: Date.now(),
@@ -19,30 +20,34 @@ describe('PostDetailsModel', () => {
     attachments: ['image1.jpg', 'image2.png'],
   };
 
+  // Helper function to create PostDetailsModelSchema (without author, with composite ID)
+  const createPostDetailsData = (
+    originalId: string,
+    nexusDetails: typeof MOCK_NEXUS_POST_DETAILS,
+  ): Core.PostDetailsModelSchema => {
+    const compositeId = `${nexusDetails.author}:${originalId}`;
+    // eslint-disable-next-line
+    const { author, ...detailsWithoutAuthor } = nexusDetails;
+    return { ...detailsWithoutAuthor, id: compositeId };
+  };
+
   describe('Constructor', () => {
     it('should create PostDetailsModel instance with all properties', () => {
-      const mockPostDetailsData = {
-        id: testPostId1,
-        ...MOCK_NEXUS_POST_DETAILS,
-      };
+      const mockPostDetailsData = createPostDetailsData(testPostId1, MOCK_NEXUS_POST_DETAILS);
 
       const postDetails = new Core.PostDetailsModel(mockPostDetailsData);
 
-      expect(postDetails.id).toBe(mockPostDetailsData.id);
+      expect(postDetails.id).toBe(`${testAuthor}:${testPostId1}`);
       expect(postDetails.content).toBe(mockPostDetailsData.content);
       expect(postDetails.indexed_at).toBe(mockPostDetailsData.indexed_at);
-      expect(postDetails.author).toBe(mockPostDetailsData.author);
       expect(postDetails.kind).toBe(mockPostDetailsData.kind);
       expect(postDetails.uri).toBe(mockPostDetailsData.uri);
       expect(postDetails.attachments).toEqual(mockPostDetailsData.attachments);
     });
 
     it('should handle null attachments', () => {
-      const mockPostDetailsData = {
-        id: testPostId1,
-        ...MOCK_NEXUS_POST_DETAILS,
-        attachments: null,
-      };
+      const mockNexusDetails = { ...MOCK_NEXUS_POST_DETAILS, attachments: null };
+      const mockPostDetailsData = createPostDetailsData(testPostId1, mockNexusDetails);
 
       const postDetails = new Core.PostDetailsModel(mockPostDetailsData);
 
@@ -52,28 +57,22 @@ describe('PostDetailsModel', () => {
 
   describe('Static Methods', () => {
     it('should insert post details', async () => {
-      const mockPostDetailsData = {
-        id: testPostId1,
-        ...MOCK_NEXUS_POST_DETAILS,
-      };
+      const mockPostDetailsData = createPostDetailsData(testPostId1, MOCK_NEXUS_POST_DETAILS);
 
       const result = await Core.PostDetailsModel.insert(mockPostDetailsData);
       expect(result).toBeDefined();
     });
 
     it('should find post details by id', async () => {
-      const mockPostDetailsData = {
-        id: testPostId1,
-        ...MOCK_NEXUS_POST_DETAILS,
-      };
+      const mockPostDetailsData = createPostDetailsData(testPostId1, MOCK_NEXUS_POST_DETAILS);
+      const compositeId = `${testAuthor}:${testPostId1}`;
 
       await Core.PostDetailsModel.insert(mockPostDetailsData);
-      const result = await Core.PostDetailsModel.findById(testPostId1);
+      const result = await Core.PostDetailsModel.findById(compositeId);
 
       expect(result).toBeInstanceOf(Core.PostDetailsModel);
-      expect(result.id).toBe(testPostId1);
+      expect(result.id).toBe(compositeId);
       expect(result.content).toBe(MOCK_NEXUS_POST_DETAILS.content);
-      expect(result.author).toBe(MOCK_NEXUS_POST_DETAILS.author);
     });
 
     it('should throw error for non-existent post details', async () => {
@@ -84,17 +83,19 @@ describe('PostDetailsModel', () => {
     });
 
     it('should bulk save post details from tuples', async () => {
-      const mockPostDetails: Core.NexusPostDetails[] = [
-        { id: testPostId1, ...MOCK_NEXUS_POST_DETAILS },
-        { id: testPostId2, ...MOCK_NEXUS_POST_DETAILS, content: 'Second post content' },
+      const mockPostDetails: Core.PostDetailsModelSchema[] = [
+        createPostDetailsData(testPostId1, MOCK_NEXUS_POST_DETAILS),
+        createPostDetailsData(testPostId2, { ...MOCK_NEXUS_POST_DETAILS, content: 'Second post content' }),
       ];
 
       const result = await Core.PostDetailsModel.bulkSave(mockPostDetails);
       expect(result).toBeDefined();
 
       // Verify the data was saved correctly
-      const postDetails1 = await Core.PostDetailsModel.findById(testPostId1);
-      const postDetails2 = await Core.PostDetailsModel.findById(testPostId2);
+      const compositeId1 = `${testAuthor}:${testPostId1}`;
+      const compositeId2 = `${testAuthor}:${testPostId2}`;
+      const postDetails1 = await Core.PostDetailsModel.findById(compositeId1);
+      const postDetails2 = await Core.PostDetailsModel.findById(compositeId2);
 
       expect(postDetails1.content).toBe('This is a test post content');
       expect(postDetails2.content).toBe('Second post content');
@@ -107,30 +108,34 @@ describe('PostDetailsModel', () => {
     });
 
     it('should handle different post kinds', async () => {
-      const mockPostDetails: Core.NexusPostDetails[] = [
-        { id: testPostId1, ...MOCK_NEXUS_POST_DETAILS, kind: 'short' },
-        { id: testPostId2, ...MOCK_NEXUS_POST_DETAILS, kind: 'long' },
+      const mockPostDetails: Core.PostDetailsModelSchema[] = [
+        createPostDetailsData(testPostId1, { ...MOCK_NEXUS_POST_DETAILS, kind: 'short' }),
+        createPostDetailsData(testPostId2, { ...MOCK_NEXUS_POST_DETAILS, kind: 'long' }),
       ];
 
       await Core.PostDetailsModel.bulkSave(mockPostDetails);
 
-      const postDetails1 = await Core.PostDetailsModel.findById(testPostId1);
-      const postDetails2 = await Core.PostDetailsModel.findById(testPostId2);
+      const compositeId1 = `${testAuthor}:${testPostId1}`;
+      const compositeId2 = `${testAuthor}:${testPostId2}`;
+      const postDetails1 = await Core.PostDetailsModel.findById(compositeId1);
+      const postDetails2 = await Core.PostDetailsModel.findById(compositeId2);
 
       expect(postDetails1.kind).toBe('short');
       expect(postDetails2.kind).toBe('long');
     });
 
     it('should handle posts with and without attachments', async () => {
-      const mockPostDetails: Core.NexusPostDetails[] = [
-        { id: testPostId1, ...MOCK_NEXUS_POST_DETAILS, attachments: ['file1.jpg'] },
-        { id: testPostId2, ...MOCK_NEXUS_POST_DETAILS, attachments: null },
+      const mockPostDetails: Core.PostDetailsModelSchema[] = [
+        createPostDetailsData(testPostId1, { ...MOCK_NEXUS_POST_DETAILS, attachments: ['file1.jpg'] }),
+        createPostDetailsData(testPostId2, { ...MOCK_NEXUS_POST_DETAILS, attachments: null }),
       ];
 
       await Core.PostDetailsModel.bulkSave(mockPostDetails);
 
-      const postDetails1 = await Core.PostDetailsModel.findById(testPostId1);
-      const postDetails2 = await Core.PostDetailsModel.findById(testPostId2);
+      const compositeId1 = `${testAuthor}:${testPostId1}`;
+      const compositeId2 = `${testAuthor}:${testPostId2}`;
+      const postDetails1 = await Core.PostDetailsModel.findById(compositeId1);
+      const postDetails2 = await Core.PostDetailsModel.findById(compositeId2);
 
       expect(postDetails1.attachments).toEqual(['file1.jpg']);
       expect(postDetails2.attachments).toBeNull();

--- a/src/core/models/post/details/postDetails.ts
+++ b/src/core/models/post/details/postDetails.ts
@@ -11,7 +11,6 @@ export class PostDetailsModel
 
   content: string;
   indexed_at: number;
-  author: Core.Pubky;
   kind: Core.NexusPostKind;
   uri: string;
   attachments: string[] | null;
@@ -20,7 +19,6 @@ export class PostDetailsModel
     super(postDetails);
     this.content = postDetails.content;
     this.indexed_at = postDetails.indexed_at;
-    this.author = postDetails.author;
     this.kind = postDetails.kind;
     this.uri = postDetails.uri;
     this.attachments = postDetails.attachments;

--- a/src/core/services/nexus/bootstrap/bootstrap.test.ts
+++ b/src/core/services/nexus/bootstrap/bootstrap.test.ts
@@ -212,24 +212,26 @@ describe('NexusService', () => {
 
       await Core.NexusBootstrapService.retrieveAndPersist(pubky);
 
+      // Create composite ID as done in bootstrap service
+      const compositePostId = `${pubky}:${testPostId}`;
+
       // Verify post details were persisted to database
-      const savedPostDetails = await Core.PostDetailsModel.findById(testPostId);
+      const savedPostDetails = await Core.PostDetailsModel.findById(compositePostId);
       expect(savedPostDetails).toBeTruthy();
-      expect(savedPostDetails.id).toBe(testPostId);
+      expect(savedPostDetails.id).toBe(compositePostId);
       expect(savedPostDetails.content).toBe('Bootstrap post content');
-      expect(savedPostDetails.author).toBe(pubky);
 
       // Verify post counts were persisted to database
-      const savedPostCounts = await Core.PostCountsModel.findById(testPostId);
+      const savedPostCounts = await Core.PostCountsModel.findById(compositePostId);
       expect(savedPostCounts).toBeTruthy();
-      expect(savedPostCounts.id).toBe(testPostId);
+      expect(savedPostCounts.id).toBe(compositePostId);
       expect(savedPostCounts.replies).toBe(0);
       expect(savedPostCounts.reposts).toBe(0);
 
       // Verify post tags were persisted to database
-      const savedPostTags = await Core.PostTagsModel.findById(testPostId);
+      const savedPostTags = await Core.PostTagsModel.findById(compositePostId);
       expect(savedPostTags).toBeTruthy();
-      expect(savedPostTags.id).toBe(testPostId);
+      expect(savedPostTags.id).toBe(compositePostId);
       expect(savedPostTags.tags).toHaveLength(2);
       expect(savedPostTags.tags[0].label).toBe('tech');
       expect(savedPostTags.tags[0].taggers_count).toBe(1);
@@ -285,16 +287,17 @@ describe('NexusService', () => {
       expect(savedUserTags).toBeTruthy();
 
       // Verify post details were persisted
-      const savedPostDetails = await Core.PostDetailsModel.findById(testPostId);
+      const compositePostId = `${testUserId}:${testPostId}`;
+      const savedPostDetails = await Core.PostDetailsModel.findById(compositePostId);
       expect(savedPostDetails).toBeTruthy();
       expect(savedPostDetails.content).toBe('Bootstrap post content');
 
       // Verify post counts were persisted
-      const savedPostCounts = await Core.PostCountsModel.findById(testPostId);
+      const savedPostCounts = await Core.PostCountsModel.findById(compositePostId);
       expect(savedPostCounts).toBeTruthy();
 
       // Verify post tags were persisted
-      const savedPostTags = await Core.PostTagsModel.findById(testPostId);
+      const savedPostTags = await Core.PostTagsModel.findById(compositePostId);
       expect(savedPostTags).toBeTruthy();
 
       const savedStream = await Core.StreamModel.findById(Core.StreamTypes.TIMELINE_ALL);

--- a/src/core/services/nexus/bootstrap/bootstrap.ts
+++ b/src/core/services/nexus/bootstrap/bootstrap.ts
@@ -30,9 +30,28 @@ export class NexusBootstrapService {
   }
 
   static async persistPosts(posts: Core.NexusPost[]) {
-    await Core.PostCountsModel.bulkSave(posts.map((post) => [post.details.id, post.counts]));
-    await Core.PostDetailsModel.bulkSave(posts.map((post) => post.details));
-    await Core.PostRelationshipsModel.bulkSave(posts.map((post) => [post.details.id, post.relationships]));
-    await Core.PostTagsModel.bulkSave(posts.map((post) => [post.details.id, post.tags]));
+    const postCounts: Core.NexusModelTuple<Core.NexusPostCounts>[] = [];
+    const postRelationships: Core.NexusModelTuple<Core.NexusPostRelationships>[] = [];
+    const postTags: Core.NexusModelTuple<Core.TagModel[]>[] = [];
+    const postDetails: Core.RecordModelBase<string, Core.PostDetailsModelSchema>[] = [];
+
+    for (const post of posts) {
+      // post.details.id is Crockford Base32 strings derived from timestamps. If two users post at the same time, the id will be the same.
+      // To avoid that, we need to use the authorId:postId format to ensure the id is unique.
+      const postId = `${post.details.author}:${post.details.id}`;
+
+      postCounts.push([postId, post.counts]);
+      postRelationships.push([postId, post.relationships]);
+      postTags.push([postId, post.tags]);
+      // Exclude the author from the post details
+      // eslint-disable-next-line
+      const { author, ...detailsWithoutAuthor } = post.details;
+      postDetails.push({ ...detailsWithoutAuthor, id: postId });
+    }
+
+    await Core.PostDetailsModel.bulkSave(postDetails);
+    await Core.PostCountsModel.bulkSave(postCounts);
+    await Core.PostTagsModel.bulkSave(postTags);
+    await Core.PostRelationshipsModel.bulkSave(postRelationships);
   }
 }


### PR DESCRIPTION
`post.details.id` is Crockford Base32 strings derived from timestamps. If two users post at the same time, the id will be the same. To avoid that, we need to use the `authorId:postId` format to ensure the id is unique.