### PR TITLE
Run E2E tests on 3 browsers and more caching

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,8 +13,9 @@ jobs:
       # https://github.com/pubky/pubky-stack
       PUBKY_STACK_REF: ce44db8342d7e0673eba8f6862ba11e163a1ff9b
     strategy:
+      fail-fast: false
       matrix:
-        browser: [chrome, firefox, safari]
+        browser: [chrome, firefox, webkit]
 
     steps:
       - name: Checkout this repository
@@ -90,25 +91,6 @@ jobs:
         working-directory: pubky-stack/docker
         run: docker compose up -d nexusd nexus-redis nexus-neo4j homeserver
 
-      - name: Wait for dockerised pubky-stack to start
-        run: |
-          PORT=8080
-          MAX_WAIT=300     # Maximum wait time in seconds (5 minutes)
-          WAIT_INTERVAL=5  # Interval between checks in seconds
-          ELAPSED=0
-
-          while ! curl -s http://localhost:$PORT; do
-            if [ $ELAPSED -ge $MAX_WAIT ]; then
-              echo "Service did not start within 5 minutes."
-              exit 1
-            fi
-            echo "Waiting for service on port $PORT to be ready... ($ELAPSED seconds elapsed)"
-            sleep $WAIT_INTERVAL
-            ELAPSED=$((ELAPSED + WAIT_INTERVAL))
-          done
-
-          echo "Service is ready."
-
       - name: Build Franky frontend
         working-directory: franky
         run: |
@@ -127,6 +109,31 @@ jobs:
           SUPPORT_ACCOUNT_ID=1" > .env
           npm ci
           npm run build
+
+      - name: Install WebKit for Safari testing
+        if: ${{ matrix.browser == 'safari' }}
+        run: |
+          npm install playwright-webkit --save-dev
+          npx playwright install-deps webkit
+
+      - name: Wait for dockerised pubky-stack to start
+        run: |
+          PORT=8080
+          MAX_WAIT=300     # Maximum wait time in seconds (5 minutes)
+          WAIT_INTERVAL=5  # Interval between checks in seconds
+          ELAPSED=0
+
+          while ! curl -s http://localhost:$PORT; do
+            if [ $ELAPSED -ge $MAX_WAIT ]; then
+              echo "Service did not start within 5 minutes."
+              exit 1
+            fi
+            echo "Waiting for service on port $PORT to be ready... ($ELAPSED seconds elapsed)"
+            sleep $WAIT_INTERVAL
+            ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+          done
+
+          echo "Service is ready."
 
       - name: Run e2e tests (${{ matrix.browser }})
         uses: cypress-io/github-action@v6

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,6 +35,35 @@ jobs:
           # limitation where only a single key can be used per repo checkout
           # see https://github.com/actions/checkout/issues/183
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            franky/node_modules
+            franky/.next/cache
+          key: ${{ runner.os }}-node-${{ hashFiles('franky/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Cache Playwright browsers
+        if: ${{ matrix.browser == 'webkit' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('franky/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: |
+            franky/.next
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('franky/package-lock.json', 'franky/src/**/*.{js,jsx,ts,tsx}', 'franky/public/**', 'franky/next.config.ts', 'franky/tailwind.config.*', 'franky/postcss.config.*') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-
+
       # reduce neo4j memory to prevent
       # ERROR Invalid memory configuration - exceeds physical memory. Check the configured values for server.memory.pagecache.size and server.memory.heap.max_size
       - name: Modify neo4j.env
@@ -111,7 +140,7 @@ jobs:
           npm run build
 
       - name: Install WebKit for Safari testing
-        if: ${{ matrix.browser == 'safari' }}
+        if: ${{ matrix.browser == 'webkit' }}
         run: |
           npm install playwright-webkit --save-dev
           npx playwright install-deps webkit

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,7 +14,7 @@ jobs:
       PUBKY_STACK_REF: ce44db8342d7e0673eba8f6862ba11e163a1ff9b
     strategy:
       matrix:
-        browser: [chrome] # [chrome, firefox]
+        browser: [chrome, firefox, safari]
 
     steps:
       - name: Checkout this repository

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
     video: true,
     viewportWidth: 1920,
     viewportHeight: 1080,
+    // Safari support
+    experimentalWebKitSupport: true,
     env: {
       // slow down execution more in CI to avoid flaky tests
       commandDelay: defaultMs,


### PR DESCRIPTION
Run E2E tests on Chrome, Firefox and Webkit (Safari). Also added caching for Node, Next.JS, and Webkit installation.