### PR TITLE
fix: missing replies in post detail view

### DIFF
--- a/src/components/organisms/PostReplies/PostReplies.tsx
+++ b/src/components/organisms/PostReplies/PostReplies.tsx
@@ -10,16 +10,17 @@ interface PostRepliesProps {
 }
 
 export function PostReplies({ postId }: PostRepliesProps) {
-  // useLiveQuery is required here instead of useEffect because when
-  // someone post a reply through PostReplyInput we need this to rerender
+  const postDetails = useLiveQuery(() => Core.db.post_details.get(postId), [postId]);
+
   const replyIds = useLiveQuery(
-    () =>
-      Core.db.post_relationships
-        .where('replied')
-        .equals(postId)
-        .toArray()
-        .then((replyRelationships) => replyRelationships.map((rel) => rel.id)),
-    [postId],
+    async () => {
+      if (!postDetails?.uri) return [];
+
+      const replyRelationships = await Core.db.post_relationships.where('replied').equals(postDetails.uri).toArray();
+
+      return replyRelationships.map((rel) => rel.id);
+    },
+    [postDetails?.uri],
     [],
   );
 

--- a/src/core/services/local/post/post.ts
+++ b/src/core/services/local/post/post.ts
@@ -103,7 +103,7 @@ export class LocalPostService {
 
       const replyRelationships: Core.PostRelationshipsModelSchema = {
         id: replyDetails.id,
-        replied: parentPostId,
+        replied: parentPost.uri,
         reposted: null,
         mentioned: [],
       };


### PR DESCRIPTION
Nexus returns `replied` field as a URI (i.e. `pubky://author/pub/pubky.app/posts/postId`) during bootstrap, but we were querying for replies using composite IDs (`author:postId`) from IndexedDB, so it couldn't find matches, resulting in empty replies. This PR uses the URI to query instead so replies are loaded properly.