### PR TITLE
feat: nested reply link

### DIFF
--- a/src/components/organisms/PostReplies/PostReplies.test.tsx
+++ b/src/components/organisms/PostReplies/PostReplies.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { PostReplies } from './PostReplies';
+
+// Mock Next.js router
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+// Mock dexie-react-hooks
+vi.mock('dexie-react-hooks', () => ({
+  useLiveQuery: vi.fn(),
+}));
+
+// Mock Organisms components
+vi.mock('@/organisms', () => ({
+  Post: vi.fn(({ postId, isReply, clickable, onClick }) => (
+    <div
+      data-testid={`post-${postId}`}
+      data-reply={isReply}
+      data-clickable={clickable}
+      onClick={onClick}
+      style={{ cursor: clickable ? 'pointer' : 'default' }}
+    >
+      Post {postId}
+    </div>
+  )),
+}));
+
+// Mock Atoms components
+vi.mock('@/atoms', () => ({
+  Container: vi.fn(({ children, className }) => (
+    <div data-testid="container" className={className}>
+      {children}
+    </div>
+  )),
+}));
+
+const mockPush = vi.fn();
+const mockUseLiveQuery = vi.mocked(useLiveQuery);
+const mockUseRouter = vi.mocked(useRouter);
+
+describe('PostReplies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    });
+  });
+
+  it('renders without replies', () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce([]); // replyIds
+
+    render(<PostReplies postId="test-post-id" />);
+
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+    expect(screen.queryByTestId(/post-/)).not.toBeInTheDocument();
+  });
+
+  it('renders replies when available', () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['author1:reply1', 'author2:reply2']); // replyIds
+
+    render(<PostReplies postId="test-post-id" />);
+
+    expect(screen.getByTestId('post-author1:reply1')).toBeInTheDocument();
+    expect(screen.getByTestId('post-author2:reply2')).toBeInTheDocument();
+
+    // Check that replies are marked as replies and clickable
+    expect(screen.getByTestId('post-author1:reply1')).toHaveAttribute('data-reply', 'true');
+    expect(screen.getByTestId('post-author1:reply1')).toHaveAttribute('data-clickable', 'true');
+  });
+
+  it('navigates to reply when clicked', async () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['author1:reply1']); // replyIds
+
+    render(<PostReplies postId="test-post-id" />);
+
+    const replyPost = screen.getByTestId('post-author1:reply1');
+    fireEvent.click(replyPost);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/post/author1/reply1');
+    });
+  });
+
+  it('handles malformed combinedId gracefully', async () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['malformed-id-without-colon']); // replyIds
+
+    render(<PostReplies postId="test-post-id" />);
+
+    const replyPost = screen.getByTestId('post-malformed-id-without-colon');
+    fireEvent.click(replyPost);
+
+    // Should not navigate when ID is malformed
+    await waitFor(() => {
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('handles empty segments in combinedId gracefully', async () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce([':reply1', 'author1:']); // replyIds with empty segments
+
+    render(<PostReplies postId="test-post-id" />);
+
+    // Click first reply with empty authorId
+    const firstReply = screen.getByTestId('post-:reply1');
+    fireEvent.click(firstReply);
+
+    // Click second reply with empty replyPostId
+    const secondReply = screen.getByTestId('post-author1:');
+    fireEvent.click(secondReply);
+
+    // Should not navigate when segments are empty
+    await waitFor(() => {
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('maintains proper structure with reply connectors', () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['author1:reply1', 'author2:reply2']); // replyIds
+
+    render(<PostReplies postId="test-post-id" />);
+
+    const container = screen.getByTestId('container');
+    expect(container).toHaveClass('flex', 'flex-col', 'gap-4');
+
+    // Check that each reply has the proper flex structure for connectors
+    const replyContainers = container.querySelectorAll('.flex.gap-4');
+    expect(replyContainers).toHaveLength(2);
+
+    replyContainers.forEach((replyContainer) => {
+      // Check for connector space
+      const connectorSpace = replyContainer.querySelector('.w-8.flex-shrink-0');
+      expect(connectorSpace).toBeInTheDocument();
+
+      // Check for reply content area
+      const contentArea = replyContainer.querySelector('.flex-1');
+      expect(contentArea).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/organisms/PostReplies/PostReplies.test.tsx
+++ b/src/components/organisms/PostReplies/PostReplies.test.tsx
@@ -55,30 +55,40 @@ describe('PostReplies', () => {
     });
   });
 
-  it('renders without replies', () => {
+  it('renders snapshot without replies', () => {
     mockUseLiveQuery
       .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
       .mockReturnValueOnce([]); // replyIds
 
-    render(<PostReplies postId="test-post-id" />);
-
-    expect(screen.getByTestId('container')).toBeInTheDocument();
-    expect(screen.queryByTestId(/post-/)).not.toBeInTheDocument();
+    const { container } = render(<PostReplies postId="test-post-id" />);
+    expect(container).toMatchSnapshot();
   });
 
-  it('renders replies when available', () => {
+  it('renders snapshot with single reply', () => {
     mockUseLiveQuery
       .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
-      .mockReturnValueOnce(['author1:reply1', 'author2:reply2']); // replyIds
+      .mockReturnValueOnce(['author1:reply1']); // replyIds
 
-    render(<PostReplies postId="test-post-id" />);
+    const { container } = render(<PostReplies postId="test-post-id" />);
+    expect(container).toMatchSnapshot();
+  });
 
-    expect(screen.getByTestId('post-author1:reply1')).toBeInTheDocument();
-    expect(screen.getByTestId('post-author2:reply2')).toBeInTheDocument();
+  it('renders snapshot with multiple replies', () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['author1:reply1', 'author2:reply2', 'author3:reply3']); // replyIds
 
-    // Check that replies are marked as replies and clickable
-    expect(screen.getByTestId('post-author1:reply1')).toHaveAttribute('data-reply', 'true');
-    expect(screen.getByTestId('post-author1:reply1')).toHaveAttribute('data-clickable', 'true');
+    const { container } = render(<PostReplies postId="test-post-id" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders snapshot with malformed reply IDs', () => {
+    mockUseLiveQuery
+      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
+      .mockReturnValueOnce(['malformed-id-without-colon', ':reply1', 'author1:']); // replyIds
+
+    const { container } = render(<PostReplies postId="test-post-id" />);
+    expect(container).toMatchSnapshot();
   });
 
   it('navigates to reply when clicked', async () => {
@@ -130,31 +140,6 @@ describe('PostReplies', () => {
     // Should not navigate when segments are empty
     await waitFor(() => {
       expect(mockPush).not.toHaveBeenCalled();
-    });
-  });
-
-  it('maintains proper structure with reply connectors', () => {
-    mockUseLiveQuery
-      .mockReturnValueOnce({ uri: 'test-uri' }) // postDetails
-      .mockReturnValueOnce(['author1:reply1', 'author2:reply2']); // replyIds
-
-    render(<PostReplies postId="test-post-id" />);
-
-    const container = screen.getByTestId('container');
-    expect(container).toHaveClass('flex', 'flex-col', 'gap-4');
-
-    // Check that each reply has the proper flex structure for connectors
-    const replyContainers = container.querySelectorAll('.flex.gap-4');
-    expect(replyContainers).toHaveLength(2);
-
-    replyContainers.forEach((replyContainer) => {
-      // Check for connector space
-      const connectorSpace = replyContainer.querySelector('.w-8.flex-shrink-0');
-      expect(connectorSpace).toBeInTheDocument();
-
-      // Check for reply content area
-      const contentArea = replyContainer.querySelector('.flex-1');
-      expect(contentArea).toBeInTheDocument();
     });
   });
 });

--- a/src/components/organisms/PostReplies/PostReplies.test.tsx.snap
+++ b/src/components/organisms/PostReplies/PostReplies.test.tsx.snap
@@ -1,0 +1,180 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PostReplies > renders snapshot with malformed reply IDs 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4"
+    data-testid="container"
+  >
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-malformed-id-without-colon"
+          style="cursor: pointer;"
+        >
+          Post 
+          malformed-id-without-colon
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-:reply1"
+          style="cursor: pointer;"
+        >
+          Post 
+          :reply1
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-author1:"
+          style="cursor: pointer;"
+        >
+          Post 
+          author1:
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PostReplies > renders snapshot with multiple replies 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4"
+    data-testid="container"
+  >
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-author1:reply1"
+          style="cursor: pointer;"
+        >
+          Post 
+          author1:reply1
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-author2:reply2"
+          style="cursor: pointer;"
+        >
+          Post 
+          author2:reply2
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-author3:reply3"
+          style="cursor: pointer;"
+        >
+          Post 
+          author3:reply3
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PostReplies > renders snapshot with single reply 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4"
+    data-testid="container"
+  >
+    <div
+      class="flex gap-4"
+    >
+      <div
+        class="w-8 flex-shrink-0"
+      />
+      <div
+        class="flex-1"
+      >
+        <div
+          data-clickable="true"
+          data-reply="true"
+          data-testid="post-author1:reply1"
+          style="cursor: pointer;"
+        >
+          Post 
+          author1:reply1
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PostReplies > renders snapshot without replies 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4"
+    data-testid="container"
+  />
+</div>
+`;

--- a/src/components/organisms/PostReplies/PostReplies.tsx
+++ b/src/components/organisms/PostReplies/PostReplies.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLiveQuery } from 'dexie-react-hooks';
+import { useRouter } from 'next/navigation';
 import * as Atoms from '@/atoms';
 import * as Core from '@/core';
 import * as Organisms from '@/organisms';
@@ -12,6 +13,10 @@ interface PostRepliesProps {
 export function PostReplies({ postId }: PostRepliesProps) {
   const postDetails = useLiveQuery(() => Core.db.post_details.get(postId), [postId]);
 
+  const router = useRouter();
+
+  // useLiveQuery is required here instead of useEffect because when
+  // someone post a reply through PostReplyInput we need this to rerender
   const replyIds = useLiveQuery(
     async () => {
       if (!postDetails?.uri) return [];
@@ -24,13 +29,23 @@ export function PostReplies({ postId }: PostRepliesProps) {
     [],
   );
 
+  const handleReplyClick = (combinedId: string) => {
+    const [authorId, postId] = combinedId.split(':');
+    router.push(`/post/${authorId}/${postId}`);
+  };
+
   return (
     <Atoms.Container className="flex flex-col gap-4">
       {replyIds?.map((replyId) => (
         <div key={replyId} className="flex gap-4">
           <div className="w-8 flex-shrink-0">{/* Reply connector SVG will go here */}</div>
           <div className="flex-1">
-            <Organisms.Post postId={replyId} isReply={true} />
+            <Organisms.Post
+              postId={replyId}
+              isReply={true}
+              clickable={true}
+              onClick={() => handleReplyClick(replyId)}
+            />
           </div>
         </div>
       ))}

--- a/src/components/organisms/PostReplies/PostReplies.tsx
+++ b/src/components/organisms/PostReplies/PostReplies.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useRouter } from 'next/navigation';
+
 import * as Atoms from '@/atoms';
 import * as Core from '@/core';
 import * as Organisms from '@/organisms';
@@ -29,10 +31,14 @@ export function PostReplies({ postId }: PostRepliesProps) {
     [],
   );
 
-  const handleReplyClick = (combinedId: string) => {
-    const [authorId, postId] = combinedId.split(':');
-    router.push(`/post/${authorId}/${postId}`);
-  };
+  const handleReplyClick = useCallback(
+    (combinedId: string) => {
+      const [authorId, replyPostId] = combinedId.split(':');
+      if (!authorId || !replyPostId) return; // defensive guard
+      router.push(`/post/${authorId}/${replyPostId}`);
+    },
+    [router],
+  );
 
   return (
     <Atoms.Container className="flex flex-col gap-4">


### PR DESCRIPTION
Enable users to click a reply to open the post detail page with that reply as the root, allowing navigation into deeply nested threads.