### PR TITLE
feat: handle 'Enter' key to submit forms to improve UX

### DIFF
--- a/src/components/molecules/InputField/InputField.tsx
+++ b/src/components/molecules/InputField/InputField.tsx
@@ -19,6 +19,7 @@ interface InputFieldProps {
   loadingIcon?: ReactNode;
   status?: 'default' | 'success' | 'error';
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   maxLength?: number;
   iconPosition?: 'left' | 'right';
   message?: ReactNode;
@@ -42,6 +43,7 @@ export function InputField({
   loadingIcon,
   status = 'default',
   onChange,
+  onKeyDown,
   maxLength,
   iconPosition = 'left',
   message,
@@ -108,6 +110,7 @@ export function InputField({
           readOnly={readOnly}
           onClick={onClick}
           onChange={onChange}
+          onKeyDown={onKeyDown}
           maxLength={maxLength}
           aria-invalid={status === 'error'}
         />

--- a/src/components/molecules/TextareaField/TextareaField.test.tsx
+++ b/src/components/molecules/TextareaField/TextareaField.test.tsx
@@ -88,6 +88,31 @@ describe('TextareaField', () => {
     const textarea = screen.getByTestId('textarea');
     expect(textarea).toBeDisabled();
   });
+
+  it('handles onKeyDown events', () => {
+    const handleKeyDown = vi.fn();
+    render(<TextareaField value="" onKeyDown={handleKeyDown} />);
+
+    const textarea = screen.getByTestId('textarea');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(handleKeyDown).toHaveBeenCalledTimes(1);
+    expect(handleKeyDown).toHaveBeenCalledWith(expect.objectContaining({ key: 'Enter' }));
+  });
+
+  it('passes through onKeyDown with proper event type', () => {
+    const handleKeyDown = vi.fn((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Verify we receive the proper event type with textarea-specific properties
+      expect(e.currentTarget).toBeInstanceOf(HTMLTextAreaElement);
+    });
+
+    render(<TextareaField value="test" onKeyDown={handleKeyDown} />);
+
+    const textarea = screen.getByTestId('textarea');
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    expect(handleKeyDown).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('TextareaField - Snapshots', () => {

--- a/src/components/molecules/TextareaField/TextareaField.tsx
+++ b/src/components/molecules/TextareaField/TextareaField.tsx
@@ -12,6 +12,7 @@ interface TextareaFieldProps {
   variant?: 'default' | 'dashed';
   status?: 'default' | 'success' | 'error';
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   maxLength?: number;
   rows?: number;
   maxRows?: number;
@@ -30,6 +31,7 @@ export function TextareaField({
   variant = 'default',
   status = 'default',
   onChange,
+  onKeyDown,
   maxLength,
   rows = 4,
   message,
@@ -66,6 +68,7 @@ export function TextareaField({
           readOnly={readOnly}
           onClick={onClick}
           onChange={onChange}
+          onKeyDown={onKeyDown}
           maxLength={maxLength}
           rows={rows}
           aria-invalid={status === 'error'}

--- a/src/components/molecules/WordSlot/WordSlot.tsx
+++ b/src/components/molecules/WordSlot/WordSlot.tsx
@@ -6,7 +6,7 @@ export const WordSlot = (props: Types.WordSlotProps) => {
   const { index, word, mode } = props;
 
   if (mode === 'editable') {
-    const { isError, showError, isRestoring, onChange, onValidate } = props;
+    const { isError, showError, isRestoring, onChange, onValidate, onKeyDown } = props;
     const hasError = isError && showError;
 
     const containerClasses = Libs.cn(
@@ -37,6 +37,7 @@ export const WordSlot = (props: Types.WordSlotProps) => {
             className={inputColor}
             onChange={(e) => onChange(index, e.target.value.toLowerCase().trim())}
             onBlur={() => onValidate(index, word)}
+            onKeyDown={onKeyDown}
             disabled={isRestoring}
           />
         </Atoms.Container>

--- a/src/components/molecules/WordSlot/WordSlot.types.ts
+++ b/src/components/molecules/WordSlot/WordSlot.types.ts
@@ -10,7 +10,7 @@ type EditableWordSlotProps = BaseWordSlotProps & {
   isRestoring: boolean;
   onChange: (index: number, value: string) => void;
   onValidate: (index: number, word: string) => void;
-  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 };
 
 type ReadOnlyWordSlotProps = BaseWordSlotProps & {

--- a/src/components/molecules/WordSlot/WordSlot.types.ts
+++ b/src/components/molecules/WordSlot/WordSlot.types.ts
@@ -10,6 +10,7 @@ type EditableWordSlotProps = BaseWordSlotProps & {
   isRestoring: boolean;
   onChange: (index: number, value: string) => void;
   onValidate: (index: number, word: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
 };
 
 type ReadOnlyWordSlotProps = BaseWordSlotProps & {

--- a/src/components/organisms/DialogBackupEncrypted/DialogBackupEncrypted.tsx
+++ b/src/components/organisms/DialogBackupEncrypted/DialogBackupEncrypted.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import * as Atoms from '@/components/atoms';
 import * as Libs from '@/libs';
+import * as Hooks from '@/hooks';
 import Image from 'next/image';
 import { DialogClose } from '@radix-ui/react-dialog';
 import { Identity } from '@/libs';
@@ -100,15 +101,10 @@ function RecoveryStep1({ setStep }: { setStep: (step: number) => void }) {
   };
 
   const isFormValid = () => {
-    return password && passwordsMatch;
+    return Boolean(password && passwordsMatch);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && isFormValid()) {
-      e.preventDefault();
-      handleDownload();
-    }
-  };
+  const handleKeyDown = Hooks.useEnterSubmit(isFormValid, handleDownload);
 
   return (
     <>

--- a/src/components/organisms/DialogBackupEncrypted/DialogBackupEncrypted.tsx
+++ b/src/components/organisms/DialogBackupEncrypted/DialogBackupEncrypted.tsx
@@ -99,6 +99,17 @@ function RecoveryStep1({ setStep }: { setStep: (step: number) => void }) {
     setStep(2);
   };
 
+  const isFormValid = () => {
+    return password && passwordsMatch;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && isFormValid()) {
+      e.preventDefault();
+      handleDownload();
+    }
+  };
+
   return (
     <>
       <Atoms.DialogHeader className="space-y-1.5 pr-6">
@@ -124,6 +135,7 @@ function RecoveryStep1({ setStep }: { setStep: (step: number) => void }) {
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
+                  onKeyDown={handleKeyDown}
                   className="h-14 rounded-md border-dashed border bg-opacity-90 shadow-sm p-4"
                   placeholder="Enter a strong password"
                   autoComplete="new-password"
@@ -164,6 +176,7 @@ function RecoveryStep1({ setStep }: { setStep: (step: number) => void }) {
                 type="password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
+                onKeyDown={handleKeyDown}
                 className={`h-14 rounded-md border-dashed border bg-opacity-90 shadow-sm p-4 ${
                   confirmPassword && !passwordsMatch ? 'border-red-400' : ''
                 }`}
@@ -197,7 +210,7 @@ function RecoveryStep1({ setStep }: { setStep: (step: number) => void }) {
           id="download-file-btn"
           className="order-1 flex-1 rounded-full h-10 px-4 py-2.5 md:px-12 md:py-6"
           onClick={handleDownload}
-          disabled={!password || !passwordsMatch}
+          disabled={!isFormValid()}
         >
           <Libs.Download className="mr-2 h-4 w-4" />
           Download file

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
@@ -312,6 +312,31 @@ describe('DialogRestoreEncryptedFile', () => {
     expect(passwordInput).toHaveValue('testpassword');
   });
 
+  it('handles Enter key on password input to trigger restore', async () => {
+    mockLoginWithEncryptedFile.mockResolvedValue();
+
+    render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
+
+    const fileInput = screen.getByLabelText('Select encrypted backup file');
+    const passwordInput = screen.getByTestId('input');
+    const testFile = mockFile('test.pkarr');
+
+    // Set up file and password
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } });
+
+    // Press Enter on password input
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockLoginWithEncryptedFile).toHaveBeenCalledWith({ encryptedFile: testFile, password: 'testpassword' });
+    });
+
+    await waitFor(() => {
+      expect(mockOnRestore).toHaveBeenCalled();
+    });
+  });
+
   it('enables restore button when both file and password are provided', async () => {
     render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
 

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
@@ -33,36 +33,40 @@ vi.mock('@radix-ui/react-dialog', () => ({
 }));
 
 // Mock libs
-vi.mock('@/libs', () => ({
-  FileUp: ({ className }: { className?: string }) => (
-    <div data-testid="file-up-icon" className={className}>
-      FileUp
-    </div>
-  ),
-  Upload: ({ className }: { className?: string }) => (
-    <div data-testid="upload-icon" className={className}>
-      Upload
-    </div>
-  ),
-  FileText: ({ className }: { className?: string }) => (
-    <div data-testid="file-text-icon" className={className}>
-      FileText
-    </div>
-  ),
-  Loader2: ({ className }: { className?: string }) => (
-    <div data-testid="loader-icon" className={className}>
-      Loading
-    </div>
-  ),
-  RotateCcw: ({ className }: { className?: string }) => (
-    <div data-testid="rotate-icon" className={className}>
-      Rotate
-    </div>
-  ),
-  Identity: {
-    secretKeyToHex: vi.fn((key) => `hex-${key}`),
-  },
-}));
+vi.mock('@/libs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/libs')>();
+  return {
+    ...actual,
+    FileUp: ({ className }: { className?: string }) => (
+      <div data-testid="file-up-icon" className={className}>
+        FileUp
+      </div>
+    ),
+    Upload: ({ className }: { className?: string }) => (
+      <div data-testid="upload-icon" className={className}>
+        Upload
+      </div>
+    ),
+    FileText: ({ className }: { className?: string }) => (
+      <div data-testid="file-text-icon" className={className}>
+        FileText
+      </div>
+    ),
+    Loader2: ({ className }: { className?: string }) => (
+      <div data-testid="loader-icon" className={className}>
+        Loading
+      </div>
+    ),
+    RotateCcw: ({ className }: { className?: string }) => (
+      <div data-testid="rotate-icon" className={className}>
+        Rotate
+      </div>
+    ),
+    Identity: {
+      secretKeyToHex: vi.fn((key) => `hex-${key}`),
+    },
+  };
+});
 
 // Mock atoms
 vi.mock('@/components/atoms', () => ({
@@ -557,5 +561,85 @@ describe('DialogRestoreEncryptedFile', () => {
 
     const dialogTitle = screen.getByTestId('dialog-title');
     expect(dialogTitle).toHaveClass('text-2xl', 'font-bold', 'leading-8', 'sm:text-xl', 'sm:leading-7');
+  });
+
+  it('handles Enter key to trigger restore when form is valid', async () => {
+    mockLoginWithEncryptedFile.mockResolvedValue({});
+
+    render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
+
+    const fileInput = screen.getByLabelText('Select encrypted backup file');
+    const passwordInput = screen.getByTestId('input');
+    const testFile = mockFile('test.pkarr');
+
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } });
+
+    // Press Enter on password input
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockLoginWithEncryptedFile).toHaveBeenCalledWith({
+        encryptedFile: testFile,
+        password: 'testpassword',
+      });
+    });
+  });
+
+  it('does not trigger restore on Enter when form is invalid', async () => {
+    render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
+
+    const passwordInput = screen.getByTestId('input');
+
+    // No file selected, only password
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } });
+
+    // Press Enter on password input
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockLoginWithEncryptedFile).not.toHaveBeenCalled();
+    });
+  });
+
+  it('guards against double-submit when Enter is pressed twice', async () => {
+    // Mock a slow async operation
+    mockLoginWithEncryptedFile.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 100)));
+
+    render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
+
+    const fileInput = screen.getByLabelText('Select encrypted backup file');
+    const passwordInput = screen.getByTestId('input');
+    const testFile = mockFile('test.pkarr');
+
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } });
+
+    // Press Enter twice quickly
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      // Should only be called once, not twice
+      expect(mockLoginWithEncryptedFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('guards against IME composition on Enter key', async () => {
+    render(<DialogRestoreEncryptedFile onRestore={mockOnRestore} />);
+
+    const fileInput = screen.getByLabelText('Select encrypted backup file');
+    const passwordInput = screen.getByTestId('input');
+    const testFile = mockFile('test.pkarr');
+
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } });
+
+    // Press Enter during IME composition
+    fireEvent.keyDown(passwordInput, { key: 'Enter', isComposing: true });
+
+    await waitFor(() => {
+      expect(mockLoginWithEncryptedFile).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
@@ -6,6 +6,7 @@ import { DialogClose } from '@radix-ui/react-dialog';
 import * as Atoms from '@/atoms';
 import * as Core from '@/core';
 import * as Libs from '@/libs';
+import * as Hooks from '@/hooks';
 
 export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => void }) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -32,6 +33,9 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
   };
 
   const handleRestore = async () => {
+    // Guard against double-submit race condition
+    if (isRestoring) return;
+
     if (!selectedFile || !password) {
       setError('Please select a file and enter your password');
       return;
@@ -83,15 +87,10 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
   };
 
   const isFormValid = () => {
-    return selectedFile && password && !isRestoring;
+    return Boolean(selectedFile && password && !isRestoring);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && isFormValid()) {
-      e.preventDefault();
-      handleRestore();
-    }
-  };
+  const handleKeyDown = Hooks.useEnterSubmit(isFormValid, handleRestore);
 
   return (
     <Atoms.Dialog>

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
@@ -82,6 +82,17 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
     }
   };
 
+  const isFormValid = () => {
+    return selectedFile && password && !isRestoring;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && isFormValid()) {
+      e.preventDefault();
+      handleRestore();
+    }
+  };
+
   return (
     <Atoms.Dialog>
       <Atoms.DialogTrigger asChild>
@@ -153,6 +164,7 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={handleKeyDown}
               className="h-14 rounded-md border-dashed border bg-opacity-90 shadow-sm p-4"
               placeholder="Enter your password"
               autoComplete="current-password"
@@ -186,7 +198,7 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
             id="encrypted-file-restore-btn"
             className="order-1 flex-1 rounded-full h-10 px-4 py-2.5 md:px-12 md:py-6"
             onClick={handleRestore}
-            disabled={!selectedFile || !password || isRestoring}
+            disabled={!isFormValid()}
           >
             {isRestoring ? (
               <>

--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
@@ -135,6 +135,21 @@ function RestoreForm({
     [errors, touched, onErrorsChange, onTouchedChange],
   );
 
+  const isFormValid = () => {
+    const allWordsFilled = userWords.every((word) => word !== '');
+    const noErrors = !errors.some((error) => error);
+    const allTouched = touched.every((t) => t);
+
+    return allWordsFilled && noErrors && allTouched && !isRestoring;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && isFormValid()) {
+      e.preventDefault();
+      onRestore();
+    }
+  };
+
   return (
     <>
       <Atoms.DialogHeader className="space-y-1.5 pr-6">
@@ -162,6 +177,7 @@ function RestoreForm({
                 isRestoring={isRestoring}
                 onChange={handleWordChange}
                 onValidate={handleWordValidate}
+                onKeyDown={handleKeyDown}
               />
             );
           })}
@@ -190,7 +206,7 @@ function RestoreForm({
           id="recovery-phrase-restore-btn"
           className="flex-1 rounded-full h-10 px-4 py-2.5 md:px-12 md:py-6"
           onClick={onRestore}
-          disabled={userWords.some((word) => word === '') || errors.some((error) => error) || isRestoring}
+          disabled={!isFormValid()}
         >
           {isRestoring ? (
             <>

--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
@@ -6,6 +6,7 @@ import * as Atoms from '@/atoms';
 import * as Core from '@/core';
 import * as Libs from '@/libs';
 import * as Molecules from '@/molecules';
+import * as Hooks from '@/hooks';
 
 interface DialogRestoreRecoveryPhraseProps {
   onRestore?: () => void;
@@ -19,6 +20,9 @@ export function DialogRestoreRecoveryPhrase({ onRestore }: DialogRestoreRecovery
   const { toast } = Molecules.useToast();
 
   const handleRestore = async () => {
+    // Guard against double-submit race condition
+    if (isRestoring) return;
+
     setIsRestoring(true);
 
     try {
@@ -143,12 +147,7 @@ function RestoreForm({
     return allWordsFilled && noErrors && allTouched && !isRestoring;
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && isFormValid()) {
-      e.preventDefault();
-      onRestore();
-    }
-  };
+  const handleKeyDown = Hooks.useEnterSubmit(isFormValid, onRestore);
 
   return (
     <>

--- a/src/components/organisms/HomeserverCard/HomeserverCard.test.tsx
+++ b/src/components/organisms/HomeserverCard/HomeserverCard.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+
+import { HomeserverCard } from './HomeserverCard';
+import * as Core from '@/core';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+// Mock the onboarding store
+vi.mock('@/core', () => ({
+  useOnboardingStore: vi.fn(),
+  AuthController: {
+    signUp: vi.fn(),
+  },
+}));
+
+// Mock all the components to avoid complex dependencies
+vi.mock('@/molecules', () => ({
+  ContentCard: ({ children }: { children: React.ReactNode }) => <div data-testid="content-card">{children}</div>,
+  InputField: ({
+    id,
+    value,
+    onChange,
+    onKeyDown,
+    placeholder,
+    disabled,
+  }: {
+    id?: string;
+    value: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    disabled?: boolean;
+  }) => (
+    <input
+      data-testid="input-field"
+      id={id}
+      value={value}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  ),
+  HomeserverFooter: () => <div data-testid="homeserver-footer">Footer</div>,
+  PopoverInviteHomeserver: () => <div data-testid="popover-invite-homeserver">Popover</div>,
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+// Mock atoms
+vi.mock('@/atoms', () => ({
+  Container: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="container" className={className}>
+      {children}
+    </div>
+  ),
+  Heading: ({
+    children,
+    level,
+    size,
+    className,
+  }: {
+    children: React.ReactNode;
+    level?: number;
+    size?: string;
+    className?: string;
+  }) => (
+    <h3 data-testid="heading" data-level={level} data-size={size} className={className}>
+      {children}
+    </h3>
+  ),
+  Typography: ({ children, size, className }: { children: React.ReactNode; size?: string; className?: string }) => (
+    <p data-testid="typography" data-size={size} className={className}>
+      {children}
+    </p>
+  ),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    className,
+    id,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    className?: string;
+    id?: string;
+  }) => (
+    <button data-testid="button" id={id} onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+// Mock libs
+vi.mock('@/libs', () => ({
+  formatInviteCode: (code: string) => code,
+  Logger: {
+    info: vi.fn(),
+  },
+  cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(' '),
+  Server: () => <div data-testid="server-icon">Server</div>,
+  ArrowLeft: () => <div data-testid="arrow-left-icon">ArrowLeft</div>,
+  ArrowRight: () => <div data-testid="arrow-right-icon">ArrowRight</div>,
+  Loader2: () => <div data-testid="loader-icon">Loader</div>,
+}));
+
+// Mock app routes
+vi.mock('@/app', () => ({
+  ONBOARDING_ROUTES: {
+    PROFILE: '/onboarding/profile',
+    BACKUP: '/onboarding/backup',
+  },
+}));
+
+describe('HomeserverCard', () => {
+  const mockPush = vi.fn();
+  const mockSignUp = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({
+      push: mockPush,
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+    } as ReturnType<typeof useRouter>);
+    vi.mocked(Core.useOnboardingStore).mockReturnValue({
+      pubky: 'mock-public-key',
+      secretKey: 'mock-secret-key',
+    });
+    vi.mocked(Core.AuthController.signUp).mockImplementation(mockSignUp);
+  });
+
+  it('handles Enter key on invite code input when form is valid', async () => {
+    mockSignUp.mockResolvedValue(undefined);
+
+    render(<HomeserverCard />);
+
+    const inviteCodeInput = screen.getByTestId('input-field');
+
+    // Enter a valid invite code (14 characters)
+    fireEvent.change(inviteCodeInput, { target: { value: 'ABCD-EFGH-IJKL' } });
+
+    // Press Enter key
+    fireEvent.keyDown(inviteCodeInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledWith({
+        keypair: {
+          pubky: 'mock-public-key',
+          secretKey: 'mock-secret-key',
+        },
+        signupToken: 'ABCD-EFGH-IJKL',
+      });
+    });
+  });
+
+  it('does not trigger signup on Enter when invite code is invalid', async () => {
+    render(<HomeserverCard />);
+
+    const inviteCodeInput = screen.getByTestId('input-field');
+
+    // Enter an invalid invite code (less than 14 characters)
+    fireEvent.change(inviteCodeInput, { target: { value: 'ABCD-EFGH' } });
+
+    // Press Enter key
+    fireEvent.keyDown(inviteCodeInput, { key: 'Enter' });
+
+    // Wait a bit to ensure no async operations occur
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger signup on Enter when loading', async () => {
+    render(<HomeserverCard />);
+
+    const inviteCodeInput = screen.getByTestId('input-field');
+    const continueButton = screen.getByText('Continue');
+
+    // Enter a valid invite code
+    fireEvent.change(inviteCodeInput, { target: { value: 'ABCD-EFGH-IJKL' } });
+
+    // Start the signup process by clicking continue
+    fireEvent.click(continueButton);
+
+    // Wait for loading state
+    await waitFor(() => {
+      expect(screen.getByText('Validating')).toBeInTheDocument();
+    });
+
+    // Try to press Enter while loading
+    fireEvent.keyDown(inviteCodeInput, { key: 'Enter' });
+
+    // The signup should only be called once (from the button click)
+    expect(mockSignUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/organisms/HomeserverCard/HomeserverCard.test.tsx
+++ b/src/components/organisms/HomeserverCard/HomeserverCard.test.tsx
@@ -113,12 +113,16 @@ vi.mock('@/libs', () => ({
 }));
 
 // Mock app routes
-vi.mock('@/app', () => ({
-  ONBOARDING_ROUTES: {
-    PROFILE: '/onboarding/profile',
-    BACKUP: '/onboarding/backup',
-  },
-}));
+vi.mock('@/app', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app')>();
+  return {
+    ...actual,
+    ONBOARDING_ROUTES: {
+      PROFILE: '/onboarding/profile',
+      BACKUP: '/onboarding/backup',
+    },
+  };
+});
 
 describe('HomeserverCard', () => {
   const mockPush = vi.fn();

--- a/src/components/organisms/HomeserverCard/HomeserverCard.tsx
+++ b/src/components/organisms/HomeserverCard/HomeserverCard.tsx
@@ -52,6 +52,17 @@ export function HomeserverCard() {
     });
   };
 
+  const isFormValid = () => {
+    return !continueButtonDisabled && !isLoading;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && isFormValid()) {
+      e.preventDefault();
+      onHandleContinueButton();
+    }
+  };
+
   const onHandleContinueButton = async () => {
     try {
       setContinueButtonDisabled(true);
@@ -100,6 +111,7 @@ export function HomeserverCard() {
               variant="dashed"
               onClick={() => setInviteCode(inviteCode)}
               onChange={handleOnChange}
+              onKeyDown={handleKeyDown}
               placeholder="XXXX-XXXX-XXXX"
               maxLength={14}
               disabled={isLoading}

--- a/src/components/organisms/HomeserverCard/HomeserverCard.tsx
+++ b/src/components/organisms/HomeserverCard/HomeserverCard.tsx
@@ -141,7 +141,7 @@ export function HomeserverCard() {
           size="lg"
           className="rounded-full flex-1 md:flex-0 w-full"
           onClick={onHandleContinueButton}
-          disabled={continueButtonDisabled}
+          disabled={!isFormValid()}
         >
           {isLoading ? (
             <>

--- a/src/components/organisms/HomeserverCard/HomeserverCard.tsx
+++ b/src/components/organisms/HomeserverCard/HomeserverCard.tsx
@@ -8,6 +8,7 @@ import * as Atoms from '@/atoms';
 import * as Core from '@/core';
 import * as Libs from '@/libs';
 import * as App from '@/app';
+import * as Hooks from '@/hooks';
 
 export function HomeserverCard() {
   const router = useRouter();
@@ -52,17 +53,6 @@ export function HomeserverCard() {
     });
   };
 
-  const isFormValid = () => {
-    return !continueButtonDisabled && !isLoading;
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && isFormValid()) {
-      e.preventDefault();
-      onHandleContinueButton();
-    }
-  };
-
   const onHandleContinueButton = async () => {
     try {
       setContinueButtonDisabled(true);
@@ -82,6 +72,12 @@ export function HomeserverCard() {
       setIsLoading(false);
     }
   };
+
+  const isFormValid = () => {
+    return !continueButtonDisabled && !isLoading;
+  };
+
+  const handleKeyDown = Hooks.useEnterSubmit(isFormValid, onHandleContinueButton);
 
   return (
     <>
@@ -109,7 +105,6 @@ export function HomeserverCard() {
               id="invite-code-input"
               value={inviteCode}
               variant="dashed"
-              onClick={() => setInviteCode(inviteCode)}
               onChange={handleOnChange}
               onKeyDown={handleKeyDown}
               placeholder="XXXX-XXXX-XXXX"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useAuthStatus';
 export * from './useAuthActions';
 export * from './useElementHeight';
 export * from './useInfiniteScroll';
+export * from './useEnterSubmit';

--- a/src/hooks/useEnterSubmit/index.ts
+++ b/src/hooks/useEnterSubmit/index.ts
@@ -1,0 +1,1 @@
+export * from './useEnterSubmit';

--- a/src/hooks/useEnterSubmit/useEnterSubmit.test.tsx
+++ b/src/hooks/useEnterSubmit/useEnterSubmit.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEnterSubmit } from './useEnterSubmit';
+
+describe('useEnterSubmit', () => {
+  const createKeyboardEvent = (key: string, isComposing: boolean = false): React.KeyboardEvent =>
+    ({
+      key,
+      nativeEvent: { isComposing } as KeyboardEvent,
+      preventDefault: vi.fn(),
+    }) as unknown as React.KeyboardEvent;
+
+  it('calls onSubmit when Enter is pressed and form is valid', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => true);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onSubmit when form is invalid', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => false);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not call onSubmit when key is not Enter', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => true);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    act(() => {
+      result.current(createKeyboardEvent('Space'));
+    });
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('guards against IME composition', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => true);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    act(() => {
+      result.current(createKeyboardEvent('Enter', true));
+    });
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('guards against double-submit for async functions', async () => {
+    let resolveSubmit: () => void;
+    const submitPromise = new Promise<void>((resolve) => {
+      resolveSubmit = resolve;
+    });
+
+    const mockOnSubmit = vi.fn(() => submitPromise);
+    const mockIsValid = vi.fn(() => true);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    // First Enter press
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    // Second Enter press while first is still pending
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+
+    // Resolve the promise
+    await act(async () => {
+      resolveSubmit!();
+      await submitPromise;
+    });
+
+    // Now a third press should work
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('prevents default behavior when Enter is pressed with valid form', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => true);
+    const mockPreventDefault = vi.fn();
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    const event = createKeyboardEvent('Enter');
+    event.preventDefault = mockPreventDefault;
+
+    act(() => {
+      result.current(event);
+    });
+
+    expect(mockPreventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prevent default when form is invalid', () => {
+    const mockOnSubmit = vi.fn();
+    const mockIsValid = vi.fn(() => false);
+    const mockPreventDefault = vi.fn();
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    const event = createKeyboardEvent('Enter');
+    event.preventDefault = mockPreventDefault;
+
+    act(() => {
+      result.current(event);
+    });
+
+    expect(mockPreventDefault).not.toHaveBeenCalled();
+  });
+
+  it('works with synchronous submit functions', () => {
+    const mockOnSubmit = vi.fn(); // Synchronous function
+    const mockIsValid = vi.fn(() => true);
+
+    const { result } = renderHook(() => useEnterSubmit(mockIsValid, mockOnSubmit));
+
+    // First press
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+
+    // Second press should also work (no async lock)
+    act(() => {
+      result.current(createKeyboardEvent('Enter'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useEnterSubmit/useEnterSubmit.ts
+++ b/src/hooks/useEnterSubmit/useEnterSubmit.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useRef } from 'react';
+
+/**
+ * Custom hook to handle Enter key submission with IME composition and double-submit guards
+ *
+ * @param isValid - Function that returns whether the form is valid and ready to submit
+ * @param onSubmit - Function to call when Enter is pressed and form is valid
+ * @returns onKeyDown event handler to be attached to form inputs
+ *
+ * @example
+ * ```tsx
+ * const isFormValid = () => password && passwordsMatch;
+ * const handleKeyDown = useEnterSubmit(isFormValid, handleDownload);
+ *
+ * <Input onKeyDown={handleKeyDown} />
+ * ```
+ */
+export function useEnterSubmit(isValid: () => boolean, onSubmit: () => void | Promise<void>) {
+  const isSubmittingRef = useRef(false);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    // Guard against IME composition (prevents accidental submit while composing CJK input)
+    if (e.nativeEvent.isComposing) return;
+
+    // Guard against double-submit race condition
+    if (isSubmittingRef.current) return;
+
+    if (e.key === 'Enter' && isValid()) {
+      e.preventDefault();
+
+      isSubmittingRef.current = true;
+
+      const result = onSubmit();
+
+      // If onSubmit is async, wait for it to complete before allowing another submit
+      if (result instanceof Promise) {
+        result.finally(() => {
+          isSubmittingRef.current = false;
+        });
+      } else {
+        // Reset immediately for synchronous functions
+        isSubmittingRef.current = false;
+      }
+    }
+  };
+
+  return onKeyDown;
+}


### PR DESCRIPTION
Can now use 'Enter' key to submit form when:
- Backing up recovery file (after entering and confirming password)
- Restore with recovery file (after entering password)
- Restore with seed phrase (after entering all words)
- Submitting invite code for default homeserver

All methods reuse and share existing form validation rules.

Resolves https://github.com/pubky/franky/issues/238