### PR TITLE
fix: wrong header logo on mobile

### DIFF
--- a/src/components/molecules/MobileHeader/MobileHeader.test.tsx
+++ b/src/components/molecules/MobileHeader/MobileHeader.test.tsx
@@ -2,15 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MobileHeader } from './MobileHeader';
 
-// Mock the atoms
-vi.mock('@/atoms', () => ({
-  Typography: ({ children, className, size }: { children: React.ReactNode; className?: string; size?: string }) => (
-    <span className={className} data-size={size}>
-      {children}
-    </span>
-  ),
-}));
-
 // Mock the molecules
 vi.mock('@/molecules', () => ({
   FilterDrawer: ({
@@ -32,6 +23,9 @@ vi.mock('@/molecules', () => ({
   WhoToFollow: () => <div data-testid="who-to-follow">Who to Follow</div>,
   ActiveUsers: () => <div data-testid="active-users">Active Users</div>,
   FeedbackCard: () => <div data-testid="feedback-card">Feedback Card</div>,
+  Logo: ({ width, height }: { width?: number; height?: number }) => (
+    <img data-testid="logo" alt="Pubky" data-width={width} data-height={height} />
+  ),
 }));
 
 // Mock the libs
@@ -53,7 +47,7 @@ describe('MobileHeader', () => {
   it('renders with default props', () => {
     render(<MobileHeader />);
 
-    expect(screen.getByText('Pubky')).toBeInTheDocument();
+    expect(screen.getByAltText('Pubky')).toBeInTheDocument();
     expect(screen.getByTestId('sliders-horizontal-icon')).toBeInTheDocument();
     expect(screen.getByTestId('activity-icon')).toBeInTheDocument();
   });
@@ -61,7 +55,7 @@ describe('MobileHeader', () => {
   it('renders with custom className', () => {
     render(<MobileHeader className="custom-header" />);
 
-    expect(screen.getByText('Pubky')).toBeInTheDocument();
+    expect(screen.getByAltText('Pubky')).toBeInTheDocument();
   });
 
   it('renders with custom onLeftIconClick', () => {
@@ -77,13 +71,13 @@ describe('MobileHeader', () => {
   it('applies correct classes to container', () => {
     render(<MobileHeader />);
 
-    expect(screen.getByText('Pubky')).toBeInTheDocument();
+    expect(screen.getByAltText('Pubky')).toBeInTheDocument();
   });
 
   it('applies correct classes to inner container', () => {
     render(<MobileHeader />);
 
-    const innerContainer = screen.getByText('Pubky').closest('div')?.parentElement;
+    const innerContainer = screen.getByTestId('logo').closest('div')?.parentElement;
     expect(innerContainer).toHaveClass('flex', 'items-center', 'justify-between', 'px-4', 'h-16');
   });
 
@@ -104,15 +98,16 @@ describe('MobileHeader', () => {
   it('applies correct classes to logo container', () => {
     render(<MobileHeader />);
 
-    const logoContainer = screen.getByText('Pubky').closest('div');
+    const logoContainer = screen.getByTestId('logo').closest('div');
     expect(logoContainer).toHaveClass('flex', 'items-center', 'gap-2');
   });
 
-  it('applies correct classes to logo text', () => {
+  it('renders logo with correct dimensions', () => {
     render(<MobileHeader />);
 
-    const logoText = screen.getByText('Pubky');
-    expect(logoText).toHaveClass('font-bold');
+    const logo = screen.getByTestId('logo');
+    expect(logo).toHaveAttribute('data-width', '96');
+    expect(logo).toHaveAttribute('data-height', '32');
   });
 
   it('renders right drawer with correct content', () => {
@@ -147,7 +142,7 @@ describe('MobileHeader', () => {
   it('renders with correct responsive behavior', () => {
     render(<MobileHeader />);
 
-    expect(screen.getByText('Pubky')).toBeInTheDocument();
+    expect(screen.getByAltText('Pubky')).toBeInTheDocument();
   });
 
   it('handles hover states correctly', () => {
@@ -160,19 +155,12 @@ describe('MobileHeader', () => {
     expect(rightButton).toHaveClass('hover:bg-secondary/10', 'transition-colors');
   });
 
-  it('renders logo with correct attributes', () => {
-    render(<MobileHeader />);
-
-    const logoText = screen.getByText('Pubky');
-    expect(logoText).toHaveAttribute('data-size', 'md');
-  });
-
   it('renders with correct structure', () => {
     render(<MobileHeader />);
 
     // Check that all main elements are present
     expect(screen.getByTestId('sliders-horizontal-icon')).toBeInTheDocument();
-    expect(screen.getByText('Pubky')).toBeInTheDocument();
+    expect(screen.getByAltText('Pubky')).toBeInTheDocument();
     expect(screen.getByTestId('activity-icon')).toBeInTheDocument();
   });
 });
@@ -211,7 +199,7 @@ describe('MobileHeader - Snapshots', () => {
   it('matches snapshot for logo', () => {
     render(<MobileHeader />);
 
-    const logoText = screen.getByText('Pubky');
-    expect(logoText).toMatchSnapshot();
+    const logo = screen.getByTestId('logo');
+    expect(logo).toMatchSnapshot();
   });
 });

--- a/src/components/molecules/MobileHeader/MobileHeader.test.tsx.snap
+++ b/src/components/molecules/MobileHeader/MobileHeader.test.tsx.snap
@@ -14,12 +14,12 @@ exports[`MobileHeader - Snapshots > matches snapshot for left button 1`] = `
 `;
 
 exports[`MobileHeader - Snapshots > matches snapshot for logo 1`] = `
-<span
-  class="font-bold"
-  data-size="md"
->
-  Pubky
-</span>
+<img
+  alt="Pubky"
+  data-height="32"
+  data-testid="logo"
+  data-width="96"
+/>
 `;
 
 exports[`MobileHeader - Snapshots > matches snapshot for right button 1`] = `
@@ -55,12 +55,12 @@ exports[`MobileHeader - Snapshots > matches snapshot with custom className 1`] =
     <div
       class="flex items-center gap-2"
     >
-      <span
-        class="font-bold"
-        data-size="md"
-      >
-        Pubky
-      </span>
+      <img
+        alt="Pubky"
+        data-height="32"
+        data-testid="logo"
+        data-width="96"
+      />
     </div>
     <button
       class="p-2 hover:bg-secondary/10 rounded-full transition-colors"
@@ -96,12 +96,12 @@ exports[`MobileHeader - Snapshots > matches snapshot with custom onLeftIconClick
     <div
       class="flex items-center gap-2"
     >
-      <span
-        class="font-bold"
-        data-size="md"
-      >
-        Pubky
-      </span>
+      <img
+        alt="Pubky"
+        data-height="32"
+        data-testid="logo"
+        data-width="96"
+      />
     </div>
     <button
       class="p-2 hover:bg-secondary/10 rounded-full transition-colors"
@@ -137,12 +137,12 @@ exports[`MobileHeader - Snapshots > matches snapshot with default props 1`] = `
     <div
       class="flex items-center gap-2"
     >
-      <span
-        class="font-bold"
-        data-size="md"
-      >
-        Pubky
-      </span>
+      <img
+        alt="Pubky"
+        data-height="32"
+        data-testid="logo"
+        data-width="96"
+      />
     </div>
     <button
       class="p-2 hover:bg-secondary/10 rounded-full transition-colors"

--- a/src/components/molecules/MobileHeader/MobileHeader.tsx
+++ b/src/components/molecules/MobileHeader/MobileHeader.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Libs from '@/libs';
 
@@ -29,9 +28,7 @@ export function MobileHeader({ onLeftIconClick, className }: MobileHeaderProps) 
 
           {/* Center - Logo */}
           <div className="flex items-center gap-2">
-            <Atoms.Typography size="md" className="font-bold">
-              Pubky
-            </Atoms.Typography>
+            <Molecules.Logo noLink width={96} height={32} />
           </div>
 
           {/* Right icon - community info */}


### PR DESCRIPTION
Fixes #225

- Updated the mobile header to render the shared Pubky logo component on mobile viewports so the brand mark appears instead of plain text.
- Refreshed the MobileHeader unit tests and snapshots to exercise the new logo rendering and verify its dimensions in the layout

<img width="453" height="117" alt="image" src="https://github.com/user-attachments/assets/1f8a9ea3-b78d-4f2b-85f4-4881296902b5" />

✅ npm run test -- MobileHeader 
