### PR TITLE
fix: IndexedDB retention on logout

### DIFF
--- a/src/core/controllers/auth/auth.ts
+++ b/src/core/controllers/auth/auth.ts
@@ -106,6 +106,12 @@ export class AuthController {
       Core.useOnboardingStore.getState().reset();
       Core.useAuthStore.getState().reset();
       Libs.clearCookies();
+
+      try {
+        await Core.clearDatabase();
+      } catch (error) {
+        Libs.Logger.warn('Failed to clear local database on logout', error);
+      }
     }
   }
 

--- a/src/core/database/franky/franky.helpers.ts
+++ b/src/core/database/franky/franky.helpers.ts
@@ -1,8 +1,17 @@
-import { indexedDB } from 'fake-indexeddb';
 import { db } from '@/core';
 import { DB_NAME } from '@/config';
 
+export async function clearDatabase(): Promise<void> {
+  if (!db.isOpen()) {
+    await db.open();
+  }
+
+  await Promise.all(db.tables.map((table) => table.clear()));
+}
+
 export async function resetDatabase(): Promise<void> {
+  const { indexedDB } = await import('fake-indexeddb');
+
   db.close();
   indexedDB.deleteDatabase(DB_NAME);
   await db.open();


### PR DESCRIPTION
fixes #240 

- Added a reusable `clearDatabase` helper to wipe every Dexie table and updated the test reset helper to lazy-load the fake IndexedDB implementation. 
- Ensured `AuthController.logout` always clears IndexedDB data in addition to store and cookie resets, and logs a warning if the cleanup fails. 
- Expanded the auth controller logout tests with mocked stores to verify database clearing and warning behaviour.