### PR TITLE
fix: profile avatar scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-easy-crop": "^5.5.3",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.0",
         "zod": "^3.25.36",
@@ -9738,6 +9739,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -10426,6 +10433,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.3.tgz",
+      "integrity": "sha512-iKwFTnAsq+IVuyF6N0Q3zjRx9DG1NMySkwWxVfM/xAOeHYH1vhvM+V2kFiq5HOIQGWouITjfltCx54mbDpMpmA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-easy-crop": "^5.5.3",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.25.36",

--- a/src/components/atoms/Avatar/Avatar.tsx
+++ b/src/components/atoms/Avatar/Avatar.tsx
@@ -19,7 +19,11 @@ const AvatarImage = React.forwardRef<
   React.ComponentRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn('aspect-square h-full w-full', className)} {...props} />
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn('aspect-square h-full w-full object-cover object-center', className)}
+    {...props}
+  />
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 

--- a/src/components/molecules/DialogCropImage/DialogCropImage.tsx
+++ b/src/components/molecules/DialogCropImage/DialogCropImage.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Cropper, { type Area } from 'react-easy-crop';
+import 'react-easy-crop/react-easy-crop.css';
+
+import * as Atoms from '@/atoms';
+import * as Libs from '@/libs';
+
+type DialogCropImageProps = {
+  open: boolean;
+  imageSrc: string | null;
+  fileName: string;
+  fileType: string;
+  onClose: () => void;
+  onBack: () => void;
+  onCrop: (file: File, previewUrl: string) => void;
+};
+
+const DEFAULT_FILE_NAME = 'cropped-image.png';
+
+export function DialogCropImage({ open, imageSrc, fileName, fileType, onClose, onBack, onCrop }: DialogCropImageProps) {
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [isCropping, setIsCropping] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setCrop({ x: 0, y: 0 });
+      setZoom(1);
+      setCroppedAreaPixels(null);
+      setIsCropping(false);
+    }
+  }, [open, imageSrc]);
+
+  const handleCropComplete = useCallback((_croppedArea: Area, croppedAreaPixelsValue: Area) => {
+    setCroppedAreaPixels(croppedAreaPixelsValue);
+  }, []);
+
+  const hasImage = useMemo(() => Boolean(imageSrc), [imageSrc]);
+
+  const handleDone = useCallback(async () => {
+    if (!imageSrc || !croppedAreaPixels) return;
+
+    try {
+      setIsCropping(true);
+      const targetMimeType = fileType && fileType.startsWith('image/') ? fileType : 'image/png';
+      const blob = await Libs.cropImageToBlob(imageSrc, croppedAreaPixels, targetMimeType);
+      const resolvedMimeType = blob.type || targetMimeType;
+      const croppedFile = new File([blob], fileName || DEFAULT_FILE_NAME, { type: resolvedMimeType });
+      const previewUrl = URL.createObjectURL(blob);
+      onCrop(croppedFile, previewUrl);
+    } catch (error) {
+      console.error('Failed to crop image', error);
+    } finally {
+      setIsCropping(false);
+    }
+  }, [croppedAreaPixels, fileName, fileType, imageSrc, onCrop]);
+
+  return (
+    <Atoms.Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <Atoms.DialogContent
+        className="bg-popover border-border p-8 sm:p-6 max-w-xl gap-6 rounded-2xl"
+        showCloseButton={false}
+      >
+        <Atoms.DialogHeader className="gap-1">
+          <Atoms.DialogTitle className="text-2xl sm:text-xl">Cropped Image</Atoms.DialogTitle>
+          <Atoms.DialogDescription>Adjust the selection to create the perfect square avatar.</Atoms.DialogDescription>
+        </Atoms.DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="relative mx-auto aspect-square w-full max-w-sm overflow-hidden rounded-2xl bg-black/60">
+            {hasImage ? (
+              <Cropper
+                image={imageSrc ?? undefined}
+                crop={crop}
+                zoom={zoom}
+                aspect={1}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={handleCropComplete}
+                restrictPosition
+                objectFit="contain"
+                showGrid
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+                Select an image to start cropping
+              </div>
+            )}
+
+            <Atoms.Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute bottom-4 left-4 rounded-full bg-black/50 px-4 text-white hover:bg-black/70"
+              onClick={onBack}
+            >
+              ← Back
+            </Atoms.Button>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zoom</span>
+            <input
+              type="range"
+              min={1}
+              max={3}
+              step={0.01}
+              value={zoom}
+              onChange={(event) => setZoom(Number(event.target.value))}
+              className="w-full accent-brand"
+            />
+          </div>
+        </div>
+
+        <Atoms.DialogFooter className="gap-4">
+          <Atoms.Button type="button" variant="outline" size="lg" className="flex-1 rounded-full" onClick={onClose}>
+            Cancel
+          </Atoms.Button>
+          <Atoms.Button
+            type="button"
+            size="lg"
+            className="flex-1 rounded-full"
+            onClick={handleDone}
+            disabled={!hasImage || !croppedAreaPixels || isCropping}
+          >
+            {isCropping ? 'Processing…' : 'Done'}
+          </Atoms.Button>
+        </Atoms.DialogFooter>
+      </Atoms.DialogContent>
+    </Atoms.Dialog>
+  );
+}

--- a/src/components/molecules/DialogCropImage/index.ts
+++ b/src/components/molecules/DialogCropImage/index.ts
@@ -1,0 +1,1 @@
+export * from './DialogCropImage';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -11,6 +11,7 @@ export * from './HotTags';
 export * from './ButtonsNavigation';
 export * from './Content';
 export * from './DialogAddLink';
+export * from './DialogCropImage';
 export * from './DialogAge';
 export * from './DialogBackupPhrase';
 export * from './DialogDownloadPubkyRing';

--- a/src/libs/image/cropImage.ts
+++ b/src/libs/image/cropImage.ts
@@ -1,0 +1,60 @@
+import type { Area } from 'react-easy-crop';
+
+type CropArea = Pick<Area, 'x' | 'y' | 'width' | 'height'>;
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (event) => reject(event));
+    image.setAttribute('crossorigin', 'anonymous');
+    image.src = src;
+  });
+}
+
+function createBlobFromCanvas(canvas: HTMLCanvasElement, mimeType: string, quality?: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('Failed to crop image'));
+          return;
+        }
+        resolve(blob);
+      },
+      mimeType,
+      quality,
+    );
+  });
+}
+
+export async function cropImageToBlob(
+  imageSrc: string,
+  cropArea: CropArea,
+  mimeType = 'image/png',
+  quality?: number,
+): Promise<Blob> {
+  if (!imageSrc) {
+    throw new Error('Image source is required to crop');
+  }
+
+  const image = await loadImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const outputWidth = Math.round(cropArea.width);
+  const outputHeight = Math.round(cropArea.height);
+
+  canvas.width = outputWidth;
+  canvas.height = outputHeight;
+
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  context.imageSmoothingQuality = 'high';
+
+  context.drawImage(image, cropArea.x, cropArea.y, cropArea.width, cropArea.height, 0, 0, outputWidth, outputHeight);
+
+  return createBlobFromCanvas(canvas, mimeType, quality);
+}

--- a/src/libs/image/index.ts
+++ b/src/libs/image/index.ts
@@ -1,0 +1,1 @@
+export * from './cropImage';

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -2,6 +2,7 @@ export * from './env';
 export * from './error';
 export * from './icons';
 export * from './identity';
+export * from './image';
 export * from './logger';
 export * from './share';
 export * from './svg';


### PR DESCRIPTION
fixes #148 

- Added a `DialogCropImage` molecule that uses react-easy-crop to let users crop and zoom a square avatar within a dedicated modal. 
- Implemented a reusable `cropImageToBlob` helper and exposed it through the shared libs barrel so clients can persist cropped blobs with consistent quality settings. 
- Wired the new modal into the create-profile flow, managing pending previews/cleanup, improving validation recovery, and updating the test harness to exercise the cropping workflow.

<img width="1072" height="682" alt="Screenshot from 2025-10-08 16-04-21" src="https://github.com/user-attachments/assets/f3c2a7db-de69-459a-afb6-7f71e587550e" />
<img width="306" height="333" alt="Screenshot from 2025-10-08 16-04-44" src="https://github.com/user-attachments/assets/e577d0ec-c9c7-4d9f-a80d-6f80993ead3a" />
<img width="615" height="393" alt="Screenshot from 2025-10-08 16-04-56" src="https://github.com/user-attachments/assets/18145708-4002-4a25-aaab-3594072a4592" />

- todo: tests.