### PR TITLE
tests(e2e): update routing and component structure for landing page

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add(
 
     cy.get('#profile-finish-btn').click();
 
-    cy.location('pathname').should('eq', '/feed');
+    cy.location('pathname').should('eq', '/home');
 
     // confirm welcome message is shown and dismiss it
     cy.get('#welcome-title').should('exist');
@@ -155,7 +155,7 @@ function collectRecoveryPhraseWords(): Cypress.Chainable<string> {
 
 Cypress.Commands.add('signOut', () => {
   // temporary approach to sign out
-  cy.get('#feed-logout-btn').click();
+  cy.get('#home-logout-btn').click();
   cy.location('pathname').should('eq', '/logout');
   // navigate back to homepage
   cy.get('#logout-navigation-back-btn').click();
@@ -200,7 +200,7 @@ Cypress.Commands.add('signInWithEncryptedFile', (backupFilepath: string, passcod
   cy.get('#restore-password').type(passcode);
   cy.get('#encrypted-file-restore-btn').click();
 
-  cy.location('pathname').should('eq', '/feed');
+  cy.location('pathname').should('eq', '/home');
 });
 
 Cypress.Commands.add('signInWithRecoveryPhrase', (recoveryPhrase: string) => {
@@ -216,7 +216,7 @@ Cypress.Commands.add('signInWithRecoveryPhrase', (recoveryPhrase: string) => {
   inputRecoveryPhraseWords(recoveryPhrase);
   cy.get('#recovery-phrase-restore-btn').click();
 
-  cy.location('pathname').should('eq', '/feed');
+  cy.location('pathname').should('eq', '/home');
 });
 
 // Input recovery phrase words into the form

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import * as Templates from '@/templates';
 
-export default function Home() {
-  return <Templates.Home />;
+export default function LandingPage() {
+  return <Templates.Landing />;
 }

--- a/src/components/templates/Landing/Landing.tsx
+++ b/src/components/templates/Landing/Landing.tsx
@@ -1,0 +1,18 @@
+import * as Atoms from '@/atoms';
+import * as Molecules from '@/molecules';
+
+export function Landing() {
+  return (
+    <>
+      <Atoms.ImageBackground image="/images/bg-home.svg" mobileImage="/images/bg-home-mobile.svg" />
+      <Atoms.Container size="container" className="px-6">
+        <Molecules.PageContainer size="narrow" className="items-start mx-0 flex flex-col gap-6">
+          <Molecules.HomePageHeading />
+          <Molecules.HomeSectionTitle />
+          <Molecules.HomeActions />
+          <Molecules.HomeFooter />
+        </Molecules.PageContainer>
+      </Atoms.Container>
+    </>
+  );
+}

--- a/src/components/templates/Landing/index.ts
+++ b/src/components/templates/Landing/index.ts
@@ -1,0 +1,1 @@
+export * from './Landing';

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -4,6 +4,7 @@ export * from './Home';
 export * from './Hot';
 export * from './Install';
 export * from './Homeserver';
+export * from './Landing';
 export * from './Logout';
 export * from './ProfilePage';
 export * from './Profile';


### PR DESCRIPTION
- Changed navigation from '/feed' to '/home' in Cypress commands.
- Renamed Home component to LandingPage and updated its template.
- Introduced new Landing template with structured layout components.