### PR TITLE
feat: paste multiple words when restoring with recovery phrase

### DIFF
--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.test.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.test.tsx
@@ -264,6 +264,36 @@ describe('DialogRestoreRecoveryPhrase', () => {
       // Test that onBlur was triggered (indirect test)
       expect(firstInput).not.toHaveFocus();
     });
+
+    it('distributes 12 words across all fields when pasting space-delimited string into first field', () => {
+      render(<DialogRestoreRecoveryPhrase />);
+
+      const inputs = screen.getAllByTestId('word-input');
+      const firstInput = inputs[0];
+
+      const twelveWords = [
+        'ability',
+        'able',
+        'above',
+        'absent',
+        'accident',
+        'absorb',
+        'abstract',
+        'absurd',
+        'about',
+        'abuse',
+        'access',
+        'abandon',
+      ];
+
+      // Paste 12 words as a space-delimited string into the first field
+      fireEvent.change(firstInput, { target: { value: twelveWords.join(' ') } });
+
+      // Verify all 12 fields are populated with the correct words
+      inputs.forEach((input, index) => {
+        expect(input).toHaveValue(twelveWords[index]);
+      });
+    });
   });
 
   describe('Validation', () => {

--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
@@ -101,6 +101,36 @@ function RestoreForm({
 }) {
   const handleWordChange = useCallback(
     (index: number, value: string) => {
+      // Check if the value contains multiple words (e.g. pasted from clipboard or inserted from Android keyboard suggestions)
+      // Split by common delimiters: spaces, newlines, tabs, commas
+      const words = value
+        .split(/[\s\n\t,]+/)
+        .map((word) => word.toLowerCase().trim())
+        .filter((word) => word !== '');
+
+      // If multiple words detected, distribute them across fields
+      if (words.length > 1) {
+        const newUserWords = [...userWords];
+        const newTouched = [...touched];
+        const newErrors = [...errors];
+
+        words.forEach((word, offset) => {
+          const targetIndex = index + offset;
+          if (targetIndex < 12) {
+            newUserWords[targetIndex] = word;
+            newTouched[targetIndex] = true;
+            // Clear error when distributing words
+            newErrors[targetIndex] = false;
+          }
+        });
+
+        onWordChange(newUserWords);
+        onTouchedChange(newTouched);
+        onErrorsChange(newErrors);
+        return;
+      }
+
+      // Handle single-word input
       const newUserWords = [...userWords];
       newUserWords[index] = value;
       onWordChange(newUserWords);

--- a/src/components/organisms/SinglePostUserDetails/SinglePostUserDetails.test.tsx
+++ b/src/components/organisms/SinglePostUserDetails/SinglePostUserDetails.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { SinglePostUserDetails } from './SinglePostUserDetails';
@@ -56,6 +56,9 @@ const mockUseLiveQuery = vi.mocked(useLiveQuery);
 const mockDbUserDetailsGet = vi.mocked(Core.db.user_details.get);
 const mockDbPostDetailsGet = vi.mocked(Core.db.post_details.get);
 
+// Fixed "now" time for deterministic tests: 2024-03-15T10:00:00Z
+const FIXED_NOW = new Date('2024-03-15T10:00:00Z').getTime();
+
 describe('SinglePostUserDetails', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -92,9 +95,19 @@ describe('SinglePostUserDetails', () => {
 describe('SinglePostUserDetails - Snapshots', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Set fixed time for deterministic snapshot tests
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('matches snapshot with user and post details', () => {
+    // 14 days before FIXED_NOW
+    const indexedAt = FIXED_NOW - 14 * 24 * 60 * 60 * 1000;
+
     mockUseLiveQuery
       .mockReturnValueOnce({
         id: '69deadbeef1234567890',
@@ -103,7 +116,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       }) // userDetails
       .mockReturnValueOnce({
         uri: 'pubky://author123/pub/example.com/posts/post1',
-        indexed_at: new Date('2024-01-01T12:00:00Z').getTime(),
+        indexed_at: indexedAt,
       }); // postDetails
 
     const { container } = render(<SinglePostUserDetails postId="author123:post1" />);
@@ -111,6 +124,9 @@ describe('SinglePostUserDetails - Snapshots', () => {
   });
 
   it('matches snapshot with no user image', () => {
+    // 14 days before FIXED_NOW
+    const indexedAt = FIXED_NOW - 14 * 24 * 60 * 60 * 1000;
+
     mockUseLiveQuery
       .mockReturnValueOnce({
         id: '69deadbeef1234567890',
@@ -119,7 +135,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       })
       .mockReturnValueOnce({
         uri: 'pubky://author123/pub/example.com/posts/post1',
-        indexed_at: new Date('2024-01-01T12:00:00Z').getTime(),
+        indexed_at: indexedAt,
       });
 
     const { container } = render(<SinglePostUserDetails postId="author123:post1" />);
@@ -127,6 +143,9 @@ describe('SinglePostUserDetails - Snapshots', () => {
   });
 
   it('matches snapshot with empty name', () => {
+    // 14 days before FIXED_NOW
+    const indexedAt = FIXED_NOW - 14 * 24 * 60 * 60 * 1000;
+
     mockUseLiveQuery
       .mockReturnValueOnce({
         id: '69deadbeef1234567890',
@@ -135,7 +154,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       })
       .mockReturnValueOnce({
         uri: 'pubky://author123/pub/example.com/posts/post1',
-        indexed_at: new Date('2024-01-01T12:00:00Z').getTime(),
+        indexed_at: indexedAt,
       });
 
     const { container } = render(<SinglePostUserDetails postId="author123:post1" />);
@@ -143,6 +162,9 @@ describe('SinglePostUserDetails - Snapshots', () => {
   });
 
   it('matches snapshot with different postId', () => {
+    // 5 days before FIXED_NOW
+    const indexedAt = FIXED_NOW - 5 * 24 * 60 * 60 * 1000;
+
     mockUseLiveQuery
       .mockReturnValueOnce({
         id: 'different1234567890',
@@ -151,7 +173,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       })
       .mockReturnValueOnce({
         uri: 'pubky://different123/pub/example.com/posts/post2',
-        indexed_at: new Date('2024-02-01T15:30:00Z').getTime(),
+        indexed_at: indexedAt,
       });
 
     const { container } = render(<SinglePostUserDetails postId="different123:post2" />);
@@ -159,8 +181,8 @@ describe('SinglePostUserDetails - Snapshots', () => {
   });
 
   it('matches snapshot with recent post', () => {
-    const recentDate = new Date();
-    recentDate.setMinutes(recentDate.getMinutes() - 5); // 5 minutes ago
+    // 5 minutes before FIXED_NOW
+    const indexedAt = FIXED_NOW - 5 * 60 * 1000;
 
     mockUseLiveQuery
       .mockReturnValueOnce({
@@ -170,7 +192,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       })
       .mockReturnValueOnce({
         uri: 'pubky://author123/pub/example.com/posts/post1',
-        indexed_at: recentDate.getTime(),
+        indexed_at: indexedAt,
       });
 
     const { container } = render(<SinglePostUserDetails postId="author123:post1" />);
@@ -178,6 +200,10 @@ describe('SinglePostUserDetails - Snapshots', () => {
   });
 
   it('matches snapshot with old post', () => {
+    // will use formatDistanceToNow because more than 24 hours before FIXED_NOW
+    // 4 years before FIXED_NOW
+    const indexedAt = FIXED_NOW - 4 * 365 * 24 * 60 * 60 * 1000;
+
     mockUseLiveQuery
       .mockReturnValueOnce({
         id: '69deadbeef1234567890',
@@ -186,7 +212,7 @@ describe('SinglePostUserDetails - Snapshots', () => {
       })
       .mockReturnValueOnce({
         uri: 'pubky://author123/pub/example.com/posts/post1',
-        indexed_at: new Date('2020-01-01T12:00:00Z').getTime(),
+        indexed_at: indexedAt,
       });
 
     const { container } = render(<SinglePostUserDetails postId="author123:post1" />);

--- a/src/components/organisms/SinglePostUserDetails/SinglePostUserDetails.test.tsx.snap
+++ b/src/components/organisms/SinglePostUserDetails/SinglePostUserDetails.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`SinglePostUserDetails - Snapshots > matches snapshot with different pos
               data-size="sm"
               data-testid="typography"
             >
-              almost 2 years ago
+              5 days ago
             </div>
           </div>
         </div>
@@ -164,7 +164,7 @@ exports[`SinglePostUserDetails - Snapshots > matches snapshot with empty name 1`
               data-size="sm"
               data-testid="typography"
             >
-              almost 2 years ago
+              14 days ago
             </div>
           </div>
         </div>
@@ -251,7 +251,7 @@ exports[`SinglePostUserDetails - Snapshots > matches snapshot with no user image
               data-size="sm"
               data-testid="typography"
             >
-              almost 2 years ago
+              14 days ago
             </div>
           </div>
         </div>
@@ -339,7 +339,7 @@ exports[`SinglePostUserDetails - Snapshots > matches snapshot with old post 1`] 
               data-size="sm"
               data-testid="typography"
             >
-              almost 6 years ago
+              almost 4 years ago
             </div>
           </div>
         </div>
@@ -515,7 +515,7 @@ exports[`SinglePostUserDetails - Snapshots > matches snapshot with user and post
               data-size="sm"
               data-testid="typography"
             >
-              almost 2 years ago
+              14 days ago
             </div>
           </div>
         </div>


### PR DESCRIPTION
fixes https://github.com/pubky/franky/issues/135

Paste or insert recovery phrase words separated by space, comma, new line or tabs to distribute across input fields for convenience.