### PR TITLE
feat(PostContent): media link embeds

### DIFF
--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/GenericPreview.tsx
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/GenericPreview.tsx
@@ -27,7 +27,18 @@ export function GenericPreview({ url }: GenericPreviewProps) {
     return null;
   }
 
-  const { url: displayUrl, title, image } = metadata;
+  const { url: displayUrl, title, image, type } = metadata;
+
+  if (type === 'image')
+    return (
+      <Atoms.Link overrideDefaults href={url}>
+        <Atoms.Image src={url} alt="Image preview" className="w-full rounded-md object-contain" />
+      </Atoms.Link>
+    );
+
+  if (type === 'video') return <Atoms.Video src={url} className="w-full cursor-auto object-contain" />;
+
+  if (type === 'audio') return <Atoms.Audio src={url} className="cursor-auto" />;
 
   return (
     <Atoms.Link data-testid="generic-website-preview" href={url}>

--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
@@ -1,0 +1,199 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GenericPreview - Snapshots > matches snapshot for audio type 1`] = `
+<div>
+  <audio
+    class="w-full cursor-auto"
+    controls=""
+    data-testid="audio"
+    preload="metadata"
+    src="https://example.com/audio.mp3"
+  />
+</div>
+`;
+
+exports[`GenericPreview - Snapshots > matches snapshot for image type 1`] = `
+<div>
+  <a
+    href="https://example.com/photo.jpg"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="Image preview"
+      class="h-auto max-w-full w-full rounded-md object-contain"
+      data-nimg="1"
+      decoding="async"
+      height="600"
+      loading="lazy"
+      src="https://example.com/photo.jpg"
+      style="color: transparent;"
+      width="800"
+    />
+  </a>
+</div>
+`;
+
+exports[`GenericPreview - Snapshots > matches snapshot for loading state 1`] = `
+<div>
+  <p
+    class="text-sm font-semibold text-muted-foreground"
+    data-testid="typography"
+  >
+    Loading preview...
+  </p>
+</div>
+`;
+
+exports[`GenericPreview - Snapshots > matches snapshot for video type 1`] = `
+<div>
+  <video
+    class="h-auto max-w-full rounded-md bg-black w-full cursor-auto object-contain"
+    controls=""
+    data-testid="video"
+    preload="metadata"
+    src="https://example.com/video.mp4"
+  />
+</div>
+`;
+
+exports[`GenericPreview - Snapshots > matches snapshot for website type with all fields 1`] = `
+<div>
+  <a
+    class="cursor-pointer hover:text-brand/80 transition-colors text-brand text-sm"
+    data-testid="generic-website-preview"
+    href="https://example.com"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="mx-auto w-full flex-col flex justify-between gap-6 rounded-md bg-muted p-6 lg:flex-row"
+      data-testid="container"
+    >
+      <div
+        class="mx-auto w-full flex-col flex gap-y-2"
+        data-testid="container"
+      >
+        <p
+          class="text-2xl font-bold text-foreground wrap-break-word"
+          data-testid="typography"
+        >
+          Example Website Title
+        </p>
+        <div
+          class="mx-auto w-full flex flex-row items-center gap-x-1"
+          data-testid="container"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-globe shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"
+            />
+            <path
+              d="M2 12h20"
+            />
+          </svg>
+          <p
+            class="text-sm max-w-50 overflow-hidden font-medium text-ellipsis whitespace-nowrap text-muted-foreground sm:max-w-none sm:whitespace-normal"
+            data-testid="typography"
+          >
+            example.com
+          </p>
+        </div>
+      </div>
+      <img
+        alt="Website social image"
+        class="max-w-full h-25 w-45 shrink-0 rounded-md object-cover object-center"
+        data-nimg="1"
+        decoding="async"
+        height="100"
+        loading="lazy"
+        src="https://example.com/og-image.jpg"
+        style="color: transparent;"
+        width="180"
+      />
+    </div>
+  </a>
+</div>
+`;
+
+exports[`GenericPreview - Snapshots > matches snapshot for website type without image 1`] = `
+<div>
+  <a
+    class="cursor-pointer hover:text-brand/80 transition-colors text-brand text-sm"
+    data-testid="generic-website-preview"
+    href="https://example.com"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="mx-auto w-full flex-col flex justify-between gap-6 rounded-md bg-muted p-6 lg:flex-row"
+      data-testid="container"
+    >
+      <div
+        class="mx-auto w-full flex-col flex gap-y-2"
+        data-testid="container"
+      >
+        <p
+          class="text-2xl font-bold text-foreground wrap-break-word"
+          data-testid="typography"
+        >
+          Example Website Title
+        </p>
+        <div
+          class="mx-auto w-full flex flex-row items-center gap-x-1"
+          data-testid="container"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-globe shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"
+            />
+            <path
+              d="M2 12h20"
+            />
+          </svg>
+          <p
+            class="text-sm max-w-50 overflow-hidden font-medium text-ellipsis whitespace-nowrap text-muted-foreground sm:max-w-none sm:whitespace-normal"
+            data-testid="typography"
+          >
+            example.com
+          </p>
+        </div>
+      </div>
+    </div>
+  </a>
+</div>
+`;

--- a/src/hooks/useOgMetadata/useOgMetadata.ts
+++ b/src/hooks/useOgMetadata/useOgMetadata.ts
@@ -6,6 +6,7 @@ export interface OgMetadata {
   url: string;
   title: string | null;
   image: string | null;
+  type: 'website' | 'image' | 'video' | 'audio';
 }
 
 // Simple in-memory cache for metadata


### PR DESCRIPTION
## 🎯 Summary

Add support for image, video, and audio link embeds in post content.

---

## 📋 Description

This PR extends our metadata handling to support non-HTML content types. Previously, the API only parsed generic HTML pages that contained tags. Now, media files are properly detected and rendered with appropriate native elements.

### What's Changed

- **Added content-type detection** for images, videos, and audio files
- **Updated preview component** to render media files appropriately
- **Added tests** to cover new features

---

## 🎬 Supported Content Types

| Type | Behavior |
|------|----------|
| 🖼️ **Images** | Rendered with `<img>` element |
| 🎥 **Videos** | Rendered with `<video>` element |
| 🎵 **Audio** | Rendered with `<audio>` element |
| 📄 **HTML** | Rendered with website preview (existing behavior) |

---

## 💡 Motivation

Users can share direct links to media files (e.g., CDN-hosted images, video files, audio clips). Previously, these links would not generate previews. This change provides a seamless preview experience for all common media types.

---

## 🔗 Related

- Sub-task of #396 
- This PR's target branch is another open PR #537 due to shared components

---

## 📸 Screenshots

### Image Preview
<img width="756" height="615" alt="image" src="https://github.com/user-attachments/assets/9826f64c-88ae-49ab-9ede-ce79316f44cc" />

### Video Preview
<img width="756" height="615" alt="image" src="https://github.com/user-attachments/assets/66bb1b60-3fac-46d2-a99f-16440dcf8519" />

### Audio Preview
<img width="756" height="276" alt="image" src="https://github.com/user-attachments/assets/f7d6ea75-11c1-42a9-bd7d-f2f6654f9cbb" />

---

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Tests added/updated for new functionality
- [x] Documentation updated (if applicable)
- [x] Tested locally with various media file types