### PR TITLE
feat: deleted posts detection and rendering

### DIFF
--- a/src/components/molecules/PostDeleted/PostDeleted.test.tsx
+++ b/src/components/molecules/PostDeleted/PostDeleted.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PostDeleted } from './PostDeleted';
+
+// Mock atoms
+vi.mock('@/atoms', () => ({
+  CardContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="card-content" className={className}>
+      {children}
+    </div>
+  ),
+  Typography: ({ children, size, className }: { children: React.ReactNode; size?: string; className?: string }) => (
+    <p data-testid="typography" data-size={size} className={className}>
+      {children}
+    </p>
+  ),
+}));
+
+describe('PostDeleted', () => {
+  it('renders the deleted message', () => {
+    render(<PostDeleted />);
+    expect(screen.getByText(/This post has been deleted by its author/i)).toBeInTheDocument();
+  });
+
+  it('renders CardContent wrapper', () => {
+    render(<PostDeleted />);
+    expect(screen.getByTestId('card-content')).toBeInTheDocument();
+  });
+
+  it('renders Typography with correct size', () => {
+    render(<PostDeleted />);
+    const typography = screen.getByTestId('typography');
+    expect(typography).toHaveAttribute('data-size', 'sm');
+  });
+
+  it('applies correct styling classes to CardContent', () => {
+    render(<PostDeleted />);
+    const cardContent = screen.getByTestId('card-content');
+    expect(cardContent).toHaveClass('py-2');
+  });
+
+  it('applies correct styling classes to Typography', () => {
+    render(<PostDeleted />);
+    const typography = screen.getByTestId('typography');
+    expect(typography).toHaveClass('text-center');
+    expect(typography).toHaveClass('font-normal');
+    expect(typography).toHaveClass('text-muted-foreground');
+  });
+});
+
+describe('PostDeleted - Snapshots', () => {
+  it('matches snapshot with default props', () => {
+    const { container } = render(<PostDeleted />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/PostDeleted/PostDeleted.test.tsx.snap
+++ b/src/components/molecules/PostDeleted/PostDeleted.test.tsx.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PostDeleted - Snapshots > matches snapshot with default props 1`] = `
+<div
+  class="py-2"
+  data-testid="card-content"
+>
+  <p
+    class="text-center font-normal text-muted-foreground"
+    data-size="sm"
+    data-testid="typography"
+  >
+    This post has been deleted by its author.
+  </p>
+</div>
+`;

--- a/src/components/molecules/PostDeleted/PostDeleted.tsx
+++ b/src/components/molecules/PostDeleted/PostDeleted.tsx
@@ -1,0 +1,11 @@
+import * as Atoms from '@/atoms';
+
+export const PostDeleted = () => {
+  return (
+    <Atoms.CardContent className="py-2">
+      <Atoms.Typography size="sm" className="text-center font-normal text-muted-foreground">
+        This post has been deleted by its author.
+      </Atoms.Typography>
+    </Atoms.CardContent>
+  );
+};

--- a/src/components/molecules/PostDeleted/index.ts
+++ b/src/components/molecules/PostDeleted/index.ts
@@ -1,0 +1,1 @@
+export * from './PostDeleted';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -38,6 +38,7 @@ export * from './ProfilePageLinks';
 export * from './ProfilePageLayoutWrapper';
 export * from './ProfileNavigation';
 export * from './PostCodeBlock';
+export * from './PostDeleted';
 export * from './PostHashtags';
 export * from './PostLinkEmbeds';
 export * from './PostTag';

--- a/src/components/organisms/PostMain/PostMain.test.tsx.snap
+++ b/src/components/organisms/PostMain/PostMain.test.tsx.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`PostMain - Snapshots > matches snapshot with deleted post 1`] = `
+<div
+  data-class-name="relative flex cursor-pointer"
+  data-override-defaults="true"
+  data-testid="container"
+>
+  <div
+    data-class-name="flex-1 rounded-md py-0"
+    data-testid="card"
+  >
+    <div
+      data-testid="post-deleted"
+    >
+      PostDeleted
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
 <div
   data-class-name="relative flex cursor-pointer"

--- a/src/components/organisms/PostMain/PostMain.tsx
+++ b/src/components/organisms/PostMain/PostMain.tsx
@@ -16,6 +16,9 @@ export interface PostMainProps {
 }
 
 export function PostMain({ postId, onClick, className, isReply = false, isLastReply = false }: PostMainProps) {
+  const { postDetails } = Hooks.usePostDetails(postId);
+  const isDeleted = Libs.isPostDeleted(postDetails?.content);
+
   const [replyDialogOpen, setReplyDialogOpen] = useState(false);
 
   // Get post height for thread connector
@@ -41,18 +44,22 @@ export function PostMain({ postId, onClick, className, isReply = false, isLastRe
           </Atoms.Container>
         )}
         <Atoms.Card ref={cardRef} className={Libs.cn('flex-1 rounded-md py-0', className)}>
-          <Atoms.CardContent className="flex flex-col gap-4 p-6">
-            <Organisms.PostHeader postId={postId} />
-            <Organisms.PostContent postId={postId} />
-            <Atoms.Container onClick={handleFooterClick} className="justify-between gap-2 md:flex-row md:gap-0">
-              <Molecules.PostTagsList postId={postId} showInput={false} addMode={true} />
-              <Organisms.PostActionsBar
-                postId={postId}
-                onReplyClick={handleReplyClick}
-                className="w-full flex-1 justify-start md:justify-end"
-              />
-            </Atoms.Container>
-          </Atoms.CardContent>
+          {isDeleted ? (
+            <Molecules.PostDeleted />
+          ) : (
+            <Atoms.CardContent className="flex flex-col gap-4 p-6">
+              <Organisms.PostHeader postId={postId} />
+              <Organisms.PostContent postId={postId} />
+              <Atoms.Container onClick={handleFooterClick} className="justify-between gap-2 md:flex-row md:gap-0">
+                <Molecules.PostTagsList postId={postId} showInput={false} addMode={true} />
+                <Organisms.PostActionsBar
+                  postId={postId}
+                  onReplyClick={handleReplyClick}
+                  className="w-full flex-1 justify-start md:justify-end"
+                />
+              </Atoms.Container>
+            </Atoms.CardContent>
+          )}
         </Atoms.Card>
       </Atoms.Container>
       <Organisms.DialogReply postId={postId} open={replyDialogOpen} onOpenChangeAction={setReplyDialogOpen} />

--- a/src/components/organisms/SinglePost/SinglePost.test.tsx.snap
+++ b/src/components/organisms/SinglePost/SinglePost.test.tsx.snap
@@ -1,5 +1,66 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SinglePost - Snapshots > matches snapshot when post is deleted 1`] = `
+<div
+  class="relative"
+>
+  <div
+    class="rounded-lg py-0 "
+    data-testid="card"
+  >
+    <div
+      data-testid="post-deleted"
+    >
+      Post Deleted
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SinglePost - Snapshots > matches snapshot when post is deleted with clickable true 1`] = `
+<div
+  class="relative"
+>
+  <div
+    class="rounded-lg py-0 cursor-pointer"
+    data-testid="card"
+  >
+    <div
+      data-testid="post-deleted"
+    >
+      Post Deleted
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SinglePost - Snapshots > matches snapshot when post is deleted with isReply true 1`] = `
+<div
+  class="relative"
+>
+  <div
+    class="absolute top-0 -left-12"
+  >
+    <div
+      data-height="0"
+      data-testid="reply-line"
+    >
+      ReplyLine
+    </div>
+  </div>
+  <div
+    class="rounded-lg py-0 "
+    data-testid="card"
+  >
+    <div
+      data-testid="post-deleted"
+    >
+      Post Deleted
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SinglePost - Snapshots > matches snapshot with all props provided 1`] = `
 <div
   class="relative"
@@ -15,11 +76,11 @@ exports[`SinglePost - Snapshots > matches snapshot with all props provided 1`] =
     </div>
   </div>
   <div
-    class="rounded-lg p-6 cursor-pointer"
+    class="rounded-lg py-0 cursor-pointer"
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -86,11 +147,11 @@ exports[`SinglePost - Snapshots > matches snapshot with clickable false explicit
   class="relative"
 >
   <div
-    class="rounded-lg p-6 "
+    class="rounded-lg py-0 "
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -157,11 +218,11 @@ exports[`SinglePost - Snapshots > matches snapshot with clickable true 1`] = `
   class="relative"
 >
   <div
-    class="rounded-lg p-6 cursor-pointer"
+    class="rounded-lg py-0 cursor-pointer"
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -228,11 +289,11 @@ exports[`SinglePost - Snapshots > matches snapshot with default props 1`] = `
   class="relative"
 >
   <div
-    class="rounded-lg p-6 "
+    class="rounded-lg py-0 "
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -299,11 +360,11 @@ exports[`SinglePost - Snapshots > matches snapshot with different postId 1`] = `
   class="relative"
 >
   <div
-    class="rounded-lg p-6 "
+    class="rounded-lg py-0 "
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -370,11 +431,11 @@ exports[`SinglePost - Snapshots > matches snapshot with isReply false explicitly
   class="relative"
 >
   <div
-    class="rounded-lg p-6 "
+    class="rounded-lg py-0 "
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div
@@ -451,11 +512,11 @@ exports[`SinglePost - Snapshots > matches snapshot with isReply true 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg p-6 "
+    class="rounded-lg py-0 "
     data-testid="card"
   >
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3"
       data-testid="container"
     >
       <div

--- a/src/components/organisms/SinglePost/SinglePost.tsx
+++ b/src/components/organisms/SinglePost/SinglePost.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import * as Atoms from '@/atoms';
-import * as Hooks from '@/hooks';
+import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
+import * as Hooks from '@/hooks';
+import * as Libs from '@/libs';
 
 interface PostProps {
   postId: string;
@@ -12,6 +14,9 @@ interface PostProps {
 }
 
 export function SinglePost({ postId, clickable = false, isReply = false, onClick }: PostProps) {
+  const { postDetails } = Hooks.usePostDetails(postId);
+  const isDeleted = Libs.isPostDeleted(postDetails?.content);
+
   const { ref: cardRef, height: postHeight } = Hooks.useElementHeight();
 
   return (
@@ -23,34 +28,38 @@ export function SinglePost({ postId, clickable = false, isReply = false, onClick
       )}
       <Atoms.Card
         ref={cardRef}
-        className={`rounded-lg p-6 ${clickable ? 'cursor-pointer' : ''}`}
+        className={`rounded-lg py-0 ${clickable ? 'cursor-pointer' : ''}`}
         onClick={clickable ? onClick : undefined}
       >
-        <Atoms.Container className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <Atoms.Container className="flex flex-col gap-4 lg:col-span-2">
-            <div onClick={(e) => e.stopPropagation()}>
-              <Organisms.SinglePostUserDetails postId={postId} />
-            </div>
-
-            <Atoms.Container className="flex flex-col gap-4">
-              <Organisms.SinglePostContent postId={postId} />
-
-              {/* Tags on mobile - between content and buttons */}
-              <Atoms.Container className="block lg:hidden">
-                <Organisms.SinglePostTags postId={postId} />
-              </Atoms.Container>
-
+        {isDeleted ? (
+          <Molecules.PostDeleted />
+        ) : (
+          <Atoms.Container className="grid grid-cols-1 gap-4 p-6 lg:grid-cols-3">
+            <Atoms.Container className="flex flex-col gap-4 lg:col-span-2">
               <div onClick={(e) => e.stopPropagation()}>
-                <Organisms.SinglePostCounts postId={postId} />
+                <Organisms.SinglePostUserDetails postId={postId} />
               </div>
+
+              <Atoms.Container className="flex flex-col gap-4">
+                <Organisms.SinglePostContent postId={postId} />
+
+                {/* Tags on mobile - between content and buttons */}
+                <Atoms.Container className="block lg:hidden">
+                  <Organisms.SinglePostTags postId={postId} />
+                </Atoms.Container>
+
+                <div onClick={(e) => e.stopPropagation()}>
+                  <Organisms.SinglePostCounts postId={postId} />
+                </div>
+              </Atoms.Container>
+            </Atoms.Container>
+
+            {/* Tags on desktop - right column */}
+            <Atoms.Container className="hidden lg:block" onClick={(e) => e.stopPropagation()}>
+              <Organisms.SinglePostTags postId={postId} />
             </Atoms.Container>
           </Atoms.Container>
-
-          {/* Tags on desktop - right column */}
-          <Atoms.Container className="hidden lg:block" onClick={(e) => e.stopPropagation()}>
-            <Organisms.SinglePostTags postId={postId} />
-          </Atoms.Container>
-        </Atoms.Container>
+        )}
       </Atoms.Card>
     </div>
   );

--- a/src/libs/utils/utils.test.ts
+++ b/src/libs/utils/utils.test.ts
@@ -15,6 +15,7 @@ import {
   hoursAgo,
   daysAgo,
   formatNotificationTime,
+  isPostDeleted,
 } from './utils';
 
 describe('Utils', () => {
@@ -924,6 +925,36 @@ describe('Utils', () => {
         const timestamp = now - 7 * 24 * 60 * 60 * 1000; // exactly 7 days
         expect(formatNotificationTime(timestamp, true)).toBe('7 DAYS AGO');
       });
+    });
+  });
+
+  describe('isPostDeleted', () => {
+    it('should return true for "[DELETED]" content', () => {
+      expect(isPostDeleted('[DELETED]')).toBe(true);
+    });
+
+    it('should return false for regular content', () => {
+      expect(isPostDeleted('Hello world')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isPostDeleted('')).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isPostDeleted(undefined)).toBe(false);
+    });
+
+    it('should return false for similar but not exact match', () => {
+      expect(isPostDeleted('[deleted]')).toBe(false);
+      expect(isPostDeleted('DELETED')).toBe(false);
+      expect(isPostDeleted('[DELETED] ')).toBe(false);
+      expect(isPostDeleted(' [DELETED]')).toBe(false);
+    });
+
+    it('should return false for content containing "[DELETED]"', () => {
+      expect(isPostDeleted('This post is [DELETED]')).toBe(false);
+      expect(isPostDeleted('[DELETED] post')).toBe(false);
     });
   });
 });

--- a/src/libs/utils/utils.ts
+++ b/src/libs/utils/utils.ts
@@ -442,3 +442,5 @@ export const convertHmsToSeconds = (
 
   return h * 3600 + m * 60 + s;
 };
+
+export const isPostDeleted = (content: string | undefined) => content === '[DELETED]';


### PR DESCRIPTION
## 🗑️ Add PostDeleted Component and Integrate with Post Views

### Summary

This PR introduces a new `PostDeleted` molecule component to gracefully handle the display of deleted posts throughout the application. The implementation includes a utility function for deletion detection and seamless integration with existing post view components.

---

### ✨ Changes

#### New Component
- **`PostDeleted`** - A new molecule component that displays a user-friendly message when a post has been deleted

#### New Utility
- **`isPostDeleted`** - Utility function that checks for the `[DELETED]` content marker to determine if a post has been removed

#### Updated Components
- **`PostMain`** (organism) - Now detects deleted posts and renders `PostDeleted` instead of normal content
- **`SinglePost`** (organism) - Now detects deleted posts and renders `PostDeleted` instead of normal content

---

### 🔧 How It Works

1. Read the post details from the `usePostDetails` hook (wrapper for `getPostDetails` Controller)
2. The `isPostDeleted` utility function checks post content for the `[DELETED]` marker
3. When rendering posts, `PostMain` and `SinglePost` first check if the post is deleted
4. If deleted, the `PostDeleted` component is rendered in place of the standard post content
5. If not deleted, normal post rendering proceeds as usual

---

### 🧪 Testing

All test files have been updated or created accordingly.

- [x] Verify `PostDeleted` component renders correctly with appropriate styling
- [x] Confirm deleted posts are properly detected in `PostMain`
- [x] Confirm deleted posts are properly detected in `SinglePost`
- [x] Ensure non-deleted posts continue to render normally
- [x] Test edge cases (empty content, partial matches, etc.)

---

### 📸 Screenshots

<img width="783" height="499" alt="image" src="https://github.com/user-attachments/assets/ebab1f41-aced-4c48-b09f-1e1fd7006845" />

---

### 🔗 Related Issues

This issue is tracked in our spreadsheet.