### PR TITLE
chore: add claude.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,8 @@ public/sw.js.map
 /.cursor/plans
 /.cursor/commands
 
+# Claude
+CLAUDE.md
+
 # AI generated reviews
 .ai-reviews/


### PR DESCRIPTION
## 🔧 Add CLAUDE.md to .gitignore

### Summary

This PR adds `CLAUDE.md` to the `.gitignore` file to prevent the Claude AI configuration file from being tracked in version control.

### Changes

- ➕ Added `CLAUDE.md` to `.gitignore` under a new "Claude" section
- This keeps developer-specific AI assistant configuration local and out of the repository

### Rationale

The `CLAUDE.md` file contains project-specific guidance for Claude AI assistants (like Claude Code). Since this file may contain personalized instructions or be modified frequently during development sessions, it's best kept as a local configuration file rather than committed to the repository.

---

### Notes

- Developers who use Claude AI tools will need to create their own local `CLAUDE.md` file if needed
- Existing `CLAUDE.md` files will need to be manually removed from tracking if already committed (`git rm --cached CLAUDE.md`)
