### PR TITLE
feat: Profile moderation

### DIFF
--- a/src/core/application/moderation/moderation.test.ts
+++ b/src/core/application/moderation/moderation.test.ts
@@ -5,12 +5,8 @@ import * as Core from '@/core';
 vi.mock('@/core/services/local/moderation', () => ({
   LocalModerationService: {
     setUnblur: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/models/moderation', () => ({
-  ModerationModel: {
-    findByIds: vi.fn(),
+    getModerationRecords: vi.fn(),
+    getModerationRecord: vi.fn(),
   },
 }));
 
@@ -21,12 +17,12 @@ describe('ModerationApplication', () => {
 
   describe('setUnblur', () => {
     it('should delegate to LocalModerationService', async () => {
-      const postId = 'author:post1';
+      const id = 'author:post1';
       const spy = vi.spyOn(Core.LocalModerationService, 'setUnblur').mockResolvedValue(undefined);
 
-      await ModerationApplication.setUnblur(postId);
+      await ModerationApplication.setUnblur(id);
 
-      expect(spy).toHaveBeenCalledWith(postId);
+      expect(spy).toHaveBeenCalledWith(id);
     });
   });
 
@@ -43,7 +39,7 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      vi.spyOn(Core.ModerationModel, 'findByIds').mockResolvedValue([]);
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, false);
 
@@ -62,8 +58,8 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      vi.spyOn(Core.ModerationModel, 'findByIds').mockResolvedValue([
-        { id: posts[0].id, is_blurred: true, created_at: Date.now() },
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: posts[0].id, type: Core.ModerationType.POST, is_blurred: true, created_at: Date.now() },
       ]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, false);
@@ -83,8 +79,8 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      vi.spyOn(Core.ModerationModel, 'findByIds').mockResolvedValue([
-        { id: posts[0].id, is_blurred: false, created_at: Date.now() },
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: posts[0].id, type: Core.ModerationType.POST, is_blurred: false, created_at: Date.now() },
       ]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, false);
@@ -104,8 +100,8 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      vi.spyOn(Core.ModerationModel, 'findByIds').mockResolvedValue([
-        { id: posts[0].id, is_blurred: true, created_at: Date.now() },
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: posts[0].id, type: Core.ModerationType.POST, is_blurred: true, created_at: Date.now() },
       ]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, true); // blur disabled
@@ -113,7 +109,7 @@ describe('ModerationApplication', () => {
       expect(result).toEqual([{ ...posts[0], is_moderated: true, is_blurred: false }]);
     });
 
-    it('should use single batch query for multiple posts', async () => {
+    it('should use single batch query for multiple posts with POST type filter', async () => {
       const posts: Core.PostDetailsModelSchema[] = [
         {
           id: 'author:post1',
@@ -133,13 +129,15 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      const findByIdsSpy = vi
-        .spyOn(Core.ModerationModel, 'findByIds')
-        .mockResolvedValue([{ id: 'author:post1', is_blurred: true, created_at: Date.now() }]);
+      const getModerationRecordsSpy = vi
+        .spyOn(Core.LocalModerationService, 'getModerationRecords')
+        .mockResolvedValue([
+          { id: 'author:post1', type: Core.ModerationType.POST, is_blurred: true, created_at: Date.now() },
+        ]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, false);
 
-      expect(findByIdsSpy).toHaveBeenCalledWith(['author:post1', 'author:post2']);
+      expect(getModerationRecordsSpy).toHaveBeenCalledWith(['author:post1', 'author:post2'], Core.ModerationType.POST);
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({ ...posts[0], is_moderated: true, is_blurred: true });
       expect(result[1]).toEqual({ ...posts[1], is_moderated: false, is_blurred: false });
@@ -179,9 +177,9 @@ describe('ModerationApplication', () => {
         },
       ];
 
-      vi.spyOn(Core.ModerationModel, 'findByIds').mockResolvedValue([
-        { id: 'author:post1', is_blurred: false, created_at: Date.now() },
-        { id: 'author:post2', is_blurred: true, created_at: Date.now() },
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: 'author:post1', type: Core.ModerationType.POST, is_blurred: false, created_at: Date.now() },
+        { id: 'author:post2', type: Core.ModerationType.POST, is_blurred: true, created_at: Date.now() },
       ]);
 
       const result = await ModerationApplication.enrichPostsWithModeration(posts, false);
@@ -192,6 +190,140 @@ describe('ModerationApplication', () => {
       expect(result[1].is_blurred).toBe(true);
       expect(result[2].is_moderated).toBe(false);
       expect(result[2].is_blurred).toBe(false);
+    });
+  });
+
+  describe('enrichUsersWithModeration', () => {
+    const createMockUser = (id: string): Core.UserDetailsModelSchema => ({
+      id: id as Core.Pubky,
+      name: 'Test User',
+      bio: 'Test bio',
+      image: null,
+      links: [],
+      status: null,
+      indexed_at: 123456,
+    });
+
+    it('should return not moderated when no record exists', async () => {
+      const users = [createMockUser('pk:user1')];
+
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([]);
+
+      const result = await ModerationApplication.enrichUsersWithModeration(users, false);
+
+      expect(result).toEqual([{ ...users[0], is_moderated: false, is_blurred: false }]);
+    });
+
+    it('should return blurred when user is moderated and is_blurred is true', async () => {
+      const users = [createMockUser('pk:user1')];
+
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: 'pk:user1', type: Core.ModerationType.PROFILE, is_blurred: true, created_at: Date.now() },
+      ]);
+
+      const result = await ModerationApplication.enrichUsersWithModeration(users, false);
+
+      expect(result).toEqual([{ ...users[0], is_moderated: true, is_blurred: true }]);
+    });
+
+    it('should return not blurred when user is moderated but is_blurred is false', async () => {
+      const users = [createMockUser('pk:user1')];
+
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: 'pk:user1', type: Core.ModerationType.PROFILE, is_blurred: false, created_at: Date.now() },
+      ]);
+
+      const result = await ModerationApplication.enrichUsersWithModeration(users, false);
+
+      expect(result).toEqual([{ ...users[0], is_moderated: true, is_blurred: false }]);
+    });
+
+    it('should return not blurred when blur is disabled globally', async () => {
+      const users = [createMockUser('pk:user1')];
+
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: 'pk:user1', type: Core.ModerationType.PROFILE, is_blurred: true, created_at: Date.now() },
+      ]);
+
+      const result = await ModerationApplication.enrichUsersWithModeration(users, true); // blur disabled
+
+      expect(result).toEqual([{ ...users[0], is_moderated: true, is_blurred: false }]);
+    });
+
+    it('should filter by PROFILE type when calling getModerationRecords', async () => {
+      const users = [createMockUser('pk:user1'), createMockUser('pk:user2')];
+
+      const getModerationRecordsSpy = vi
+        .spyOn(Core.LocalModerationService, 'getModerationRecords')
+        .mockResolvedValue([]);
+
+      await ModerationApplication.enrichUsersWithModeration(users, false);
+
+      expect(getModerationRecordsSpy).toHaveBeenCalledWith(['pk:user1', 'pk:user2'], Core.ModerationType.PROFILE);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const result = await ModerationApplication.enrichUsersWithModeration([], false);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle mixed moderation states', async () => {
+      const users = [createMockUser('pk:user1'), createMockUser('pk:user2'), createMockUser('pk:user3')];
+
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecords').mockResolvedValue([
+        { id: 'pk:user1', type: Core.ModerationType.PROFILE, is_blurred: false, created_at: Date.now() },
+        { id: 'pk:user2', type: Core.ModerationType.PROFILE, is_blurred: true, created_at: Date.now() },
+      ]);
+
+      const result = await ModerationApplication.enrichUsersWithModeration(users, false);
+
+      expect(result[0].is_moderated).toBe(true);
+      expect(result[0].is_blurred).toBe(false);
+      expect(result[1].is_moderated).toBe(true);
+      expect(result[1].is_blurred).toBe(true);
+      expect(result[2].is_moderated).toBe(false);
+      expect(result[2].is_blurred).toBe(false);
+    });
+  });
+
+  describe('getModerationStatus', () => {
+    it('should return not moderated when no record exists', async () => {
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecord').mockResolvedValue(null);
+
+      const result = await ModerationApplication.getModerationStatus('author:post1', Core.ModerationType.POST, false);
+
+      expect(result).toEqual({ is_moderated: false, is_blurred: false });
+    });
+
+    it('should return moderated and blurred when record exists with is_blurred true', async () => {
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecord').mockResolvedValue({
+        id: 'author:post1',
+        type: Core.ModerationType.POST,
+        is_blurred: true,
+        created_at: Date.now(),
+      });
+
+      const result = await ModerationApplication.getModerationStatus('author:post1', Core.ModerationType.POST, false);
+
+      expect(result).toEqual({ is_moderated: true, is_blurred: true });
+    });
+
+    it('should return not blurred when blur is disabled globally', async () => {
+      vi.spyOn(Core.LocalModerationService, 'getModerationRecord').mockResolvedValue({
+        id: 'author:post1',
+        type: Core.ModerationType.POST,
+        is_blurred: true,
+        created_at: Date.now(),
+      });
+
+      const result = await ModerationApplication.getModerationStatus(
+        'author:post1',
+        Core.ModerationType.POST,
+        true, // blur disabled
+      );
+
+      expect(result).toEqual({ is_moderated: true, is_blurred: false });
     });
   });
 });

--- a/src/core/application/moderation/moderation.ts
+++ b/src/core/application/moderation/moderation.ts
@@ -4,8 +4,30 @@ import { shouldBlur } from './moderation.utils';
 export class ModerationApplication {
   private constructor() {}
 
-  static async setUnblur(postId: string): Promise<void> {
-    return Core.LocalModerationService.setUnblur(postId);
+  /**
+   * Sets an item as unblurred by the user.
+   */
+  static async setUnblur(id: string): Promise<void> {
+    return Core.LocalModerationService.setUnblur(id);
+  }
+
+  /**
+   * Enriches items with moderation status.
+   * Generic method that works for both posts and users.
+   */
+  private static enrichWithModeration<T extends { id: string }>(
+    items: T[],
+    recordMap: Map<string, Core.ModerationModelSchema>,
+    isBlurDisabledGlobally: boolean,
+  ): (T & { is_moderated: boolean; is_blurred: boolean })[] {
+    return items.map((item) => {
+      const record = recordMap.get(item.id);
+      return {
+        ...item,
+        is_moderated: !!record,
+        is_blurred: record ? shouldBlur(record.is_blurred, isBlurDisabledGlobally) : false,
+      };
+    });
   }
 
   static async enrichPostsWithModeration(
@@ -14,16 +36,42 @@ export class ModerationApplication {
   ): Promise<Core.EnrichedPostDetails[]> {
     if (posts.length === 0) return [];
 
-    const records = await Core.LocalModerationService.getModerationRecords(posts.map((p) => p.id));
+    const records = await Core.LocalModerationService.getModerationRecords(
+      posts.map((p) => p.id),
+      Core.ModerationType.POST,
+    );
     const recordMap = new Map(records.map((r) => [r.id, r]));
 
-    return posts.map((post) => {
-      const record = recordMap.get(post.id);
-      return {
-        ...post,
-        is_moderated: !!record,
-        is_blurred: record ? shouldBlur(true, record.is_blurred, isBlurDisabledGlobally) : false,
-      };
-    });
+    return this.enrichWithModeration(posts, recordMap, isBlurDisabledGlobally);
+  }
+
+  static async enrichUsersWithModeration(
+    users: Core.UserDetailsModelSchema[],
+    isBlurDisabledGlobally: boolean,
+  ): Promise<Core.EnrichedUserDetails[]> {
+    if (users.length === 0) return [];
+
+    const records = await Core.LocalModerationService.getModerationRecords(
+      users.map((u) => u.id),
+      Core.ModerationType.PROFILE,
+    );
+    const recordMap = new Map(records.map((r) => [r.id, r]));
+
+    return this.enrichWithModeration(users, recordMap, isBlurDisabledGlobally);
+  }
+
+  /**
+   * Check moderation status for a single item.
+   */
+  static async getModerationStatus(
+    id: string,
+    type: Core.ModerationType,
+    isBlurDisabledGlobally: boolean,
+  ): Promise<{ is_moderated: boolean; is_blurred: boolean }> {
+    const record = await Core.LocalModerationService.getModerationRecord(id, type);
+    return {
+      is_moderated: !!record,
+      is_blurred: record ? shouldBlur(record.is_blurred, isBlurDisabledGlobally) : false,
+    };
   }
 }

--- a/src/core/application/moderation/moderation.types.ts
+++ b/src/core/application/moderation/moderation.types.ts
@@ -4,3 +4,8 @@ export type EnrichedPostDetails = Core.PostDetailsModelSchema & {
   is_moderated: boolean;
   is_blurred: boolean;
 };
+
+export type EnrichedUserDetails = Core.UserDetailsModelSchema & {
+  is_moderated: boolean;
+  is_blurred: boolean;
+};

--- a/src/core/application/moderation/moderation.utils.test.ts
+++ b/src/core/application/moderation/moderation.utils.test.ts
@@ -78,22 +78,22 @@ describe('moderation.utils', () => {
 
   describe('shouldBlur', () => {
     it('should return false when blur is disabled globally', () => {
-      const result = shouldBlur(true, true, true);
+      const result = shouldBlur(true, true);
       expect(result).toBe(false);
     });
 
-    it('should return false when post is not moderated', () => {
-      const result = shouldBlur(false, true, false);
-      expect(result).toBe(false);
-    });
-
-    it('should return true when post is moderated and blurred', () => {
-      const result = shouldBlur(true, true, false);
+    it('should return true when item is blurred and blur is enabled globally', () => {
+      const result = shouldBlur(true, false);
       expect(result).toBe(true);
     });
 
-    it('should return false when post is moderated but not blurred', () => {
-      const result = shouldBlur(true, false, false);
+    it('should return false when item is not blurred', () => {
+      const result = shouldBlur(false, false);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when item is not blurred even if blur enabled globally', () => {
+      const result = shouldBlur(false, false);
       expect(result).toBe(false);
     });
   });

--- a/src/core/application/moderation/moderation.utils.ts
+++ b/src/core/application/moderation/moderation.utils.ts
@@ -11,8 +11,11 @@ export const detectModerationFromTags = (tags: { label: string; taggers: string[
   return tags.some((tag) => MODERATED_TAG_SET.has(tag.label) && tag.taggers.includes(Config.MODERATION_ID));
 };
 
-export const shouldBlur = (isModerated: boolean, isBlurred: boolean, isBlurDisabledGlobally: boolean): boolean => {
+/**
+ * Determines if content should be blurred based on moderation state and user preferences.
+ * Only called when a moderation record exists (item is moderated).
+ */
+export const shouldBlur = (isBlurred: boolean, isBlurDisabledGlobally: boolean): boolean => {
   if (isBlurDisabledGlobally) return false;
-  if (!isModerated) return false;
   return isBlurred;
 };

--- a/src/core/controllers/moderation/moderation.test.ts
+++ b/src/core/controllers/moderation/moderation.test.ts
@@ -6,6 +6,8 @@ vi.mock('@/core/application/moderation', () => ({
   ModerationApplication: {
     setUnblur: vi.fn(),
     enrichPostsWithModeration: vi.fn(),
+    enrichUsersWithModeration: vi.fn(),
+    getModerationStatus: vi.fn(),
   },
 }));
 
@@ -14,14 +16,24 @@ describe('ModerationController', () => {
     vi.clearAllMocks();
   });
 
-  describe('unblurPost', () => {
+  describe('unblur', () => {
     it('should call ModerationApplication.setUnblur', async () => {
-      const postId = 'author:post1';
+      const id = 'author:post1';
       const spy = vi.spyOn(Core.ModerationApplication, 'setUnblur').mockResolvedValue(undefined);
 
-      await ModerationController.unblurPost(postId);
+      await ModerationController.unblur(id);
 
-      expect(spy).toHaveBeenCalledWith(postId);
+      expect(spy).toHaveBeenCalledWith(id);
+    });
+
+    it('should work for both posts and profiles', async () => {
+      const spy = vi.spyOn(Core.ModerationApplication, 'setUnblur').mockResolvedValue(undefined);
+
+      await ModerationController.unblur('author:post1');
+      await ModerationController.unblur('pk:user1');
+
+      expect(spy).toHaveBeenCalledWith('author:post1');
+      expect(spy).toHaveBeenCalledWith('pk:user1');
     });
   });
 
@@ -63,6 +75,115 @@ describe('ModerationController', () => {
 
       expect(result).toEqual([]);
       expect(enrichSpy).toHaveBeenCalledWith([], false);
+    });
+  });
+
+  describe('enrichUsers', () => {
+    it('should pass isBlurDisabledGlobally from settings store', async () => {
+      const users: Core.UserDetailsModelSchema[] = [
+        {
+          id: 'pk:user1' as Core.Pubky,
+          name: 'Test User',
+          bio: 'Test bio',
+          image: null,
+          links: [],
+          status: null,
+          indexed_at: 123456,
+        },
+      ];
+
+      const enrichedUsers: Core.EnrichedUserDetails[] = [{ ...users[0], is_moderated: true, is_blurred: true }];
+
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: true },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      const enrichSpy = vi
+        .spyOn(Core.ModerationApplication, 'enrichUsersWithModeration')
+        .mockResolvedValue(enrichedUsers);
+
+      const result = await ModerationController.enrichUsers(users);
+
+      expect(result).toEqual(enrichedUsers);
+      expect(enrichSpy).toHaveBeenCalledWith(users, false); // blurCensored: true means isBlurDisabledGlobally: false
+    });
+
+    it('should handle blur disabled globally', async () => {
+      const users: Core.UserDetailsModelSchema[] = [
+        {
+          id: 'pk:user1' as Core.Pubky,
+          name: 'Test User',
+          bio: 'Test bio',
+          image: null,
+          links: [],
+          status: null,
+          indexed_at: 123456,
+        },
+      ];
+
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: false },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      const enrichSpy = vi.spyOn(Core.ModerationApplication, 'enrichUsersWithModeration').mockResolvedValue([]);
+
+      await ModerationController.enrichUsers(users);
+
+      expect(enrichSpy).toHaveBeenCalledWith(users, true); // blurCensored: false means isBlurDisabledGlobally: true
+    });
+
+    it('should handle empty array', async () => {
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: true },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      const enrichSpy = vi.spyOn(Core.ModerationApplication, 'enrichUsersWithModeration').mockResolvedValue([]);
+
+      const result = await ModerationController.enrichUsers([]);
+
+      expect(result).toEqual([]);
+      expect(enrichSpy).toHaveBeenCalledWith([], false);
+    });
+  });
+
+  describe('getModerationStatus', () => {
+    it('should call ModerationApplication.getModerationStatus with correct params for POST', async () => {
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: true },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      const spy = vi
+        .spyOn(Core.ModerationApplication, 'getModerationStatus')
+        .mockResolvedValue({ is_moderated: true, is_blurred: true });
+
+      const result = await ModerationController.getModerationStatus('author:post1', Core.ModerationType.POST);
+
+      expect(spy).toHaveBeenCalledWith('author:post1', Core.ModerationType.POST, false);
+      expect(result).toEqual({ is_moderated: true, is_blurred: true });
+    });
+
+    it('should call ModerationApplication.getModerationStatus with correct params for PROFILE', async () => {
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: false },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      const spy = vi
+        .spyOn(Core.ModerationApplication, 'getModerationStatus')
+        .mockResolvedValue({ is_moderated: true, is_blurred: false });
+
+      const result = await ModerationController.getModerationStatus('pk:user1', Core.ModerationType.PROFILE);
+
+      expect(spy).toHaveBeenCalledWith('pk:user1', Core.ModerationType.PROFILE, true);
+      expect(result).toEqual({ is_moderated: true, is_blurred: false });
+    });
+
+    it('should return not moderated status', async () => {
+      vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+        privacy: { blurCensored: true },
+      } as Partial<Core.SettingsStore> as Core.SettingsStore);
+      vi.spyOn(Core.ModerationApplication, 'getModerationStatus').mockResolvedValue({
+        is_moderated: false,
+        is_blurred: false,
+      });
+
+      const result = await ModerationController.getModerationStatus('pk:user1', Core.ModerationType.PROFILE);
+
+      expect(result).toEqual({ is_moderated: false, is_blurred: false });
     });
   });
 });

--- a/src/core/controllers/moderation/moderation.ts
+++ b/src/core/controllers/moderation/moderation.ts
@@ -3,12 +3,32 @@ import * as Core from '@/core';
 export class ModerationController {
   private constructor() {}
 
-  static async unblurPost(postId: string): Promise<void> {
-    return Core.ModerationApplication.setUnblur(postId);
+  private static get isBlurDisabledGlobally(): boolean {
+    return !Core.useSettingsStore.getState().privacy.blurCensored;
+  }
+
+  /**
+   * Unblur a moderated item (post or profile).
+   */
+  static async unblur(id: string): Promise<void> {
+    return Core.ModerationApplication.setUnblur(id);
   }
 
   static async enrichPosts(posts: Core.PostDetailsModelSchema[]): Promise<Core.EnrichedPostDetails[]> {
-    const isBlurDisabledGlobally = !Core.useSettingsStore.getState().privacy.blurCensored;
-    return Core.ModerationApplication.enrichPostsWithModeration(posts, isBlurDisabledGlobally);
+    return Core.ModerationApplication.enrichPostsWithModeration(posts, this.isBlurDisabledGlobally);
+  }
+
+  static async enrichUsers(users: Core.UserDetailsModelSchema[]): Promise<Core.EnrichedUserDetails[]> {
+    return Core.ModerationApplication.enrichUsersWithModeration(users, this.isBlurDisabledGlobally);
+  }
+
+  /**
+   * Get moderation status for a single item.
+   */
+  static async getModerationStatus(
+    id: string,
+    type: Core.ModerationType,
+  ): Promise<{ is_moderated: boolean; is_blurred: boolean }> {
+    return Core.ModerationApplication.getModerationStatus(id, type, this.isBlurDisabledGlobally);
   }
 }

--- a/src/core/models/moderation/moderation.schema.ts
+++ b/src/core/models/moderation/moderation.schema.ts
@@ -1,11 +1,46 @@
+/**
+ * Type of moderated content
+ */
+export enum ModerationType {
+  POST = 'post',
+  PROFILE = 'profile',
+}
+
 export interface ModerationModelSchema {
+  /**
+   * The unique ID of the moderated item.
+   * For posts: composite ID (authorId:postId)
+   * For profiles: user pubky
+   */
   id: string;
+
+  /**
+   * Type of content being moderated
+   */
+  type: ModerationType;
+
+  /**
+   * Whether the content is currently blurred.
+   * When false, the user has chosen to unblur this item.
+   */
   is_blurred: boolean;
+
+  /**
+   * Timestamp when the item was added to moderation
+   */
   created_at: number;
 }
 
+/**
+ * Dexie table schema for moderation
+ * - Primary key: id
+ * - Indexed: type (for filtering by content type)
+ * - Indexed: is_blurred (for filtering blurred items)
+ * - Indexed: created_at (for sorting)
+ */
 export const moderationTableSchema = `
   &id,
+  type,
   is_blurred,
   created_at
 `;

--- a/src/core/models/moderation/moderation.test.ts
+++ b/src/core/models/moderation/moderation.test.ts
@@ -9,19 +9,46 @@ describe('ModerationModel', () => {
     });
   });
 
-  it('should create and retrieve moderation records', async () => {
+  it('should create and retrieve post moderation records', async () => {
     const postId = 'author:post1';
-    await Core.ModerationModel.upsert({ id: postId, is_blurred: true, created_at: Date.now() });
+    await Core.ModerationModel.upsert({
+      id: postId,
+      type: Core.ModerationType.POST,
+      is_blurred: true,
+      created_at: Date.now(),
+    });
 
     const record = await Core.ModerationModel.table.get(postId);
     expect(record).toBeTruthy();
     expect(record!.id).toBe(postId);
+    expect(record!.type).toBe(Core.ModerationType.POST);
+    expect(record!.is_blurred).toBe(true);
+  });
+
+  it('should create and retrieve profile moderation records', async () => {
+    const profileId = 'pk:user1';
+    await Core.ModerationModel.upsert({
+      id: profileId,
+      type: Core.ModerationType.PROFILE,
+      is_blurred: true,
+      created_at: Date.now(),
+    });
+
+    const record = await Core.ModerationModel.table.get(profileId);
+    expect(record).toBeTruthy();
+    expect(record!.id).toBe(profileId);
+    expect(record!.type).toBe(Core.ModerationType.PROFILE);
     expect(record!.is_blurred).toBe(true);
   });
 
   it('should delete moderation records', async () => {
     const postId = 'author:post1';
-    await Core.ModerationModel.upsert({ id: postId, is_blurred: true, created_at: Date.now() });
+    await Core.ModerationModel.upsert({
+      id: postId,
+      type: Core.ModerationType.POST,
+      is_blurred: true,
+      created_at: Date.now(),
+    });
 
     await Core.ModerationModel.deleteById(postId);
 
@@ -31,7 +58,12 @@ describe('ModerationModel', () => {
 
   it('should check existence of records', async () => {
     const postId = 'author:post1';
-    await Core.ModerationModel.upsert({ id: postId, is_blurred: true, created_at: Date.now() });
+    await Core.ModerationModel.upsert({
+      id: postId,
+      type: Core.ModerationType.POST,
+      is_blurred: true,
+      created_at: Date.now(),
+    });
 
     const exists = await Core.ModerationModel.exists(postId);
     expect(exists).toBe(true);
@@ -42,7 +74,12 @@ describe('ModerationModel', () => {
 
   it('should update is_blurred field', async () => {
     const postId = 'author:post1';
-    await Core.ModerationModel.upsert({ id: postId, is_blurred: true, created_at: Date.now() });
+    await Core.ModerationModel.upsert({
+      id: postId,
+      type: Core.ModerationType.POST,
+      is_blurred: true,
+      created_at: Date.now(),
+    });
 
     await Core.ModerationModel.update(postId, { is_blurred: false });
 

--- a/src/core/models/moderation/moderation.ts
+++ b/src/core/models/moderation/moderation.ts
@@ -1,6 +1,7 @@
 import { Table } from 'dexie';
 import * as Core from '@/core';
 import { RecordModelBase } from '@/core/models/shared/base/record/baseRecord';
+import { ModerationType } from './moderation.schema';
 
 export class ModerationModel
   extends RecordModelBase<string, Core.ModerationModelSchema>
@@ -8,11 +9,13 @@ export class ModerationModel
 {
   static table: Table<Core.ModerationModelSchema> = Core.db.table('moderation');
 
+  type: ModerationType;
   is_blurred: boolean;
   created_at: number;
 
   constructor(data: Core.ModerationModelSchema) {
     super(data);
+    this.type = data.type;
     this.is_blurred = data.is_blurred;
     this.created_at = data.created_at;
   }

--- a/src/core/services/local/stream/posts/posts.ts
+++ b/src/core/services/local/stream/posts/posts.ts
@@ -234,6 +234,7 @@ export class LocalStreamPostsService {
       if (isModerated) {
         postModerations.push({
           id: postId,
+          type: Core.ModerationType.POST,
           is_blurred: true,
           created_at: Date.now(),
         });

--- a/src/core/services/local/stream/users/users.test.ts
+++ b/src/core/services/local/stream/users/users.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as Core from '@/core';
+import * as Config from '@/config';
 
 describe('LocalStreamUsersService', () => {
   const targetUserId = 'user-target' as Core.Pubky;
@@ -89,6 +90,7 @@ describe('LocalStreamUsersService', () => {
     await Core.UserCountsModel.table.clear();
     await Core.UserRelationshipsModel.table.clear();
     await Core.UserTagsModel.table.clear();
+    await Core.ModerationModel.table.clear();
   });
 
   describe('upsert', () => {
@@ -355,6 +357,91 @@ describe('LocalStreamUsersService', () => {
       expect(counts!.replies).toBe(50);
       expect(counts!.followers).toBe(300);
       expect(counts!.following).toBe(200);
+    });
+
+    describe('moderation detection', () => {
+      it('should create moderation record for user with moderation tag', async () => {
+        const userId = 'user-moderated' as Core.Pubky;
+        const moderatedTags: Core.NexusTag[] = [
+          {
+            label: Config.MODERATED_TAGS[0],
+            taggers: [Config.MODERATION_ID],
+            taggers_count: 1,
+            relationship: { tagged: true, tagged_by_viewer: false },
+          },
+        ];
+
+        const mockUser = createMockNexusUser(userId, { tags: moderatedTags });
+        await Core.LocalStreamUsersService.persistUsers([mockUser]);
+
+        const moderationRecord = await Core.ModerationModel.findById(userId);
+        expect(moderationRecord).toBeTruthy();
+        expect(moderationRecord!.type).toBe(Core.ModerationType.PROFILE);
+        expect(moderationRecord!.is_blurred).toBe(true);
+      });
+
+      it('should not create moderation record for user without moderation tag', async () => {
+        const userId = 'user-normal' as Core.Pubky;
+        const normalTags: Core.NexusTag[] = [
+          {
+            label: 'developer',
+            taggers: ['tagger-1'],
+            taggers_count: 1,
+            relationship: { tagged: true, tagged_by_viewer: false },
+          },
+        ];
+
+        const mockUser = createMockNexusUser(userId, { tags: normalTags });
+        await Core.LocalStreamUsersService.persistUsers([mockUser]);
+
+        const moderationRecord = await Core.ModerationModel.findById(userId);
+        expect(moderationRecord).toBeNull();
+      });
+
+      it('should not create moderation record when tag has wrong tagger', async () => {
+        const userId = 'user-wrong-tagger' as Core.Pubky;
+        const tagsWithWrongTagger: Core.NexusTag[] = [
+          {
+            label: Config.MODERATED_TAGS[0],
+            taggers: ['wrong-tagger-id'],
+            taggers_count: 1,
+            relationship: { tagged: true, tagged_by_viewer: false },
+          },
+        ];
+
+        const mockUser = createMockNexusUser(userId, { tags: tagsWithWrongTagger });
+        await Core.LocalStreamUsersService.persistUsers([mockUser]);
+
+        const moderationRecord = await Core.ModerationModel.findById(userId);
+        expect(moderationRecord).toBeNull();
+      });
+
+      it('should handle mixed moderated and non-moderated users', async () => {
+        const moderatedUserId = 'user-moderated' as Core.Pubky;
+        const normalUserId = 'user-normal' as Core.Pubky;
+
+        const moderatedUser = createMockNexusUser(moderatedUserId, {
+          tags: [
+            {
+              label: Config.MODERATED_TAGS[0],
+              taggers: [Config.MODERATION_ID],
+              taggers_count: 1,
+              relationship: { tagged: true, tagged_by_viewer: false },
+            },
+          ],
+        });
+
+        const normalUser = createMockNexusUser(normalUserId, { tags: [] });
+
+        await Core.LocalStreamUsersService.persistUsers([moderatedUser, normalUser]);
+
+        const moderatedRecord = await Core.ModerationModel.findById(moderatedUserId);
+        expect(moderatedRecord).toBeTruthy();
+        expect(moderatedRecord!.type).toBe(Core.ModerationType.PROFILE);
+
+        const normalRecord = await Core.ModerationModel.findById(normalUserId);
+        expect(normalRecord).toBeNull();
+      });
     });
   });
 });


### PR DESCRIPTION
I modified the moderation core to provide generic methods that can be used for both profiles and posts, additionally I chose to store a ModerationType into the moderation table so we can distinguish easily between profiles and posts. This could come in handy later, and barely takes up any space.