### PR TITLE
fix: #731 - Prevent premature redirect while session is being restored

### DIFF
--- a/src/hooks/useAuthStatus/useAuthStatus.test.tsx
+++ b/src/hooks/useAuthStatus/useAuthStatus.test.tsx
@@ -13,6 +13,7 @@ const mockOnboardingStore = {
 
 const mockAuthStore = {
   session: null,
+  sessionExport: null,
   isRestoringSession: false,
   hasProfile: false,
   hasHydrated: true,
@@ -36,6 +37,7 @@ describe('useAuthStatus', () => {
     mockOnboardingStore.pubky = '';
     mockOnboardingStore.secretKey = '';
     mockAuthStore.session = null;
+    mockAuthStore.sessionExport = null;
     mockAuthStore.isRestoringSession = false;
     mockAuthStore.hasProfile = false;
     mockAuthStore.hasHydrated = true;
@@ -79,6 +81,18 @@ describe('useAuthStatus', () => {
     const { result } = renderHook(() => useAuthStatus());
 
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return loading state when sessionExport exists but session is null (pending restoration)', () => {
+    mockOnboardingStore.hasHydrated = true;
+    mockAuthStore.hasHydrated = true;
+    mockAuthStore.sessionExport = 'some-exported-session';
+    mockAuthStore.session = null;
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    // Should be loading because we have credentials to restore
+    expect(result.current.isLoading).toBe(true);
   });
 
   it('should return UNAUTHENTICATED status when no session and no profile', () => {

--- a/src/hooks/useAuthStatus/useAuthStatus.tsx
+++ b/src/hooks/useAuthStatus/useAuthStatus.tsx
@@ -10,8 +10,13 @@ export function useAuthStatus(): AuthStatusResult {
   const authStore = Core.useAuthStore();
 
   const authStatusResult = useMemo((): AuthStatusResult => {
-    // Check if stores are still hydrating
-    const isLoading = !onboardingStore.hasHydrated || !authStore.hasHydrated || authStore.isRestoringSession;
+    // On page reload sessionExport (serialized credentials in localStorage) is restored
+    // before session (live auth object) is recreated. This flag prevents premature
+    // redirects by keeping isLoading true until session restoration is completed.
+    const isSessionRestorePending = authStore.sessionExport !== null && authStore.session === null;
+
+    const isLoading =
+      !onboardingStore.hasHydrated || !authStore.hasHydrated || authStore.isRestoringSession || isSessionRestorePending;
 
     // Check if user has keypair (session)
     const hasKeypair = authStore.session !== null;
@@ -46,6 +51,7 @@ export function useAuthStatus(): AuthStatusResult {
     onboardingStore.hasHydrated,
     authStore.hasHydrated,
     authStore.isRestoringSession,
+    authStore.sessionExport,
     authStore.session,
     authStore.hasProfile,
   ]);


### PR DESCRIPTION
Fixed a bug where reloading on `/hot`, `/settings`, or `/bookmarks` would redirect users to `/home`. The issue was a race condition during session restoration. On page reload, `sessionExport` (the exported string from sdk) loads from localStorage before session (actual auth object) is recreated, causing the route guard to briefly see an unauthenticated state and trigger a redirect. Added `isSessionRestorePending` check to `useAuthStatus` that keeps `isLoading` true while credentials exist but haven't been restored yet.