### PR TITLE
fix: remove pubkyring:// prefix to mobile auth flow

### DIFF
--- a/src/components/organisms/SignIn/SignIn.test.tsx
+++ b/src/components/organisms/SignIn/SignIn.test.tsx
@@ -265,7 +265,7 @@ describe('SignInContent', () => {
     });
 
     expect(clipboardMock.writeText).toHaveBeenCalledWith('mock-auth-url');
-    expect(window.open).toHaveBeenCalledWith('pubkyring://mock-auth-url', '_blank');
+    expect(window.open).toHaveBeenCalledWith('mock-auth-url', '_blank');
   });
 
   // Note: Retry logic and error handling for auth URL generation are now tested

--- a/src/components/organisms/SignIn/SignIn.tsx
+++ b/src/components/organisms/SignIn/SignIn.tsx
@@ -42,13 +42,11 @@ export const SignInContent = () => {
 
     await copyAuthUrlToClipboard();
 
-    const deeplink = Libs.generatePubkyRingDeeplink(url, { encode: false });
-
     try {
-      const openedWindow = window.open(deeplink, '_blank');
+      const openedWindow = window.open(url, '_blank');
 
       if (!openedWindow) {
-        window.location.href = deeplink;
+        window.location.href = url;
         return;
       }
 


### PR DESCRIPTION
Pubky-ring auth works when scanning QR but not on mobile with the 'Authorize with Pubky Ring' button. Pubky-ring errors with:
```
{
  "action": "unknown",
  "rawInput": "pubkyring://pubkyauth//signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/link&secret=f00HjbSbskM5KgpSSpKsleWLrJWWVmVb4up54ScOuFw",
  "error": "Unrecognized format. Expected a recovery phrase, invite code, auth URL, or session request."
}
```
The solution is to remove `pubkyring://` prefix from the deeplink.