### PR TITLE
fix: moderated tags environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ NEXT_PUBLIC_TTL_RETRY_DELAY_MS=60000
 # Moderation Configuration
 # =============================================================================
 NEXT_PUBLIC_MODERATION_ID=euwmq57zefw5ynnkhh37b3gcmhs7g3cptdbw1doaxj1pbmzp3wro
-NEXT_PUBLIC_MODERATED_TAGS=["adult_nu_sex_act"]
+NEXT_PUBLIC_MODERATED_TAGS=["nudity"]
 
 # =============================================================================
 # Network Configuration - Staging

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -143,7 +143,7 @@ jobs:
           NEXT_PUBLIC_HOMESERVER_ADMIN_URL=http://localhost:6288/generate_signup_token
           NEXT_PUBLIC_HOMESERVER_ADMIN_PASSWORD=admin
           NEXT_PUBLIC_MODERATION_ID=euwmq57zefw5ynnkhh37b3gcmhs7g3cptdbw1doaxj1pbmzp3wro
-          NEXT_PUBLIC_MODERATED_TAGS=["adult_nu_sex_act"]
+          NEXT_PUBLIC_MODERATED_TAGS=["nudity"]
           BASE_URL_SUPPORT=${{ secrets.BASE_URL_SUPPORT }}
           SUPPORT_API_ACCESS_TOKEN=${{ secrets.SUPPORT_API_ACCESS_TOKEN }}
           SUPPORT_ACCOUNT_ID=1

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -111,7 +111,7 @@ process.env.NEXT_PUBLIC_TESTNET = 'true';
 process.env.NEXT_PUBLIC_PKARR_RELAYS = 'http://localhost:8080';
 process.env.NEXT_PUBLIC_HOMESERVER = 'test-homeserver-key';
 process.env.NEXT_PUBLIC_MODERATION_ID = 'euwmq57zefw5ynnkhh37b3gcmhs7g3cptdbw1doaxj1pbmzp3wro';
-process.env.NEXT_PUBLIC_MODERATED_TAGS = '["adult_nu_sex_act"]';
+process.env.NEXT_PUBLIC_MODERATED_TAGS = '["nudity"]';
 process.env.NEXT_PUBLIC_EXCHANGE_RATE_API = 'https://api1.blocktank.to/api/fx/rates/btc';
 process.env.NEXT_PUBLIC_HOMEGATE_URL = 'https://localhost:5000/';
 

--- a/src/libs/env/env.ts
+++ b/src/libs/env/env.ts
@@ -145,7 +145,7 @@ const envSchema = z.object({
   NEXT_PUBLIC_MODERATION_ID: z.string().default('euwmq57zefw5ynnkhh37b3gcmhs7g3cptdbw1doaxj1pbmzp3wro'),
   NEXT_PUBLIC_MODERATED_TAGS: z
     .string()
-    .default('["adult_nu_sex_act"]')
+    .default('["nudity"]')
     .transform((val) => JSON.parse(val))
     .pipe(z.array(z.string().min(1)).min(1)),
   NEXT_PUBLIC_EXCHANGE_RATE_API: z.url().default('https://api1.blocktank.to/api/fx/rates/btc'),


### PR DESCRIPTION
# 🏷️ Update Default Moderated Tags Configuration

## Summary

This PR updates the default moderated content tags from `adult_nu_sex_act` to `nudity` across all environment configurations. This was incorrectly changed in https://github.com/pubky/franky/pull/612/changes/f7117d49a3e95511b93d32a229ebf8bdd3580498.

## Changes

### 🔧 Configuration Updates

- **`.env.example`**: Updated default `NEXT_PUBLIC_MODERATED_TAGS` value
- **`.github/workflows/e2e-test.yml`**: Updated E2E test environment configuration
- **`src/config/test.ts`**: Updated test environment configuration  
- **`src/libs/env/env.ts`**: Updated Zod schema default value

## Details

| File | Change |
|------|--------|
| `.env.example` | `["adult_nu_sex_act"]` → `["nudity"]` |
| `e2e-test.yml` | `["adult_nu_sex_act"]` → `["nudity"]` |
| `src/config/test.ts` | `["adult_nu_sex_act"]` → `["nudity"]` |
| `src/libs/env/env.ts` | Default value updated in Zod schema |

## Screenshots

- N/A (configuration change only)

## Notes

- This is a configuration-only change with no code logic modifications
- The `NEXT_PUBLIC_MODERATED_TAGS` environment variable continues to accept a JSON array of strings
- Existing deployments `NEXT_PUBLIC_MODERATED_TAGS` value is correct

---

_This pull request summary was generated, for full implementation details please reference the file changes._