### PR TITLE
fix(ui): update PostTagInput border styling to match design spec

### DIFF
--- a/src/components/molecules/PostTagInput/PostTagInput.test.tsx.snap
+++ b/src/components/molecules/PostTagInput/PostTagInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostTagInput - Snapshots > matches snapshot with emoji picker 1`] = `
 <div
-  class="relative flex h-8 items-center rounded-lg px-3 border border-dashed border-input focus-within:border-white/80"
+  class="relative flex h-8 items-center rounded-md px-3 border border-dashed border-input focus-within:border-white/80"
   data-cy="post-tag-input"
 >
   <input
@@ -65,7 +65,7 @@ exports[`PostTagInput - Snapshots > matches snapshot with emoji picker 1`] = `
 
 exports[`PostTagInput - Snapshots > matches snapshot with emoji picker and value 1`] = `
 <div
-  class="relative flex h-8 items-center rounded-lg px-3 border border-dashed border-input focus-within:border-white/80"
+  class="relative flex h-8 items-center rounded-md px-3 border border-dashed border-input focus-within:border-white/80"
   data-cy="post-tag-input"
 >
   <input
@@ -128,7 +128,7 @@ exports[`PostTagInput - Snapshots > matches snapshot with emoji picker and value
 
 exports[`PostTagInput - Snapshots > matches snapshot with empty state 1`] = `
 <div
-  class="relative flex h-8 items-center rounded-lg px-3 border border-dashed border-input focus-within:border-white/80"
+  class="relative flex h-8 items-center rounded-md px-3 border border-dashed border-input focus-within:border-white/80"
   data-cy="post-tag-input"
 >
   <input
@@ -145,7 +145,7 @@ exports[`PostTagInput - Snapshots > matches snapshot with empty state 1`] = `
 
 exports[`PostTagInput - Snapshots > matches snapshot with filled state 1`] = `
 <div
-  class="relative flex h-8 items-center rounded-lg px-3 border border-dashed border-input focus-within:border-white/80"
+  class="relative flex h-8 items-center rounded-md px-3 border border-dashed border-input focus-within:border-white/80"
   data-cy="post-tag-input"
 >
   <input

--- a/src/components/molecules/PostTagInput/PostTagInput.tsx
+++ b/src/components/molecules/PostTagInput/PostTagInput.tsx
@@ -60,7 +60,7 @@ export const PostTagInput = React.forwardRef<HTMLInputElement, PostTagInputProps
       <div
         data-cy="post-tag-input"
         className={Libs.cn(
-          'relative flex h-8 items-center rounded-lg px-3',
+          'relative flex h-8 items-center rounded-md px-3',
           'border border-dashed border-input focus-within:border-white/80',
           onClick && 'cursor-pointer',
           className,


### PR DESCRIPTION
Fix #847 
Change border-radius from rounded-lg to rounded-md and remove focus border highlight to align with PostTagAddButton styling.

![Screenshot 2026-01-19 at 10 35 05](https://github.com/user-attachments/assets/f9260d9a-a1d9-4056-a2cc-18a1d4036710)
