### PR TITLE
wip: fix(posts): add optimistic update for posts created from dialog

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,12 +23,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <Molecules.RootContainer>
       <Providers.DatabaseProvider>
         <Providers.RouteGuardProvider>
-          <Organisms.CoordinatorsManager />
-          <Organisms.Header />
-          {children}
-          <Molecules.NewPostCTA />
-          <Molecules.Toaster />
-          <Organisms.DialogSignIn />
+          <Providers.NewPostProvider>
+            <Organisms.CoordinatorsManager />
+            <Organisms.Header />
+            {children}
+            <Molecules.NewPostCTA />
+            <Molecules.Toaster />
+            <Organisms.DialogSignIn />
+          </Providers.NewPostProvider>
         </Providers.RouteGuardProvider>
       </Providers.DatabaseProvider>
     </Molecules.RootContainer>

--- a/src/components/organisms/PostInput/PostInput.test.tsx
+++ b/src/components/organisms/PostInput/PostInput.test.tsx
@@ -99,8 +99,11 @@ vi.mock('@/organisms', () => ({
   )),
 }));
 
-vi.mock('../TimelineFeed/TimelineFeed', () => ({
-  useTimelineFeedContext: vi.fn(() => null),
+vi.mock('@/providers', () => ({
+  useNewPostContext: vi.fn(() => ({
+    signalNewPost: vi.fn(),
+    subscribeToNewPosts: vi.fn(() => vi.fn()),
+  })),
 }));
 
 vi.mock('../PostInputTags', () => ({

--- a/src/components/organisms/TimelineFeed/TimelineFeed.types.ts
+++ b/src/components/organisms/TimelineFeed/TimelineFeed.types.ts
@@ -21,8 +21,9 @@ export interface TimelineFeedProps {
    */
   variant: TimelineFeedVariant;
   /**
-   * Optional children to render above the timeline (e.g., PostInput)
-   * Children can access prependPosts via TimelineFeedContext
+   * Optional children to render above the timeline (e.g., PostInput).
+   * Note: For new post prepending, use NewPostProvider.signalNewPost() instead of
+   * accessing TimelineFeedContext directly. The HOME variant subscribes automatically.
    */
   children?: ReactNode;
 }

--- a/src/hooks/usePostInput/usePostInput.test.ts
+++ b/src/hooks/usePostInput/usePostInput.test.ts
@@ -58,12 +58,12 @@ vi.mock('@/hooks', () => ({
   useEmojiInsert: vi.fn(() => vi.fn()),
 }));
 
-// Mock TimelineFeed context
-const mockPrependPosts = vi.fn();
-vi.mock('@/organisms/TimelineFeed/TimelineFeed', () => ({
-  useTimelineFeedContext: vi.fn(() => ({
-    prependPosts: mockPrependPosts,
-    removePosts: vi.fn(),
+// Mock NewPostProvider context
+const mockSignalNewPost = vi.fn();
+vi.mock('@/providers', () => ({
+  useNewPostContext: vi.fn(() => ({
+    signalNewPost: mockSignalNewPost,
+    subscribeToNewPosts: vi.fn(() => vi.fn()),
   })),
 }));
 
@@ -410,7 +410,7 @@ describe('usePostInput', () => {
       expect(mockPost).not.toHaveBeenCalled();
     });
 
-    it('calls onSuccess and prependPosts when submission succeeds for post variant', async () => {
+    it('calls onSuccess and signalNewPost when submission succeeds for post variant', async () => {
       mockContent = 'Test content';
       mockPost.mockImplementation(async ({ onSuccess }) => {
         onSuccess('created-post-id');
@@ -428,11 +428,11 @@ describe('usePostInput', () => {
         await result.current.handleSubmit();
       });
 
-      expect(mockPrependPosts).toHaveBeenCalledWith('created-post-id');
+      expect(mockSignalNewPost).toHaveBeenCalledWith('created-post-id');
       expect(mockOnSuccess).toHaveBeenCalledWith('created-post-id');
     });
 
-    it('calls onSuccess and prependPosts when submission succeeds for repost variant', async () => {
+    it('calls onSuccess and signalNewPost when submission succeeds for repost variant', async () => {
       mockContent = 'Test repost content';
       mockRepost.mockImplementation(async ({ onSuccess }) => {
         onSuccess('created-repost-id');
@@ -451,11 +451,11 @@ describe('usePostInput', () => {
         await result.current.handleSubmit();
       });
 
-      expect(mockPrependPosts).toHaveBeenCalledWith('created-repost-id');
+      expect(mockSignalNewPost).toHaveBeenCalledWith('created-repost-id');
       expect(mockOnSuccess).toHaveBeenCalledWith('created-repost-id');
     });
 
-    it('calls onSuccess but does NOT prependPosts for reply variant', async () => {
+    it('calls onSuccess but does NOT signalNewPost for reply variant', async () => {
       mockContent = 'Test reply content';
       mockReply.mockImplementation(async ({ onSuccess }) => {
         onSuccess('created-reply-id');
@@ -474,8 +474,8 @@ describe('usePostInput', () => {
         await result.current.handleSubmit();
       });
 
-      // Reply should NOT prepend to timeline (fix for issue #601)
-      expect(mockPrependPosts).not.toHaveBeenCalled();
+      // Reply should NOT signal new post (replies are local to thread)
+      expect(mockSignalNewPost).not.toHaveBeenCalled();
       // But onSuccess should still be called
       expect(mockOnSuccess).toHaveBeenCalledWith('created-reply-id');
     });

--- a/src/providers/NewPostProvider/NewPostProvider.test.tsx
+++ b/src/providers/NewPostProvider/NewPostProvider.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, renderHook } from '@testing-library/react';
+import { NewPostProvider, useNewPostContext } from './NewPostProvider';
+
+describe('NewPostProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <NewPostProvider>
+        <div data-testid="child">Child Content</div>
+      </NewPostProvider>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toHaveTextContent('Child Content');
+  });
+
+  it('provides signalNewPost function via context', () => {
+    const { result } = renderHook(() => useNewPostContext(), {
+      wrapper: NewPostProvider,
+    });
+
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current.signalNewPost).toBe('function');
+    expect(typeof result.current.subscribeToNewPosts).toBe('function');
+  });
+
+  it('signalNewPost calls all subscribers with the post ID', () => {
+    const subscriber1 = vi.fn();
+    const subscriber2 = vi.fn();
+
+    const { result } = renderHook(() => useNewPostContext(), {
+      wrapper: NewPostProvider,
+    });
+
+    // Subscribe both callbacks
+    act(() => {
+      result.current.subscribeToNewPosts(subscriber1);
+      result.current.subscribeToNewPosts(subscriber2);
+    });
+
+    // Signal a new post
+    act(() => {
+      result.current.signalNewPost('test-post-id');
+    });
+
+    expect(subscriber1).toHaveBeenCalledTimes(1);
+    expect(subscriber1).toHaveBeenCalledWith('test-post-id');
+    expect(subscriber2).toHaveBeenCalledTimes(1);
+    expect(subscriber2).toHaveBeenCalledWith('test-post-id');
+  });
+
+  it('subscribeToNewPosts returns working unsubscribe function', () => {
+    const subscriber = vi.fn();
+
+    const { result } = renderHook(() => useNewPostContext(), {
+      wrapper: NewPostProvider,
+    });
+
+    // Subscribe and get unsubscribe function
+    let unsubscribe: (() => void) | undefined;
+    act(() => {
+      unsubscribe = result.current.subscribeToNewPosts(subscriber);
+    });
+
+    // Signal should call subscriber
+    act(() => {
+      result.current.signalNewPost('post-1');
+    });
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    // Unsubscribe
+    act(() => {
+      unsubscribe?.();
+    });
+
+    // Signal should NOT call subscriber after unsubscribe
+    act(() => {
+      result.current.signalNewPost('post-2');
+    });
+    expect(subscriber).toHaveBeenCalledTimes(1); // Still 1, not 2
+  });
+
+  it('handles multiple signals to the same subscriber', () => {
+    const subscriber = vi.fn();
+
+    const { result } = renderHook(() => useNewPostContext(), {
+      wrapper: NewPostProvider,
+    });
+
+    act(() => {
+      result.current.subscribeToNewPosts(subscriber);
+    });
+
+    act(() => {
+      result.current.signalNewPost('post-1');
+      result.current.signalNewPost('post-2');
+      result.current.signalNewPost('post-3');
+    });
+
+    expect(subscriber).toHaveBeenCalledTimes(3);
+    expect(subscriber).toHaveBeenNthCalledWith(1, 'post-1');
+    expect(subscriber).toHaveBeenNthCalledWith(2, 'post-2');
+    expect(subscriber).toHaveBeenNthCalledWith(3, 'post-3');
+  });
+
+  it('signalNewPost with no subscribers does not throw', () => {
+    const { result } = renderHook(() => useNewPostContext(), {
+      wrapper: NewPostProvider,
+    });
+
+    // Should not throw when signaling with no subscribers
+    expect(() => {
+      act(() => {
+        result.current.signalNewPost('orphan-post-id');
+      });
+    }).not.toThrow();
+  });
+});
+
+describe('useNewPostContext outside provider', () => {
+  it('returns default no-op functions when used outside provider', () => {
+    // Render WITHOUT provider wrapper
+    const { result } = renderHook(() => useNewPostContext());
+
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current.signalNewPost).toBe('function');
+    expect(typeof result.current.subscribeToNewPosts).toBe('function');
+
+    // Calling functions should not throw
+    expect(() => {
+      result.current.signalNewPost('test-id');
+    }).not.toThrow();
+
+    const unsubscribe = result.current.subscribeToNewPosts(() => {});
+    expect(typeof unsubscribe).toBe('function');
+    expect(() => {
+      unsubscribe?.();
+    }).not.toThrow();
+  });
+});
+
+describe('NewPostProvider - Snapshots', () => {
+  it('matches snapshot with children', () => {
+    const { container } = render(
+      <NewPostProvider>
+        <div>Child Content</div>
+      </NewPostProvider>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/providers/NewPostProvider/NewPostProvider.test.tsx.snap
+++ b/src/providers/NewPostProvider/NewPostProvider.test.tsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NewPostProvider - Snapshots > matches snapshot with children 1`] = `
+<div>
+  <div>
+    Child Content
+  </div>
+</div>
+`;

--- a/src/providers/NewPostProvider/NewPostProvider.tsx
+++ b/src/providers/NewPostProvider/NewPostProvider.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as React from 'react';
+import type { NewPostContextValue, NewPostProviderProps, NewPostCallback } from './NewPostProvider.types';
+
+/**
+ * Default context value - provides no-op functions when outside provider
+ */
+const defaultContextValue: NewPostContextValue = {
+  signalNewPost: () => {},
+  subscribeToNewPosts: () => () => {},
+};
+
+/**
+ * Context for new post signaling
+ */
+const NewPostContext = React.createContext<NewPostContextValue>(defaultContextValue);
+
+/**
+ * NewPostProvider
+ *
+ * Provides a pub/sub mechanism for new post creation events.
+ * This enables components outside of TimelineFeed (like DialogNewPost)
+ * to signal when a post is created, allowing the home feed to update optimistically.
+ *
+ * @example
+ * ```tsx
+ * // In layout.tsx - wrap app with provider
+ * <NewPostProvider>
+ *   {children}
+ * </NewPostProvider>
+ *
+ * // In usePostInput - signal new post
+ * const { signalNewPost } = useNewPostContext();
+ * signalNewPost(createdPostId);
+ *
+ * // In TimelineFeed - subscribe to new posts
+ * const { subscribeToNewPosts } = useNewPostContext();
+ * useEffect(() => {
+ *   return subscribeToNewPosts((postId) => prependPosts(postId));
+ * }, [subscribeToNewPosts, prependPosts]);
+ * ```
+ */
+export function NewPostProvider({ children }: NewPostProviderProps) {
+  // Store subscribers in a ref to avoid re-renders
+  const subscribersRef = React.useRef<Set<NewPostCallback>>(new Set());
+
+  // Create stable context value once using lazy useState initializer
+  // The functions close over subscribersRef (stable) and only access .current when called
+  const [contextValue] = React.useState<NewPostContextValue>(() => ({
+    signalNewPost: (postId: string) => {
+      subscribersRef.current.forEach((callback) => callback(postId));
+    },
+    subscribeToNewPosts: (callback: NewPostCallback) => {
+      subscribersRef.current.add(callback);
+      return () => subscribersRef.current.delete(callback);
+    },
+  }));
+
+  return <NewPostContext.Provider value={contextValue}>{children}</NewPostContext.Provider>;
+}
+
+/**
+ * Hook to access the new post context
+ *
+ * @returns The new post context value
+ *
+ * @example
+ * ```tsx
+ * // Signal a new post (in usePostInput)
+ * const { signalNewPost } = useNewPostContext();
+ * signalNewPost(postId);
+ *
+ * // Subscribe to new posts (in TimelineFeed)
+ * const { subscribeToNewPosts } = useNewPostContext();
+ * useEffect(() => {
+ *   return subscribeToNewPosts((postId) => prependPosts(postId));
+ * }, [subscribeToNewPosts, prependPosts]);
+ * ```
+ */
+export function useNewPostContext(): NewPostContextValue {
+  return React.useContext(NewPostContext);
+}

--- a/src/providers/NewPostProvider/NewPostProvider.types.ts
+++ b/src/providers/NewPostProvider/NewPostProvider.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Callback type for new post subscribers
+ */
+export type NewPostCallback = (postId: string) => void;
+
+/**
+ * Context value for the NewPostProvider
+ */
+export interface NewPostContextValue {
+  /**
+   * Signal that a new post was created.
+   * Called by usePostInput after successful POST or REPOST.
+   * @param postId - The ID of the newly created post
+   */
+  signalNewPost: (postId: string) => void;
+
+  /**
+   * Subscribe to new post signals.
+   * Used by TimelineFeed (HOME variant) to prepend posts optimistically.
+   * @param callback - Function to call when a new post is created
+   * @returns Unsubscribe function to clean up the subscription
+   */
+  subscribeToNewPosts: (callback: NewPostCallback) => () => void;
+}
+
+/**
+ * Props for the NewPostProvider component
+ */
+export interface NewPostProviderProps {
+  /** Children to render within the provider */
+  children: React.ReactNode;
+}

--- a/src/providers/NewPostProvider/index.ts
+++ b/src/providers/NewPostProvider/index.ts
@@ -1,0 +1,2 @@
+export * from './NewPostProvider';
+export type * from './NewPostProvider.types';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
 export * from './DatabaseProvider';
+export * from './NewPostProvider';
 export * from './ProfileProvider';
 export * from './RouteGuardProvider';


### PR DESCRIPTION
Posts created from the new post dialog were not appearing in the home feed immediately. The dialog is rendered outside TimelineFeed context, so it couldn't access prependPosts directly.

Solution: Introduce NewPostProvider with pub/sub pattern
- usePostInput signals new posts via signalNewPost()
- TimelineFeed (HOME variant) subscribes and prepends automatically
- Single code path for all post creation scenarios

Refs: #618