### PR TITLE
feat(post-input): add clipboard image paste support

### DIFF
--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -58,6 +58,7 @@ export function PostInput({
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    handlePaste,
     // Mention autocomplete
     mentionUsers,
     mentionIsOpen,
@@ -147,6 +148,7 @@ export function PostInput({
               onChange={handleChange}
               onFocus={handleExpand}
               onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
               maxLength={POST_MAX_CHARACTER_LENGTH}
               rows={1}
               disabled={isSubmitting}

--- a/src/hooks/usePostInput/usePostInput.test.ts
+++ b/src/hooks/usePostInput/usePostInput.test.ts
@@ -1872,4 +1872,144 @@ describe('usePostInput', () => {
       expect(mockSetAttachments).toHaveBeenCalled();
     });
   });
+
+  describe('handlePaste', () => {
+    it('extracts files from clipboard and adds them as attachments', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+      const pasteEvent = {
+        clipboardData: {
+          items: [{ kind: 'file', getAsFile: () => file }],
+        },
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      act(() => {
+        result.current.handlePaste(pasteEvent);
+      });
+
+      expect(pasteEvent.preventDefault).toHaveBeenCalled();
+      expect(mockSetAttachments).toHaveBeenCalled();
+    });
+
+    it('does not prevent default when pasting text (no files)', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const pasteEvent = {
+        clipboardData: {
+          items: [{ kind: 'string', getAsFile: () => null }],
+        },
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      act(() => {
+        result.current.handlePaste(pasteEvent);
+      });
+
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSetAttachments).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple files from clipboard', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const file1 = new File(['test1'], 'test1.png', { type: 'image/png' });
+      const file2 = new File(['test2'], 'test2.jpg', { type: 'image/jpeg' });
+      const pasteEvent = {
+        clipboardData: {
+          items: [
+            { kind: 'file', getAsFile: () => file1 },
+            { kind: 'file', getAsFile: () => file2 },
+          ],
+        },
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      act(() => {
+        result.current.handlePaste(pasteEvent);
+      });
+
+      expect(pasteEvent.preventDefault).toHaveBeenCalled();
+      expect(mockSetAttachments).toHaveBeenCalled();
+    });
+
+    it('handles null clipboardData gracefully', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const pasteEvent = {
+        clipboardData: null,
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      expect(() => {
+        act(() => {
+          result.current.handlePaste(pasteEvent);
+        });
+      }).not.toThrow();
+
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('handles null items gracefully', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const pasteEvent = {
+        clipboardData: {
+          items: null,
+        },
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      expect(() => {
+        act(() => {
+          result.current.handlePaste(pasteEvent);
+        });
+      }).not.toThrow();
+
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('ignores items where getAsFile returns null', () => {
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      const pasteEvent = {
+        clipboardData: {
+          items: [{ kind: 'file', getAsFile: () => null }],
+        },
+        preventDefault: vi.fn(),
+      } as unknown as React.ClipboardEvent;
+
+      act(() => {
+        result.current.handlePaste(pasteEvent);
+      });
+
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSetAttachments).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/hooks/usePostInput/usePostInput.ts
+++ b/src/hooks/usePostInput/usePostInput.ts
@@ -34,6 +34,7 @@ import type { UsePostInputOptions, UsePostInputReturn } from './usePostInput.typ
  * - Content change notifications to parent
  * - File drag and drop handling
  * - Mention autocomplete (@username and pk:id patterns)
+ * - Clipboard paste handling for file attachments
  */
 export function usePostInput({
   variant,
@@ -373,6 +374,28 @@ export function usePostInput({
     fileInputRef.current?.click();
   }, []);
 
+  // Handle paste events - extract files from clipboard
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const files: File[] = [];
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile();
+        if (file) {
+          files.push(file);
+        }
+      }
+    }
+
+    if (files.length > 0) {
+      // Only prevent default if we have files - allow normal text paste
+      e.preventDefault();
+      handleFilesAdded(files);
+    }
+  };
+
   const handleArticleClick = () => setIsArticle(true);
 
   // Derived values
@@ -425,6 +448,7 @@ export function usePostInput({
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    handlePaste,
     handleMentionSelect,
     handleMentionKeyDown: mentionHandleKeyDown,
   };

--- a/src/hooks/usePostInput/usePostInput.types.ts
+++ b/src/hooks/usePostInput/usePostInput.types.ts
@@ -1,7 +1,6 @@
 import type { RefObject } from 'react';
 import { type MDXEditorProps, type MDXEditorMethods } from '@mdxeditor/editor';
 import type { PostInputVariant } from '@/organisms/PostInput/PostInput.types';
-import type { AutocompleteUserData } from '@/hooks/useUserDetailsFromIds';
 
 export interface UsePostInputOptions {
   /** Variant determines if this is a reply, repost, or a new post */
@@ -47,7 +46,7 @@ export interface UsePostInputReturn {
   setShowEmojiPicker: (show: boolean) => void;
 
   // Mention autocomplete state
-  mentionUsers: AutocompleteUserData[];
+  mentionUsers: Array<{ id: string; name: string; avatarUrl?: string }>;
   mentionIsOpen: boolean;
   mentionSelectedIndex: number | null;
   setMentionSelectedIndex: (index: number | null) => void;
@@ -71,6 +70,7 @@ export interface UsePostInputReturn {
   handleDragLeave: (e: React.DragEvent) => void;
   handleDragOver: (e: React.DragEvent) => void;
   handleDrop: (e: React.DragEvent) => void;
+  handlePaste: (e: React.ClipboardEvent) => void;
   handleMentionSelect: (userId: string) => void;
-  handleMentionKeyDown: (e: React.KeyboardEvent) => boolean;
+  handleMentionKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
 }


### PR DESCRIPTION
Add handlePaste handler to extract files from clipboard and add them as attachments when pasting into the post composer textarea. Uses the existing handleFilesAdded logic for validation and size limits.

- Only prevents default when files are present (allows normal text paste)
- Supports multiple files pasted at once
- Handles edge cases (null clipboardData, null items, null files)

Closes #827

**Note:** Franky styling for uploaded/pasted images is different than Pubky styling. Current uploaded image UI was already in place, this ticket implements only clipboard image paste support.


https://github.com/user-attachments/assets/0c3da9bf-84ee-40f2-801b-6b63594e227e

