### PR TITLE
fix: [Bug]: Font size too small in reply field

### DIFF
--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -178,7 +178,7 @@ export function PostInput({
             <Atoms.Textarea
               ref={textareaRef}
               placeholder={displayPlaceholder}
-              className="min-h-6 resize-none border-none bg-transparent p-0 text-lg font-medium text-secondary-foreground shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="min-h-6 resize-none border-none p-0 font-medium text-secondary-foreground shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               value={content}
               onChange={handleChange}
               onFocus={handleExpand}

--- a/src/components/organisms/QuickReply/QuickReply.tsx
+++ b/src/components/organisms/QuickReply/QuickReply.tsx
@@ -129,7 +129,7 @@ export function QuickReply({
                 ref={textareaRef}
                 aria-label="Reply"
                 placeholder={displayPlaceholder}
-                className="min-h-6 resize-none border-none bg-transparent p-0 text-lg font-medium text-secondary-foreground shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                className="min-h-6 resize-none border-none p-0 font-medium text-secondary-foreground shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
                 value={content}
                 onChange={handleChange}
                 onFocus={handleExpand}


### PR DESCRIPTION
## Summary

This PR implements Issue #902.

## Related Issue

Closes #902

## Description

### Bug Description

Font size is too small in the reply field. Hard to read

### Steps to Reproduce

Reply to this https://franky.pubky.app/post/pgyzyongejbmsif3qnyj3hrmd78p31e16g47bx8z65uocbiiq8ay/0034HGVY5TN50

### Affected Area

Post (create/edit/delete)

### Suspected Layer (if known)

UI / Component (visual issue)

### Frequency

Always (100%)

### Expected Behavior

Must be bigger, see Figma

### Screenshots / Recording

<img width="2394" height="1646" alt="Image" src="https://github.com/user-attachments/assets/dbdb7c84-ea1b-40ad-9a81-d8e57600fdc8" />

### Console Log Output

```shell

```

### Browser & Version

_No response_

### Device

_No response_

### Additional Context

_No response_