### PR TITLE
fix: Status missing from other profile page

### DIFF
--- a/src/components/organisms/ProfilePageContainer/ProfilePageContainer.tsx
+++ b/src/components/organisms/ProfilePageContainer/ProfilePageContainer.tsx
@@ -95,6 +95,7 @@ export function ProfilePageContainer({ children }: ProfilePageContainerProps) {
       navigateToPage={navigateToPage}
       isLoading={isLoading}
       isOwnProfile={isOwnProfile}
+      userId={pubky ?? ''}
     >
       {children}
     </Organisms.ProfilePageLayout>

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -97,6 +97,7 @@ const mockProps: ProfilePageHeaderProps = {
     isLoggingOut: false,
   },
   isOwnProfile: true,
+  userId: '1QX7GKW3abcdef1234567890',
 };
 
 const mockOtherUserProps: ProfilePageHeaderProps = {
@@ -117,6 +118,7 @@ const mockOtherUserProps: ProfilePageHeaderProps = {
     isFollowing: false,
   },
   isOwnProfile: false,
+  userId: 'other123456789012345',
 };
 
 describe('ProfilePageHeader', () => {

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -18,7 +18,7 @@ import * as Types from './ProfilePageHeader.types';
  * Subscribes the profile user to TTL tracking when visible in the viewport.
  * This ensures profile data gets refreshed when stale.
  */
-export function ProfilePageHeader({ profile, actions, isOwnProfile = true }: Types.ProfilePageHeaderProps) {
+export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userId }: Types.ProfilePageHeaderProps) {
   const t = useTranslations('profile.actions');
   const tStatus = useTranslations('status');
   const { avatarUrl, emoji = '🌴', name, bio, publicKey, status } = profile;
@@ -36,9 +36,10 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true }: Typ
   } = actions;
 
   // Subscribe to TTL coordinator based on viewport visibility
+  // Use raw userId (without prefix) for proper TTL tracking
   const { ref: ttlRef } = Hooks.useTtlSubscription({
     type: 'user',
-    id: publicKey,
+    id: userId,
   });
 
   const formattedPublicKey = Libs.formatPublicKey({ key: publicKey });

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.types.ts
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.types.ts
@@ -41,6 +41,8 @@ export interface ProfilePageHeaderProps {
   actions: ProfileHeaderActions;
   /** Whether this is the logged-in user's own profile */
   isOwnProfile?: boolean;
+  /** Raw user ID (without pubky prefix) for TTL tracking */
+  userId: string;
 }
 
 /**

--- a/src/components/organisms/ProfilePageLayout/ProfilePageLayout.test.tsx
+++ b/src/components/organisms/ProfilePageLayout/ProfilePageLayout.test.tsx
@@ -133,6 +133,7 @@ const defaultProps: ProfilePageLayoutProps = {
   filterBarActivePage: PROFILE_PAGE_TYPES.NOTIFICATIONS,
   navigateToPage: vi.fn(),
   isLoading: false,
+  userId: 'test123',
 };
 
 describe('ProfilePageLayout', () => {

--- a/src/components/organisms/ProfilePageLayout/ProfilePageLayout.tsx
+++ b/src/components/organisms/ProfilePageLayout/ProfilePageLayout.tsx
@@ -44,6 +44,7 @@ export function ProfilePageLayout({
   navigateToPage,
   isLoading,
   isOwnProfile = true,
+  userId,
 }: ProfilePageLayoutProps) {
   const [isAvatarZoomOpen, setIsAvatarZoomOpen] = useState(false);
 
@@ -77,7 +78,12 @@ export function ProfilePageLayout({
           className="hidden overflow-hidden bg-background pb-12 shadow-sm lg:block"
         >
           {!isLoading && (
-            <Organisms.ProfilePageHeader profile={profile} actions={headerActions} isOwnProfile={isOwnProfile} />
+            <Organisms.ProfilePageHeader
+              profile={profile}
+              actions={headerActions}
+              isOwnProfile={isOwnProfile}
+              userId={userId}
+            />
           )}
         </Atoms.Container>
 

--- a/src/components/organisms/ProfilePageLayout/ProfilePageLayout.types.ts
+++ b/src/components/organisms/ProfilePageLayout/ProfilePageLayout.types.ts
@@ -43,4 +43,6 @@ export interface ProfilePageLayoutProps {
   isLoading: boolean;
   /** Whether this is the logged-in user's own profile */
   isOwnProfile?: boolean;
+  /** Raw user ID (without pubky prefix) for TTL tracking */
+  userId: string;
 }

--- a/src/components/organisms/ProfileProfile/ProfileProfile.tsx
+++ b/src/components/organisms/ProfileProfile/ProfileProfile.tsx
@@ -61,7 +61,9 @@ export function ProfileProfile() {
       overrideDefaults={true}
       className="mt-6 flex min-w-0 flex-col gap-6 overflow-hidden lg:mt-0 lg:hidden"
     >
-      {!isLoading && <ProfilePageHeader profile={profile} actions={mergedActions} isOwnProfile={isOwnProfile} />}
+      {!isLoading && (
+        <ProfilePageHeader profile={profile} actions={mergedActions} isOwnProfile={isOwnProfile} userId={pubky ?? ''} />
+      )}
 
       {/* Tagged as section */}
       <Molecules.ProfilePageTaggedAs

--- a/src/hooks/useUserProfile/useUserProfile.test.tsx
+++ b/src/hooks/useUserProfile/useUserProfile.test.tsx
@@ -290,7 +290,7 @@ describe('useUserProfile', () => {
   });
 
   describe('Controller integration', () => {
-    it('triggers UserController.getOrFetchDetails to fetch from Nexus', () => {
+    it('triggers UserController.getOrFetchDetails to ensure data exists locally', () => {
       const mockUser: Core.NexusUserDetails = {
         id: 'test-user-id' as Core.Pubky,
         name: 'Test',
@@ -305,7 +305,8 @@ describe('useUserProfile', () => {
 
       renderHook(() => useUserProfile('test-user-id'));
 
-      // UserController.getOrFetchDetails should be called in useEffect
+      // UserController.getOrFetchDetails should be called in useEffect to ensure data is cached
+      // Freshness is managed by TTL Coordinator via useTtlSubscription in ProfilePageHeader
       expect(mockMocks.mockGetOrFetchDetails).toHaveBeenCalledWith({ userId: 'test-user-id' });
     });
   });


### PR DESCRIPTION
👀 **Reviewed**

---

## Summary

This PR implements Issue #523.

## Related Issue

Closes #523

## Description

### Describe the bug

When viewing other profile page, their status is missing. It should be next to the Follow/Following button.

### Reproduce

1. Go to someone else's profile page (who has a status set)
2. Observe cannot see their status text under their profile name

### Screenshots / Recording

**Actual**
<img width="806" height="447" alt="Image" src="https://github.com/user-attachments/assets/ced904e0-a327-42bc-958c-29d57f1ea15a" />

**Design** (see 'working')

<img width="689" height="350" alt="Image" src="https://github.com/user-attachments/assets/44dd7173-d256-41b7-9be5-4cfa24b9d348" />

### Web Browser

_No response_

### Pubky App Version

dacd0a6a6aea518ae8202978b8848efa2c3d861a

### Console log output

```shell

```