### PR TITLE
build: update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8967,9 +8967,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.277",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.277.tgz",
-      "integrity": "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw==",
+      "version": "1.5.278",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.278.tgz",
+      "integrity": "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {


### PR DESCRIPTION
It seems the `package-lock.json` somehow became outdated again because I ran `npm install` and there were changed to it.