### PR TITLE
refactor: move css spacing inside mdxeditor component

### DIFF
--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx.snap
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx.snap
@@ -3,6 +3,260 @@
 exports[`InitializedMDXEditor - Snapshots > matches snapshot with approaching max length warning 1`] = `
 <div>
   <div
+    class="gap-4"
+  >
+    <div
+      class="dark-theme cursor-auto"
+      data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
+      data-placeholder="Start writing your masterpiece"
+      data-plugins-count="9"
+      data-testid="mdx-editor"
+    >
+      <div
+        data-testid="toolbar"
+      >
+        <button
+          data-testid="undo-redo"
+        >
+          Undo/Redo
+        </button>
+        <button
+          data-testid="block-type-select"
+        >
+          Block Type
+        </button>
+        <button
+          data-testid="bold-italic-toggles"
+        >
+          Bold/Italic
+        </button>
+        <button
+          data-testid="strikethrough-toggle"
+        >
+          Strikethrough
+        </button>
+        <button
+          data-testid="lists-toggle"
+        >
+          Lists
+        </button>
+        <button
+          data-testid="insert-thematic-break"
+        >
+          Insert Break
+        </button>
+        <button
+          data-testid="code-toggle"
+        >
+          Code
+        </button>
+        <button
+          data-testid="insert-code-block"
+        >
+          Insert Code Block
+        </button>
+        <button
+          data-testid="button-with-tooltip"
+          title="Emoji"
+        >
+          <svg
+            class="size-6"
+            data-testid="smile-icon"
+          >
+            <title>
+              Smile
+            </title>
+          </svg>
+        </button>
+      </div>
+      <div
+        data-testid="editor-content"
+      >
+        Editor Content
+      </div>
+    </div>
+    <div
+      class="cursor-auto flex-row items-center gap-x-2 rounded-md p-2 bg-yellow-500/15 text-yellow-500"
+      data-testid="max-length-warning"
+    >
+      <svg
+        class="size-4 shrink-0"
+        data-testid="alert-triangle-icon"
+      >
+        <title>
+          Alert Triangle
+        </title>
+      </svg>
+      <span
+        class="text-sm"
+        data-override-defaults="true"
+      >
+        You're approaching the maximum character limit.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InitializedMDXEditor - Snapshots > matches snapshot with custom className 1`] = `
+<div
+  class="gap-4"
+>
+  <div
+    class="custom-editor-class"
+    data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
+    data-placeholder="Start writing your masterpiece"
+    data-plugins-count="9"
+    data-testid="mdx-editor"
+  >
+    <div
+      data-testid="toolbar"
+    >
+      <button
+        data-testid="undo-redo"
+      >
+        Undo/Redo
+      </button>
+      <button
+        data-testid="block-type-select"
+      >
+        Block Type
+      </button>
+      <button
+        data-testid="bold-italic-toggles"
+      >
+        Bold/Italic
+      </button>
+      <button
+        data-testid="strikethrough-toggle"
+      >
+        Strikethrough
+      </button>
+      <button
+        data-testid="lists-toggle"
+      >
+        Lists
+      </button>
+      <button
+        data-testid="insert-thematic-break"
+      >
+        Insert Break
+      </button>
+      <button
+        data-testid="code-toggle"
+      >
+        Code
+      </button>
+      <button
+        data-testid="insert-code-block"
+      >
+        Insert Code Block
+      </button>
+      <button
+        data-testid="button-with-tooltip"
+        title="Emoji"
+      >
+        <svg
+          class="size-6"
+          data-testid="smile-icon"
+        >
+          <title>
+            Smile
+          </title>
+        </svg>
+      </button>
+    </div>
+    <div
+      data-testid="editor-content"
+    >
+      Editor Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InitializedMDXEditor - Snapshots > matches snapshot with default props 1`] = `
+<div
+  class="gap-4"
+>
+  <div
+    class="dark-theme cursor-auto"
+    data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
+    data-placeholder="Start writing your masterpiece"
+    data-plugins-count="9"
+    data-testid="mdx-editor"
+  >
+    <div
+      data-testid="toolbar"
+    >
+      <button
+        data-testid="undo-redo"
+      >
+        Undo/Redo
+      </button>
+      <button
+        data-testid="block-type-select"
+      >
+        Block Type
+      </button>
+      <button
+        data-testid="bold-italic-toggles"
+      >
+        Bold/Italic
+      </button>
+      <button
+        data-testid="strikethrough-toggle"
+      >
+        Strikethrough
+      </button>
+      <button
+        data-testid="lists-toggle"
+      >
+        Lists
+      </button>
+      <button
+        data-testid="insert-thematic-break"
+      >
+        Insert Break
+      </button>
+      <button
+        data-testid="code-toggle"
+      >
+        Code
+      </button>
+      <button
+        data-testid="insert-code-block"
+      >
+        Insert Code Block
+      </button>
+      <button
+        data-testid="button-with-tooltip"
+        title="Emoji"
+      >
+        <svg
+          class="size-6"
+          data-testid="smile-icon"
+        >
+          <title>
+            Smile
+          </title>
+        </svg>
+      </button>
+    </div>
+    <div
+      data-testid="editor-content"
+    >
+      Editor Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InitializedMDXEditor - Snapshots > matches snapshot with emoji picker open 1`] = `
+<div
+  class="gap-4"
+>
+  <div
     class="dark-theme cursor-auto"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
@@ -73,316 +327,91 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with approaching ma
     </div>
   </div>
   <div
-    class="cursor-auto flex-row items-center gap-x-2 rounded-md p-2 bg-yellow-500/15 text-yellow-500"
-    data-testid="max-length-warning"
-  >
-    <svg
-      class="size-4 shrink-0"
-      data-testid="alert-triangle-icon"
-    >
-      <title>
-        Alert Triangle
-      </title>
-    </svg>
-    <span
-      class="text-sm"
-      data-override-defaults="true"
-    >
-      You're approaching the maximum character limit.
-    </span>
-  </div>
-</div>
-`;
-
-exports[`InitializedMDXEditor - Snapshots > matches snapshot with custom className 1`] = `
-<div
-  class="custom-editor-class"
-  data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
-  data-placeholder="Start writing your masterpiece"
-  data-plugins-count="9"
-  data-testid="mdx-editor"
->
-  <div
-    data-testid="toolbar"
+    data-testid="emoji-picker-dialog"
   >
     <button
-      data-testid="undo-redo"
+      data-testid="emoji-select-button"
     >
-      Undo/Redo
+      Select Emoji
     </button>
-    <button
-      data-testid="block-type-select"
-    >
-      Block Type
-    </button>
-    <button
-      data-testid="bold-italic-toggles"
-    >
-      Bold/Italic
-    </button>
-    <button
-      data-testid="strikethrough-toggle"
-    >
-      Strikethrough
-    </button>
-    <button
-      data-testid="lists-toggle"
-    >
-      Lists
-    </button>
-    <button
-      data-testid="insert-thematic-break"
-    >
-      Insert Break
-    </button>
-    <button
-      data-testid="code-toggle"
-    >
-      Code
-    </button>
-    <button
-      data-testid="insert-code-block"
-    >
-      Insert Code Block
-    </button>
-    <button
-      data-testid="button-with-tooltip"
-      title="Emoji"
-    >
-      <svg
-        class="size-6"
-        data-testid="smile-icon"
-      >
-        <title>
-          Smile
-        </title>
-      </svg>
-    </button>
-  </div>
-  <div
-    data-testid="editor-content"
-  >
-    Editor Content
-  </div>
-</div>
-`;
-
-exports[`InitializedMDXEditor - Snapshots > matches snapshot with default props 1`] = `
-<div
-  class="dark-theme cursor-auto"
-  data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
-  data-placeholder="Start writing your masterpiece"
-  data-plugins-count="9"
-  data-testid="mdx-editor"
->
-  <div
-    data-testid="toolbar"
-  >
-    <button
-      data-testid="undo-redo"
-    >
-      Undo/Redo
-    </button>
-    <button
-      data-testid="block-type-select"
-    >
-      Block Type
-    </button>
-    <button
-      data-testid="bold-italic-toggles"
-    >
-      Bold/Italic
-    </button>
-    <button
-      data-testid="strikethrough-toggle"
-    >
-      Strikethrough
-    </button>
-    <button
-      data-testid="lists-toggle"
-    >
-      Lists
-    </button>
-    <button
-      data-testid="insert-thematic-break"
-    >
-      Insert Break
-    </button>
-    <button
-      data-testid="code-toggle"
-    >
-      Code
-    </button>
-    <button
-      data-testid="insert-code-block"
-    >
-      Insert Code Block
-    </button>
-    <button
-      data-testid="button-with-tooltip"
-      title="Emoji"
-    >
-      <svg
-        class="size-6"
-        data-testid="smile-icon"
-      >
-        <title>
-          Smile
-        </title>
-      </svg>
-    </button>
-  </div>
-  <div
-    data-testid="editor-content"
-  >
-    Editor Content
-  </div>
-</div>
-`;
-
-exports[`InitializedMDXEditor - Snapshots > matches snapshot with emoji picker open 1`] = `
-<div
-  class="dark-theme cursor-auto"
-  data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
-  data-placeholder="Start writing your masterpiece"
-  data-plugins-count="9"
-  data-testid="mdx-editor"
->
-  <div
-    data-testid="toolbar"
-  >
-    <button
-      data-testid="undo-redo"
-    >
-      Undo/Redo
-    </button>
-    <button
-      data-testid="block-type-select"
-    >
-      Block Type
-    </button>
-    <button
-      data-testid="bold-italic-toggles"
-    >
-      Bold/Italic
-    </button>
-    <button
-      data-testid="strikethrough-toggle"
-    >
-      Strikethrough
-    </button>
-    <button
-      data-testid="lists-toggle"
-    >
-      Lists
-    </button>
-    <button
-      data-testid="insert-thematic-break"
-    >
-      Insert Break
-    </button>
-    <button
-      data-testid="code-toggle"
-    >
-      Code
-    </button>
-    <button
-      data-testid="insert-code-block"
-    >
-      Insert Code Block
-    </button>
-    <button
-      data-testid="button-with-tooltip"
-      title="Emoji"
-    >
-      <svg
-        class="size-6"
-        data-testid="smile-icon"
-      >
-        <title>
-          Smile
-        </title>
-      </svg>
-    </button>
-  </div>
-  <div
-    data-testid="editor-content"
-  >
-    Editor Content
   </div>
 </div>
 `;
 
 exports[`InitializedMDXEditor - Snapshots > matches snapshot with markdown content 1`] = `
 <div
-  class="dark-theme cursor-auto"
-  data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
-  data-placeholder="Start writing your masterpiece"
-  data-plugins-count="9"
-  data-testid="mdx-editor"
-  markdown="# Test Content"
+  class="gap-4"
 >
   <div
-    data-testid="toolbar"
+    class="dark-theme cursor-auto"
+    data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
+    data-placeholder="Start writing your masterpiece"
+    data-plugins-count="9"
+    data-testid="mdx-editor"
+    markdown="# Test Content"
   >
-    <button
-      data-testid="undo-redo"
+    <div
+      data-testid="toolbar"
     >
-      Undo/Redo
-    </button>
-    <button
-      data-testid="block-type-select"
-    >
-      Block Type
-    </button>
-    <button
-      data-testid="bold-italic-toggles"
-    >
-      Bold/Italic
-    </button>
-    <button
-      data-testid="strikethrough-toggle"
-    >
-      Strikethrough
-    </button>
-    <button
-      data-testid="lists-toggle"
-    >
-      Lists
-    </button>
-    <button
-      data-testid="insert-thematic-break"
-    >
-      Insert Break
-    </button>
-    <button
-      data-testid="code-toggle"
-    >
-      Code
-    </button>
-    <button
-      data-testid="insert-code-block"
-    >
-      Insert Code Block
-    </button>
-    <button
-      data-testid="button-with-tooltip"
-      title="Emoji"
-    >
-      <svg
-        class="size-6"
-        data-testid="smile-icon"
+      <button
+        data-testid="undo-redo"
       >
-        <title>
-          Smile
-        </title>
-      </svg>
-    </button>
-  </div>
-  <div
-    data-testid="editor-content"
-  >
-    Editor Content
+        Undo/Redo
+      </button>
+      <button
+        data-testid="block-type-select"
+      >
+        Block Type
+      </button>
+      <button
+        data-testid="bold-italic-toggles"
+      >
+        Bold/Italic
+      </button>
+      <button
+        data-testid="strikethrough-toggle"
+      >
+        Strikethrough
+      </button>
+      <button
+        data-testid="lists-toggle"
+      >
+        Lists
+      </button>
+      <button
+        data-testid="insert-thematic-break"
+      >
+        Insert Break
+      </button>
+      <button
+        data-testid="code-toggle"
+      >
+        Code
+      </button>
+      <button
+        data-testid="insert-code-block"
+      >
+        Insert Code Block
+      </button>
+      <button
+        data-testid="button-with-tooltip"
+        title="Emoji"
+      >
+        <svg
+          class="size-6"
+          data-testid="smile-icon"
+        >
+          <title>
+            Smile
+          </title>
+        </svg>
+      </button>
+    </div>
+    <div
+      data-testid="editor-content"
+    >
+      Editor Content
+    </div>
   </div>
 </div>
 `;
@@ -390,93 +419,97 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with markdown conte
 exports[`InitializedMDXEditor - Snapshots > matches snapshot with reached max length warning 1`] = `
 <div>
   <div
-    class="dark-theme cursor-auto"
-    data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
-    data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
-    data-testid="mdx-editor"
+    class="gap-4"
   >
     <div
-      data-testid="toolbar"
+      class="dark-theme cursor-auto"
+      data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
+      data-placeholder="Start writing your masterpiece"
+      data-plugins-count="9"
+      data-testid="mdx-editor"
     >
-      <button
-        data-testid="undo-redo"
+      <div
+        data-testid="toolbar"
       >
-        Undo/Redo
-      </button>
-      <button
-        data-testid="block-type-select"
-      >
-        Block Type
-      </button>
-      <button
-        data-testid="bold-italic-toggles"
-      >
-        Bold/Italic
-      </button>
-      <button
-        data-testid="strikethrough-toggle"
-      >
-        Strikethrough
-      </button>
-      <button
-        data-testid="lists-toggle"
-      >
-        Lists
-      </button>
-      <button
-        data-testid="insert-thematic-break"
-      >
-        Insert Break
-      </button>
-      <button
-        data-testid="code-toggle"
-      >
-        Code
-      </button>
-      <button
-        data-testid="insert-code-block"
-      >
-        Insert Code Block
-      </button>
-      <button
-        data-testid="button-with-tooltip"
-        title="Emoji"
-      >
-        <svg
-          class="size-6"
-          data-testid="smile-icon"
+        <button
+          data-testid="undo-redo"
         >
-          <title>
-            Smile
-          </title>
-        </svg>
-      </button>
+          Undo/Redo
+        </button>
+        <button
+          data-testid="block-type-select"
+        >
+          Block Type
+        </button>
+        <button
+          data-testid="bold-italic-toggles"
+        >
+          Bold/Italic
+        </button>
+        <button
+          data-testid="strikethrough-toggle"
+        >
+          Strikethrough
+        </button>
+        <button
+          data-testid="lists-toggle"
+        >
+          Lists
+        </button>
+        <button
+          data-testid="insert-thematic-break"
+        >
+          Insert Break
+        </button>
+        <button
+          data-testid="code-toggle"
+        >
+          Code
+        </button>
+        <button
+          data-testid="insert-code-block"
+        >
+          Insert Code Block
+        </button>
+        <button
+          data-testid="button-with-tooltip"
+          title="Emoji"
+        >
+          <svg
+            class="size-6"
+            data-testid="smile-icon"
+          >
+            <title>
+              Smile
+            </title>
+          </svg>
+        </button>
+      </div>
+      <div
+        data-testid="editor-content"
+      >
+        Editor Content
+      </div>
     </div>
     <div
-      data-testid="editor-content"
+      class="cursor-auto flex-row items-center gap-x-2 rounded-md p-2 bg-red-500/15 text-red-500"
+      data-testid="max-length-warning"
     >
-      Editor Content
+      <svg
+        class="size-4 shrink-0"
+        data-testid="alert-triangle-icon"
+      >
+        <title>
+          Alert Triangle
+        </title>
+      </svg>
+      <span
+        class="text-sm"
+        data-override-defaults="true"
+      >
+        You've reached the maximum character limit.
+      </span>
     </div>
-  </div>
-  <div
-    class="cursor-auto flex-row items-center gap-x-2 rounded-md p-2 bg-red-500/15 text-red-500"
-    data-testid="max-length-warning"
-  >
-    <svg
-      class="size-4 shrink-0"
-      data-testid="alert-triangle-icon"
-    >
-      <title>
-        Alert Triangle
-      </title>
-    </svg>
-    <span
-      class="text-sm"
-      data-override-defaults="true"
-    >
-      You've reached the maximum character limit.
-    </span>
   </div>
 </div>
 `;

--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.tsx
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.tsx
@@ -107,7 +107,7 @@ export default function InitializedMDXEditor({
   const [maxLengthWarning, setMaxLengthWarning] = useState<null | 'approaching' | 'reached'>(null);
 
   return (
-    <>
+    <Atoms.Container className="gap-4">
       <MDXEditor
         placeholder="Start writing your masterpiece"
         className="dark-theme cursor-auto"
@@ -192,6 +192,6 @@ export default function InitializedMDXEditor({
           </Atoms.Typography>
         </Atoms.Container>
       )}
-    </>
+    </Atoms.Container>
   );
 }


### PR DESCRIPTION
👀 **Reviewed**

---

## 🛠️ Refactor Markdown Editor Layout Spacing

### Summary

This PR applies defensive styling to the `InitializedMDXEditor` component by internalizing the gap spacing rather than relying on parent components to provide it.

### Changes

- **`InitializedMDXEditor.tsx`**: Replaced the React fragment (`<>...</>`) wrapper with an `Atoms.Container` component that includes `gap-4` class for proper spacing between the editor and the character limit warning message.

### Why

Previously, the component relied on parent components to apply the correct spacing between its internal elements. While this currently works, it's fragile and could lead to inconsistent layouts if the component were reused elsewhere. By moving the `gap-4` spacing directly inside the component, we ensure consistent visual separation between the MDX editor and the max length warning indicator regardless of where the component is used.

### Testing

- 📸 Updated snapshot: `InitializedMDXEditor.test.tsx.snap`

---

_This pull request summary was generated, for full implementation details please reference the file changes._