### PR TITLE
fix(posts): prevent ghost posts when undoing repost or deleting posts

### DIFF
--- a/src/components/organisms/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/TimelineFeed/TimelineFeed.tsx
@@ -150,7 +150,7 @@ function TimelineFeedContent({
 
       // Filter out deleted posts before prepending to prevent ghost posts
       // This handles race conditions where posts were deleted after being added to unread stream
-      const existingPosts = await Core.PostDetailsModel.filterDeleted(actualNewPostIds);
+      const existingPosts = await Core.StreamPostsController.filterDeletedPosts(actualNewPostIds);
       const displayedPostIdsSet = new Set(postIds);
       const postsToAdd = existingPosts.filter((id) => !displayedPostIdsSet.has(id));
 

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -70,6 +70,17 @@ export class PostStreamApplication {
   }
 
   /**
+   * Filter out deleted posts from a list of post IDs.
+   * Posts without details in cache are kept (fail-open semantics).
+   *
+   * @param postIds - Array of post IDs to filter
+   * @returns Array of post IDs that are not deleted
+   */
+  static async filterDeletedPosts(postIds: string[]): Promise<string[]> {
+    return Core.LocalPostService.filterDeletedPosts(postIds);
+  }
+
+  /**
    * Prepares the stream for initial load by performing cleanup operations.
    *
    * This method should be called before fetching the initial stream slice to ensure
@@ -192,7 +203,7 @@ export class PostStreamApplication {
       filter: async (posts) => {
         // First filter muted users (sync), then filter deleted posts (async)
         const afterMuteFilter = MuteFilter.filterPosts(posts, mutedUserIds);
-        return Core.PostDetailsModel.filterDeleted(afterMuteFilter);
+        return Core.LocalPostService.filterDeletedPosts(afterMuteFilter);
       },
       fetch: async (cursor) => {
         // Continue reading from cache using lastReturnedPostId to track position

--- a/src/core/controllers/stream/posts/posts.ts
+++ b/src/core/controllers/stream/posts/posts.ts
@@ -150,4 +150,15 @@ export class StreamPostsController {
   static async prepareStreamForInitialLoad(params: Core.TStreamIdParams): Promise<void> {
     await Core.PostStreamApplication.prepareStreamForInitialLoad(params);
   }
+
+  /**
+   * Filter out deleted posts from a list of post IDs.
+   * Posts without details in cache are kept (fail-open semantics).
+   *
+   * @param postIds - Array of post IDs to filter
+   * @returns Array of post IDs that are not deleted
+   */
+  static async filterDeletedPosts(postIds: string[]): Promise<string[]> {
+    return Core.PostStreamApplication.filterDeletedPosts(postIds);
+  }
 }

--- a/src/core/services/local/post/post.ts
+++ b/src/core/services/local/post/post.ts
@@ -15,6 +15,17 @@ export class LocalPostService {
   }
 
   /**
+   * Filter out deleted posts from a list of post IDs.
+   * Posts without details in cache are kept (fail-open semantics).
+   *
+   * @param postIds - Array of post IDs to filter
+   * @returns Array of post IDs that are not deleted
+   */
+  static async filterDeletedPosts(postIds: string[]): Promise<string[]> {
+    return Core.PostDetailsModel.filterDeleted(postIds);
+  }
+
+  /**
    * Reads post counts for a specific post
    *
    * @param postId - Composite post ID (author:postId)


### PR DESCRIPTION
## Summary

Fixes #680 - Ghost posts appearing in timeline when clicking "load new posts" after undoing a repost or deleting a post.

## Problem

When a post is deleted (e.g., user undoes a repost), there's a race condition where:
1. The post gets added to the unread stream via background polling
2. The post gets deleted
3. User clicks "load new posts" → deleted post appears as a ghost post

## Solution

Two-layer fix to handle the race condition:

1. **Preventive**: When deleting a post, also remove it from all unread stream tables (both "all" streams and kind-specific streams like `timeline:all:short`)

2. **Defensive**: Before prepending posts from the unread stream to the timeline, filter out any posts that no longer exist in the database

## Changes

- `TimelineFeed.tsx`: Added `filterDeleted` check before prepending new posts
- `post.ts`: Added removal from `UnreadPostStreamModel` when posts are deleted

## Test Plan

- [ ] Create a repost, wait for it to appear in unread stream indicator
- [ ] Undo the repost
- [ ] Click "load new posts" → verify no ghost post appears
- [ ] Delete a post while unread indicator is showing → verify no ghost post