### PR TITLE
fix(ui): truncate long usernames in dialog inputs

### DIFF
--- a/src/components/organisms/DialogFeedback/DialogFeedbackContent/DialogFeedbackContent.tsx
+++ b/src/components/organisms/DialogFeedback/DialogFeedbackContent/DialogFeedbackContent.tsx
@@ -28,7 +28,7 @@ export function DialogFeedbackContent({
       </Atoms.DialogHeader>
       <Atoms.Container className="gap-3">
         <Atoms.Container overrideDefaults className="rounded-md border border-dashed border-input p-6">
-          <Atoms.Container className="gap-4" overrideDefaults>
+          <Atoms.Container className="gap-4 contain-inline-size" overrideDefaults>
             <Organisms.PostHeader
               postId={currentUserPubky}
               isReplyInput={true}

--- a/src/components/organisms/PostInput/PostInput.test.tsx.snap
+++ b/src/components/organisms/PostInput/PostInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PostInput - Snapshots > matches snapshot for article mode 1`] = `
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <input
@@ -88,7 +88,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant 1`] = `
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -168,7 +168,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant with article 
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <input
@@ -257,7 +257,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when dragging
     </p>
   </div>
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -341,7 +341,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when submitti
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -426,7 +426,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with attachme
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -515,7 +515,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with content 
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -600,7 +600,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with custom p
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -684,7 +684,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant without conte
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -768,7 +768,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply variant without cont
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -856,7 +856,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply with thread connecto
     data-variant="dialog-reply"
   />
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div
@@ -940,7 +940,7 @@ exports[`PostInput - Snapshots > matches snapshot for repost variant without con
   data-testid="container"
 >
   <div
-    class="gap-4"
+    class="gap-4 contain-inline-size"
     data-testid="container"
   >
     <div

--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -154,7 +154,7 @@ export function PostInput({
       )}
 
       {showThreadConnector && <Atoms.PostThreadConnector variant={POST_THREAD_CONNECTOR_VARIANTS.DIALOG_REPLY} />}
-      <Atoms.Container className="gap-4">
+      <Atoms.Container className="gap-4 contain-inline-size">
         {isArticle && (
           <Atoms.Input
             placeholder={t('articleTitle')}


### PR DESCRIPTION
Use CSS containment (contain: inline-size) to prevent long usernames from breaking dialog layouts. This tells the browser that the container should not affect the size of its ancestors, allowing text truncation to work correctly in flexbox layouts.

Resolves #1135

https://github.com/user-attachments/assets/3ad552e2-23a2-4974-8189-bb926b29ea0d

