### PR TITLE
docs: allow blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 💬 Discussions
     url: https://github.com/pubky/franky/discussions


### PR DESCRIPTION
## 🔧 Enable Blank Issues in GitHub Issue Templates

### Summary

This PR enables blank issues in the GitHub issue template configuration, allowing users to create issues without using a predefined template.

### Changes

- **`.github/ISSUE_TEMPLATE/config.yml`**: Changed `blank_issues_enabled` from `false` to `true`

### Rationale

Enabling blank issues provides more flexibility for contributors who may need to report issues that don't fit neatly into the existing templates. This lowers the barrier for community contributions while still keeping the structured templates available as options.

---

### Testing

No test files were modified in this change (configuration-only update).

---

_This pull request summary was generated, for full implementation details please reference the file changes._