### PR TITLE
fix: CI for PR #1106 after #1143 merge

### DIFF
--- a/src/components/molecules/PostTagPopoverWrapper/PostTagPopoverWrapper.tsx
+++ b/src/components/molecules/PostTagPopoverWrapper/PostTagPopoverWrapper.tsx
@@ -71,7 +71,12 @@ export function PostTagPopoverWrapper({ taggers, taggersCount, children }: PostT
                 className="w-auto p-0"
                 onOpenAutoFocus={(e) => e.preventDefault()}
               >
-                {showAllTaggers && <Molecules.WhoTaggedExpandedList taggers={taggers} />}
+                {showAllTaggers && (
+                  <Molecules.WhoTaggedExpandedList
+                    taggerIds={taggers.map((tagger) => tagger.id)}
+                    fallbackTaggers={taggers}
+                  />
+                )}
               </Atoms.PopoverContent>
             </Atoms.Popover>
           )}


### PR DESCRIPTION
## Summary
This hotfix updates `PostTagPopoverWrapper` to use the new `WhoTaggedExpandedList` prop contract introduced after recent merges.

## Problem
PR #1106 started failing `Check NextJS Build` with a TypeScript error:
- `WhoTaggedExpandedList` no longer accepts `taggers`
- it now requires `taggerIds` (and can optionally receive `fallbackTaggers`)

## Root cause
`src/components/molecules/PostTagPopoverWrapper/PostTagPopoverWrapper.tsx` still passed `taggers={taggers}` to `WhoTaggedExpandedList`, which became incompatible after changes merged into the branch.

## Fix
- Replaced the old call with:
  - `taggerIds={taggers.map((tagger) => tagger.id)}`
  - `fallbackTaggers={taggers}`

This keeps the existing UI behavior while matching the updated API expected by `WhoTaggedExpandedList`.

## Validation
Ran locally on this branch:
- `npm run format:check`
- `npm run lint`
- `npm run test`
- `npm run build`

All passed.
