### PR TITLE
feat(ui): add follow button variant prop and follow/unfollow hover states (#1259)

### DIFF
--- a/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx
+++ b/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx
@@ -73,8 +73,8 @@ vi.mock('@/molecules', () => ({
 
 // Mock Organisms
 vi.mock('@/organisms', () => ({
-  UserListItem: ({ user }: { user: { id: string } }) => (
-    <div data-testid="user-list-item" data-user-id={user.id}>
+  UserListItem: ({ user, followButtonVariant }: { user: { id: string }; followButtonVariant?: string }) => (
+    <div data-testid="user-list-item" data-user-id={user.id} data-follow-button-variant={followButtonVariant}>
       User item
     </div>
   ),
@@ -165,6 +165,16 @@ describe('ProfileFollowers', () => {
     expect(userItems).toHaveLength(2);
     expect(userItems[0]).toHaveAttribute('data-user-id', 'user-1');
     expect(userItems[1]).toHaveAttribute('data-user-id', 'user-2');
+  });
+
+  it('passes followButtonVariant="iconWithText" to UserListItem', () => {
+    vi.mocked(Hooks.useProfileConnections).mockReturnValue(mockConnectionsResult);
+
+    render(<ProfileFollowers />);
+    const userItems = screen.getAllByTestId('user-list-item');
+    userItems.forEach((item) => {
+      expect(item).toHaveAttribute('data-follow-button-variant', 'iconWithText');
+    });
   });
 });
 

--- a/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx.snap
+++ b/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx.snap
@@ -87,12 +87,14 @@ exports[`ProfileFollowers - Snapshots > matches snapshot with connections 1`] = 
       data-testid="container"
     >
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-1"
       >
         User item
       </div>
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-2"
       >

--- a/src/components/organisms/ProfileFollowers/ProfileFollowers.tsx
+++ b/src/components/organisms/ProfileFollowers/ProfileFollowers.tsx
@@ -79,6 +79,7 @@ export function ProfileFollowers() {
             key={connection.id}
             user={connection}
             variant="full"
+            followButtonVariant="iconWithText"
             isLoading={isUserLoading(connection.id)}
             isStatusLoading={isLoading}
             isCurrentUser={currentUserPubky === connection.id}

--- a/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx
+++ b/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx
@@ -73,8 +73,8 @@ vi.mock('@/molecules', () => ({
 
 // Mock Organisms
 vi.mock('@/organisms', () => ({
-  UserListItem: ({ user }: { user: { id: string } }) => (
-    <div data-testid="user-list-item" data-user-id={user.id}>
+  UserListItem: ({ user, followButtonVariant }: { user: { id: string }; followButtonVariant?: string }) => (
+    <div data-testid="user-list-item" data-user-id={user.id} data-follow-button-variant={followButtonVariant}>
       User item
     </div>
   ),
@@ -165,6 +165,16 @@ describe('ProfileFollowing', () => {
     expect(userItems).toHaveLength(2);
     expect(userItems[0]).toHaveAttribute('data-user-id', 'user-1');
     expect(userItems[1]).toHaveAttribute('data-user-id', 'user-2');
+  });
+
+  it('passes followButtonVariant="iconWithText" to UserListItem', () => {
+    vi.mocked(Hooks.useProfileConnections).mockReturnValue(mockConnectionsResult);
+
+    render(<ProfileFollowing />);
+    const userItems = screen.getAllByTestId('user-list-item');
+    userItems.forEach((item) => {
+      expect(item).toHaveAttribute('data-follow-button-variant', 'iconWithText');
+    });
   });
 });
 

--- a/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx.snap
+++ b/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx.snap
@@ -87,12 +87,14 @@ exports[`ProfileFollowing - Snapshots > matches snapshot with connections 1`] = 
       data-testid="container"
     >
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-1"
       >
         User item
       </div>
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-2"
       >

--- a/src/components/organisms/ProfileFollowing/ProfileFollowing.tsx
+++ b/src/components/organisms/ProfileFollowing/ProfileFollowing.tsx
@@ -79,6 +79,7 @@ export function ProfileFollowing() {
             key={connection.id}
             user={connection}
             variant="full"
+            followButtonVariant="iconWithText"
             isLoading={isUserLoading(connection.id)}
             isStatusLoading={isLoading}
             isCurrentUser={currentUserPubky === connection.id}

--- a/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx
+++ b/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx
@@ -73,8 +73,8 @@ vi.mock('@/molecules', () => ({
 
 // Mock Organisms
 vi.mock('@/organisms', () => ({
-  UserListItem: ({ user }: { user: { id: string } }) => (
-    <div data-testid="user-list-item" data-user-id={user.id}>
+  UserListItem: ({ user, followButtonVariant }: { user: { id: string }; followButtonVariant?: string }) => (
+    <div data-testid="user-list-item" data-user-id={user.id} data-follow-button-variant={followButtonVariant}>
       User item
     </div>
   ),
@@ -165,6 +165,16 @@ describe('ProfileFriends', () => {
     expect(userItems).toHaveLength(2);
     expect(userItems[0]).toHaveAttribute('data-user-id', 'user-1');
     expect(userItems[1]).toHaveAttribute('data-user-id', 'user-2');
+  });
+
+  it('passes followButtonVariant="iconWithText" to UserListItem', () => {
+    vi.mocked(Hooks.useProfileConnections).mockReturnValue(mockConnectionsResult);
+
+    render(<ProfileFriends />);
+    const userItems = screen.getAllByTestId('user-list-item');
+    userItems.forEach((item) => {
+      expect(item).toHaveAttribute('data-follow-button-variant', 'iconWithText');
+    });
   });
 });
 

--- a/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx.snap
+++ b/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx.snap
@@ -87,12 +87,14 @@ exports[`ProfileFriends - Snapshots > matches snapshot with connections 1`] = `
       data-testid="container"
     >
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-1"
       >
         User item
       </div>
       <div
+        data-follow-button-variant="iconWithText"
         data-testid="user-list-item"
         data-user-id="user-2"
       >

--- a/src/components/organisms/ProfileFriends/ProfileFriends.tsx
+++ b/src/components/organisms/ProfileFriends/ProfileFriends.tsx
@@ -81,6 +81,7 @@ export function ProfileFriends() {
             key={connection.id}
             user={connection}
             variant="full"
+            followButtonVariant="iconWithText"
             isLoading={isUserLoading(connection.id)}
             isStatusLoading={isLoading}
             isCurrentUser={currentUserPubky === connection.id}

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx
@@ -258,6 +258,28 @@ describe('ProfilePageHeader - Other User Profile', () => {
     expect(screen.getByText('Following')).toBeInTheDocument();
   });
 
+  it('renders Unfollow text for hover state when following', () => {
+    const props = {
+      ...mockOtherUserProps,
+      actions: { ...mockOtherUserProps.actions, isFollowing: true },
+    };
+    render(<ProfilePageHeader {...props} />);
+
+    // Both "Following" and "Unfollow" are in the DOM (CSS group-hover swaps visibility)
+    const followingText = screen.getByText('Following');
+    const unfollowText = screen.getByText('Unfollow');
+    expect(followingText).toBeInTheDocument();
+    expect(unfollowText).toBeInTheDocument();
+
+    // Verify the button has "group" class to enable group-hover for children
+    const button = followingText.closest('button');
+    expect(button).toHaveClass('group');
+
+    // Verify CSS classes that swap visibility on hover
+    expect(followingText.closest('span')).toHaveClass('group-hover:hidden');
+    expect(unfollowText.closest('span')).toHaveClass('group-hover:flex');
+  });
+
   it('hides Edit, Sign out buttons when viewing other user', () => {
     render(<ProfilePageHeader {...mockOtherUserProps} />);
 

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -145,6 +145,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
                   data-cy="profile-follow-toggle-btn"
                   variant="secondary"
                   size="sm"
+                  className="group w-[110px] justify-center"
                   onClick={onFollowToggle}
                   disabled={isFollowLoading}
                 >
@@ -153,19 +154,21 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
                       <Icons.Loader2 className="size-4 animate-spin" />
                       {isFollowing ? t('unfollowing') : t('followingProgress')}
                     </>
+                  ) : isFollowing ? (
+                    <>
+                      <span className="flex items-center gap-1.5 group-hover:hidden">
+                        <Icons.Check className="size-4" />
+                        {t('followingButton')}
+                      </span>
+                      <span className="hidden items-center gap-1.5 group-hover:flex">
+                        <Icons.UserMinus className="size-4" />
+                        {t('unfollow')}
+                      </span>
+                    </>
                   ) : (
                     <>
-                      {isFollowing ? (
-                        <>
-                          <Icons.Check className="size-4" />
-                          {t('followingButton')}
-                        </>
-                      ) : (
-                        <>
-                          <Icons.UserPlus className="size-4" />
-                          {t('follow')}
-                        </>
-                      )}
+                      <Icons.UserPlus className="size-4" />
+                      {t('follow')}
                     </>
                   )}
                 </Atoms.Button>

--- a/src/components/organisms/UserListItem/UserListItem.test.tsx
+++ b/src/components/organisms/UserListItem/UserListItem.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UserListItem } from './UserListItem';
+import type { UserListItemData } from './UserListItem.types';
+
+// Mock Hooks
+vi.mock('@/hooks', () => ({
+  useRequireAuth: () => ({ requireAuth: (fn: () => void) => fn() }),
+  useTtlSubscription: () => ({ ref: () => {} }),
+}));
+
+// Mock Atoms - lightweight pass-through components
+vi.mock('@/atoms', () => ({
+  Button: ({
+    children,
+    variant,
+    size,
+    overrideDefaults: _overrideDefaults,
+    ...rest
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button data-size={size} data-variant={variant} {...rest}>
+      {children}
+    </button>
+  ),
+  Container: ({
+    children,
+    overrideDefaults: _overrideDefaults,
+    ...rest
+  }: React.PropsWithChildren<Record<string, unknown>>) => <div {...rest}>{children}</div>,
+  Typography: ({
+    children,
+    as: Tag = 'span',
+    overrideDefaults: _overrideDefaults,
+    size: _size,
+    ...rest
+  }: React.PropsWithChildren<{ as?: React.ElementType } & Record<string, unknown>>) => {
+    const Component = Tag as React.ElementType;
+    return <Component {...rest}>{children}</Component>;
+  },
+  Link: ({
+    children,
+    overrideDefaults: _overrideDefaults,
+    ...rest
+  }: React.PropsWithChildren<Record<string, unknown>>) => <a {...rest}>{children}</a>,
+}));
+
+// Mock Organisms
+vi.mock('@/organisms', () => ({
+  AvatarWithFallback: () => <div data-testid="avatar" />,
+  ClickableTagsList: () => <div data-testid="tags-list" />,
+}));
+
+// Mock Libs
+vi.mock('@/libs', () => ({
+  formatPublicKey: ({ key }: { key: string }) => `pk:${key.slice(0, 8)}`,
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+  Check: (props: Record<string, unknown>) => <svg data-testid="check-icon" {...props} />,
+  UserMinus: (props: Record<string, unknown>) => <svg data-testid="user-minus-icon" {...props} />,
+  UserPlus: (props: Record<string, unknown>) => <svg data-testid="user-plus-icon" {...props} />,
+  UserRoundPlus: (props: Record<string, unknown>) => <svg data-testid="user-round-plus-icon" {...props} />,
+  CircleUserRound: (props: Record<string, unknown>) => <svg data-testid="circle-user-round" {...props} />,
+}));
+
+// Mock Core
+vi.mock('@/core', () => ({
+  TagKind: { USER: 'user' },
+}));
+
+// Mock Config
+vi.mock('@/config', () => ({
+  USER_LIST_TAG_MAX_LENGTH: 8,
+  USER_LIST_TAGS_MAX_TOTAL_CHARS: 20,
+  USER_LIST_TAGS_MAX_COUNT: 3,
+}));
+
+const mockUser: UserListItemData = {
+  id: 'test-user-pubky-123456',
+  name: 'Test User',
+  avatarUrl: 'https://example.com/avatar.jpg',
+  tags: ['tag1'],
+  stats: { tags: 5, posts: 10 },
+  isFollowing: false,
+};
+
+describe('UserListItem - followButtonVariant', () => {
+  it('defaults to icon variant for compact layout', () => {
+    render(<UserListItem user={mockUser} variant="compact" onFollowClick={vi.fn()} />);
+
+    // Icon variant: aria-label includes user name, button has size="icon"
+    const followButton = screen.getByRole('button', { name: /Follow Test User/i });
+    expect(followButton).toHaveAttribute('data-size', 'icon');
+    // No visible "Follow" text
+    expect(screen.queryByText('Follow')).not.toBeInTheDocument();
+  });
+
+  it('defaults to icon variant for full layout', () => {
+    render(<UserListItem user={mockUser} variant="full" onFollowClick={vi.fn()} />);
+
+    // Full variant renders desktop + mobile follow buttons, both should be icon
+    const followButtons = screen.getAllByRole('button', { name: /Follow Test User/i });
+    expect(followButtons.length).toBeGreaterThan(0);
+    followButtons.forEach((btn) => {
+      expect(btn).toHaveAttribute('data-size', 'icon');
+    });
+    expect(screen.queryByText('Follow')).not.toBeInTheDocument();
+  });
+
+  it('shows icon and text when followButtonVariant="iconWithText"', () => {
+    render(
+      <UserListItem user={mockUser} variant="compact" followButtonVariant="iconWithText" onFollowClick={vi.fn()} />,
+    );
+
+    // iconWithText variant shows both icon and visible "Follow" text
+    expect(screen.getByTestId('user-round-plus-icon')).toBeInTheDocument();
+    expect(screen.getAllByText('Follow').length).toBeGreaterThan(0);
+  });
+
+  it('shows check icon and "Following" text when iconWithText and isFollowing', () => {
+    render(
+      <UserListItem
+        user={{ ...mockUser, isFollowing: true }}
+        variant="compact"
+        followButtonVariant="iconWithText"
+        onFollowClick={vi.fn()}
+      />,
+    );
+
+    // iconWithText + isFollowing shows Check icon and "Following" text
+    expect(screen.getByTestId('check-icon')).toBeInTheDocument();
+    const followingText = screen.getByText('Following');
+    expect(followingText).toBeInTheDocument();
+    // Hover state also renders "Unfollow" text and UserMinus icon
+    expect(screen.getByTestId('user-minus-icon')).toBeInTheDocument();
+    const unfollowText = screen.getByText('Unfollow');
+    expect(unfollowText).toBeInTheDocument();
+
+    // Verify the button has "group" class to enable group-hover for children
+    const button = followingText.closest('button');
+    expect(button).toHaveClass('group');
+
+    // Verify CSS classes that swap visibility on hover
+    const followingContainer = followingText.closest('div');
+    expect(followingContainer).toHaveClass('group-hover:hidden');
+    const unfollowContainer = unfollowText.closest('div');
+    expect(unfollowContainer).toHaveClass('group-hover:flex');
+  });
+
+  it('defaults to icon variant for MeButton when isCurrentUser', () => {
+    render(<UserListItem user={mockUser} variant="compact" isCurrentUser />);
+
+    // MeButton icon variant: aria-label "This is you", size="icon", no "Me" text
+    const meButton = screen.getByRole('button', { name: /This is you/i });
+    expect(meButton).toHaveAttribute('data-size', 'icon');
+    expect(screen.queryByText('Me')).not.toBeInTheDocument();
+  });
+
+  it('shows Me text when followButtonVariant="iconWithText" and isCurrentUser', () => {
+    render(<UserListItem user={mockUser} variant="compact" isCurrentUser followButtonVariant="iconWithText" />);
+
+    expect(screen.getByText('Me')).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/UserListItem/UserListItem.tsx
+++ b/src/components/organisms/UserListItem/UserListItem.tsx
@@ -35,13 +35,16 @@ function FollowButton({ isFollowing, isLoading, isStatusLoading, displayName, va
         size="icon"
         onClick={onClick}
         disabled={showLoading}
-        className="size-8 shrink-0 rounded-full"
+        className="group size-8 shrink-0 rounded-full"
         aria-label={isFollowing ? `${t('unfollow')} ${displayName}` : `${t('follow')} ${displayName}`}
       >
         {showLoading ? (
           <Libs.Loader2 className="size-5 animate-spin" />
         ) : isFollowing ? (
-          <Libs.Check className="size-5" />
+          <>
+            <Libs.Check className="size-5 group-hover:hidden" />
+            <Libs.UserMinus className="hidden size-5 group-hover:block" />
+          </>
         ) : (
           <Libs.UserPlus className="size-5" />
         )}
@@ -49,7 +52,7 @@ function FollowButton({ isFollowing, isLoading, isStatusLoading, displayName, va
     );
   }
 
-  // Text variant with hover states
+  // iconWithText variant with hover states
   return (
     <Atoms.Button
       data-cy="profile-follower-item-follow-toggle-btn"
@@ -93,7 +96,7 @@ function FollowButton({ isFollowing, isLoading, isStatusLoading, displayName, va
  * MeButton
  * Disabled button shown when viewing own profile
  */
-function MeButton({ variant = 'text', className }: { variant?: 'text' | 'icon'; className?: string }) {
+function MeButton({ variant = 'iconWithText', className }: { variant?: 'iconWithText' | 'icon'; className?: string }) {
   const t = useTranslations('userList');
   const tProfile = useTranslations('profile.actions');
 
@@ -214,6 +217,7 @@ function CompactVariant({
   isStatusLoading,
   isCurrentUser,
   showStats,
+  followButtonVariant,
   className,
   dataTestId,
   onUserClick,
@@ -258,14 +262,14 @@ function CompactVariant({
 
       {/* Follow button or Me button */}
       {isCurrentUser ? (
-        <MeButton variant="icon" />
+        <MeButton variant={followButtonVariant} />
       ) : (
         <FollowButton
           isFollowing={isFollowing}
           isLoading={isLoading}
           isStatusLoading={isStatusLoading}
           displayName={displayName}
-          variant="icon"
+          variant={followButtonVariant}
           onClick={onFollowClick}
         />
       )}
@@ -287,6 +291,7 @@ function FullVariant({
   isLoading,
   isStatusLoading,
   isCurrentUser,
+  followButtonVariant,
   className,
   dataTestId,
   onFollowClick,
@@ -321,7 +326,7 @@ function FullVariant({
 
         {/* Desktop: Follow Button */}
         {isCurrentUser ? (
-          <MeButton className="hidden lg:flex" />
+          <MeButton variant={followButtonVariant} className="hidden lg:flex" />
         ) : (
           <Atoms.Container overrideDefaults className="hidden lg:flex">
             <FollowButton
@@ -329,7 +334,7 @@ function FullVariant({
               isLoading={isLoading}
               isStatusLoading={isStatusLoading}
               displayName={displayName}
-              variant="text"
+              variant={followButtonVariant}
               onClick={onFollowClick}
             />
           </Atoms.Container>
@@ -340,14 +345,14 @@ function FullVariant({
       <Atoms.Container overrideDefaults className="flex flex-wrap items-center justify-between gap-3 lg:hidden">
         <TagsList userId={user.id} className="flex-1" />
         {isCurrentUser ? (
-          <MeButton />
+          <MeButton variant={followButtonVariant} />
         ) : (
           <FollowButton
             isFollowing={isFollowing}
             isLoading={isLoading}
             isStatusLoading={isStatusLoading}
             displayName={displayName}
-            variant="text"
+            variant={followButtonVariant}
             onClick={onFollowClick}
           />
         )}
@@ -380,6 +385,7 @@ export function UserListItem({
   isStatusLoading = false,
   isCurrentUser = false,
   showStats = false,
+  followButtonVariant: followButtonVariantProp,
   onUserClick,
   onFollowClick,
   className,
@@ -428,6 +434,7 @@ export function UserListItem({
     className,
     dataTestId,
     onUserClick: handleUserClick,
+    followButtonVariant: followButtonVariantProp ?? 'icon',
     onFollowClick: handleFollowClick,
     ttlRef,
   };

--- a/src/components/organisms/UserListItem/UserListItem.types.ts
+++ b/src/components/organisms/UserListItem/UserListItem.types.ts
@@ -44,6 +44,8 @@ export interface UserListItemProps {
   isCurrentUser?: boolean;
   /** Show stats with icons in compact variant (for ActiveUsers) */
   showStats?: boolean;
+  /** Override the follow button style (defaults to 'icon') */
+  followButtonVariant?: 'icon' | 'iconWithText';
   /** Callback when user area is clicked */
   onUserClick?: (id: Pubky) => void;
   /** Callback when follow button is clicked */
@@ -63,7 +65,7 @@ export interface FollowButtonProps {
   isLoading: boolean;
   isStatusLoading: boolean;
   displayName: string;
-  variant: 'icon' | 'text';
+  variant: 'icon' | 'iconWithText';
   onClick: (e: React.MouseEvent) => void;
 }
 
@@ -89,6 +91,7 @@ export interface VariantProps {
   isStatusLoading: boolean;
   isCurrentUser: boolean;
   showStats: boolean;
+  followButtonVariant: 'icon' | 'iconWithText';
   className?: string;
   dataTestId?: string;
   onUserClick: () => void;

--- a/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx
+++ b/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx
@@ -75,8 +75,8 @@ vi.mock('@/libs', () => ({
 
 // Mock Organisms
 vi.mock('@/organisms', () => ({
-  UserListItem: ({ user }: { user: { id: string } }) => (
-    <div data-testid="user-list-item" data-user-id={user.id}>
+  UserListItem: ({ user, followButtonVariant = 'icon' }: { user: { id: string }; followButtonVariant?: string }) => (
+    <div data-testid="user-list-item" data-user-id={user.id} data-follow-button-variant={followButtonVariant}>
       User item
     </div>
   ),
@@ -159,6 +159,17 @@ describe('WhoToFollowPageMain', () => {
     expect(userItems).toHaveLength(2);
     expect(userItems[0]).toHaveAttribute('data-user-id', 'user-1');
     expect(userItems[1]).toHaveAttribute('data-user-id', 'user-2');
+  });
+
+  it('uses default icon followButtonVariant for UserListItem', () => {
+    vi.mocked(Hooks.useUserStream).mockReturnValue(mockUsersResult);
+
+    render(<WhoToFollowPageMain />);
+    const userItems = screen.getAllByTestId('user-list-item');
+    userItems.forEach((item) => {
+      // should default to icon only without text
+      expect(item).toHaveAttribute('data-follow-button-variant', 'icon');
+    });
   });
 
   it('calls useUserStream with correct params', () => {

--- a/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx.snap
+++ b/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx.snap
@@ -207,12 +207,14 @@ exports[`WhoToFollowPageMain - Snapshots > matches snapshot with users 1`] = `
       data-testid="container"
     >
       <div
+        data-follow-button-variant="icon"
         data-testid="user-list-item"
         data-user-id="user-1"
       >
         User item
       </div>
       <div
+        data-follow-button-variant="icon"
         data-testid="user-list-item"
         data-user-id="user-2"
       >


### PR DESCRIPTION
Fix #1259 
  - Rule: Display only icon should be the default and the user's profile page is exception (should display 'following' text by default) 
  - UserListItem: New followButtonVariant prop ('icon' | 'iconWithText'), defaulting to 'icon'. Renamed old 'text' variant to 'iconWithText'.
  - Follow/Unfollow hover states: Both icon and iconWithText follow buttons now swap to "Unfollow" / UserMinus icon on hover via Tailwind group-hover.
  - ProfilePageHeader: Same hover state treatment on the follow toggle button with fixed width.
  - ProfileFollowers/Following/Friends: Pass followButtonVariant="iconWithText" to UserListItem.
  - WhoToFollowPage: Uses the default 'icon' variant.
  - Tests: New test file for UserListItem and updated tests across all affected components.
  
  Screenshots
<img width="220" height="251" alt="Screenshot 2026-02-24 at 06 08 54" src="https://github.com/user-attachments/assets/b7397234-9e9e-4be1-9f81-5d86f458bdf1" />
<img width="226" height="260" alt="Screenshot 2026-02-24 at 06 09 00" src="https://github.com/user-attachments/assets/473c963e-0c7a-48fd-ba42-ec9c2916ae4e" />
<img width="769" height="238" alt="Screenshot 2026-02-24 at 06 09 11" src="https://github.com/user-attachments/assets/83333248-1948-4419-b73a-dc4e5e6667f0" />
<img width="558" height="241" alt="Screenshot 2026-02-24 at 06 09 19" src="https://github.com/user-attachments/assets/9f170709-71e3-49db-aa75-398df9a2dd0d" />
<img width="557" height="222" alt="Screenshot 2026-02-24 at 06 09 27" src="https://github.com/user-attachments/assets/aabf05b5-aeb0-4ec5-94b0-da9e4ae5b904" />
<img width="355" height="278" alt="Screenshot 2026-02-24 at 06 09 36" src="https://github.com/user-attachments/assets/26c9ce54-e16b-4191-94a2-62b0fbb6e9e8" />
<img width="315" height="252" alt="Screenshot 2026-02-24 at 06 09 43" src="https://github.com/user-attachments/assets/4f26fd6b-705d-4330-9396-aaa6ff932d83" />
