### PR TITLE
fix: remove serwist defaultCache to prevent other origin services such as pkar, homeserver and http-relay from being cached by service worker

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,6 +1,5 @@
 /// <reference lib="webworker" />
 
-import { defaultCache } from '@serwist/next/worker';
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
 import { Serwist, NetworkFirst, ExpirationPlugin } from 'serwist';
 
@@ -94,8 +93,7 @@ const serwist = new Serwist({
         ],
       }),
     },
-    // Use default caching strategies for everything else
-    ...defaultCache,
+    // Do not use `defaultCache` to prevent other origin services such as pkarr, homeserver and httprelay from being cached
   ],
   fallbacks: {
     entries: [


### PR DESCRIPTION
Hoping this will fix https://github.com/pubky/pubky-app/issues/1136 but hard to reproduce so still uncertain.

The theory is that the promises made by via the service worker for each of the requests made to each of the two pkarr relays hit the Serwit cache and concurrently succeed but also cancel each other resulting in total failure. The full report is internally: https://synonymworkspace.slack.com/archives/C031F2DC1JM/p1771924740369439?thread_ts=1771869915.915639&cid=C031F2DC1JM