### PR TITLE
fix: auth error toast on sign-in page load

### DIFF
--- a/src/core/services/homeserver/error.utils.ts
+++ b/src/core/services/homeserver/error.utils.ts
@@ -25,6 +25,7 @@ const PUBKY_ERROR_NAMES = {
 } as const;
 
 const RETRYABLE_STATUS_CODES = [
+  HttpStatusCode.NOT_FOUND,
   HttpStatusCode.REQUEST_TIMEOUT,
   HttpStatusCode.TOO_MANY_REQUESTS,
   HttpStatusCode.INTERNAL_SERVER_ERROR,

--- a/src/core/services/homeserver/homeserver.test.ts
+++ b/src/core/services/homeserver/homeserver.test.ts
@@ -435,6 +435,34 @@ describe('HomeserverService', () => {
         }
       });
 
+      it('should retry polling on 404 Not Found (relay may not have registered flow yet)', async () => {
+        vi.useFakeTimers();
+        try {
+          const session = createMockSession();
+          const tryPollOnce = vi
+            .fn()
+            .mockRejectedValueOnce({ name: 'RequestError', message: '404 Not Found', data: { statusCode: 404 } })
+            .mockResolvedValueOnce(session);
+          const free = vi.fn();
+          mockState.startAuthFlow.mockReturnValue({
+            authorizationUrl: 'https://auth.example.com/authorize',
+            tryPollOnce,
+            free,
+          });
+
+          const result = await HomeserverService.generateAuthUrl();
+          const approvalPromise = result.awaitApproval;
+
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(2_000);
+
+          await expect(approvalPromise).resolves.toBe(session);
+          expect(tryPollOnce).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('should call startAuthFlow with default capabilities', async () => {
         await HomeserverService.generateAuthUrl();
 


### PR DESCRIPTION
## 🐛 Fix: Auth relay 404 on first poll causes error toast on `/sign-in` page load

### Problem

An "Authorization was not completed" error toast appeared immediately on the `/sign-in` route without any user interaction. The sign-in flow itself worked fine — users could still complete authentication — but the toast created a confusing UX.

### Root Cause

The relay returns a **404 Not Found** on the first `tryPollOnce()` call during auth flow polling — a transient race where the relay hasn't registered the auth flow yet when the first poll fires.

The client's `isRetryableRelayPollError` function did not include 404 in its retryable status codes, so the error was treated as fatal. This caused the `awaitApproval` promise to reject, which fell through the `AuthFlowCanceled` and timeout/expired checks in `useAuthUrl` and triggered the error toast.

### Fix

- Added `HttpStatusCode.NOT_FOUND` (404) to `RETRYABLE_STATUS_CODES` in `error.utils.ts`
- Added a test case covering the 404 retry scenario during auth relay polling

A 404 during auth polling is a transient condition (the relay just hasn't registered the flow yet), not a permanent failure. The polling loop now correctly retries instead of rejecting the promise on the first 404.

### Screenshots

<img width="1593" height="1276" alt="image" src="https://github.com/user-attachments/assets/a6d3b5a6-b1c4-4ccb-9a39-f744b1770fa7" />

### Notes

- The sign-in flow was not actually broken — only the error handling was too aggressive for the first poll
- The relay was recently updated, which likely contributed to this behavior
- The existing 504 retry test was used as the pattern for the new 404 test

---

_This pull request summary was generated, for full implementation details please reference the file changes._
