### PR TITLE
fix: correct link for 'New here?' button in onboarding header

### DIFF
--- a/src/components/molecules/Header/Header.test.tsx
+++ b/src/components/molecules/Header/Header.test.tsx
@@ -341,7 +341,7 @@ describe('Header Components', () => {
       const button = screen.getByText('New here?');
       fireEvent.click(button);
 
-      expect(mockPush).toHaveBeenCalledWith('/sign-in');
+      expect(mockPush).toHaveBeenCalledWith('/onboarding/human');
     });
 
     it('applies correct classes', () => {

--- a/src/components/molecules/HeaderButtonSignIn/HeaderButtonSignIn.test.tsx
+++ b/src/components/molecules/HeaderButtonSignIn/HeaderButtonSignIn.test.tsx
@@ -44,8 +44,8 @@ vi.mock('@/libs', async () => {
 
 // Mock app
 vi.mock('@/app', () => ({
-  AUTH_ROUTES: {
-    SIGN_IN: '/sign-in',
+  ONBOARDING_ROUTES: {
+    HUMAN: '/onboarding/human',
   },
 }));
 
@@ -64,13 +64,13 @@ describe('HeaderButtonSignIn', () => {
     expect(screen.getByTestId('header-sign-in-btn')).toBeInTheDocument();
   });
 
-  it('navigates to sign in page when clicked', () => {
+  it('navigates to onboarding when clicked', () => {
     render(<HeaderButtonSignIn />);
 
     const button = screen.getByRole('button', { name: /New here?/i });
     button.click();
 
-    expect(mockPush).toHaveBeenCalledWith('/sign-in');
+    expect(mockPush).toHaveBeenCalledWith('/onboarding/human');
   });
 
   it('passes through additional props', () => {

--- a/src/components/molecules/HeaderButtonSignIn/HeaderButtonSignIn.tsx
+++ b/src/components/molecules/HeaderButtonSignIn/HeaderButtonSignIn.tsx
@@ -12,8 +12,8 @@ export function HeaderButtonSignIn({ ...props }: React.HTMLAttributes<HTMLButton
   const t = useTranslations('header');
   const router = useRouter();
 
-  const handleSignIn = () => {
-    router.push(App.AUTH_ROUTES.SIGN_IN);
+  const handleNewHere = () => {
+    router.push(App.ONBOARDING_ROUTES.HUMAN);
   };
 
   return (
@@ -21,7 +21,7 @@ export function HeaderButtonSignIn({ ...props }: React.HTMLAttributes<HTMLButton
       id="header-sign-in-btn"
       data-testid="header-sign-in-btn"
       variant="secondary"
-      onClick={handleSignIn}
+      onClick={handleNewHere}
       className="gap-2"
       {...props}
     >


### PR DESCRIPTION
Fixes bug highlighted in comment https://github.com/pubky/pubky-app/pull/1266#issuecomment-4095694180

The "New here?" button still linked to `/sign-in`, now it links to `/onboarding/human`.