### PR TITLE
chore: Sherlock extension integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ public/sw.js.map
 
 # AI Context Plans
 .plans
+
+# Sherlock extension related files
+project.inlang/cache/*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ See [docs/environment.md](./docs/environment.md) for more details.
 - Run local code review workflow (Cursor): use `/review` (defined in `.cursor/skills/code-review/SKILL.md`)
 - Follow commit message format: [docs/commit-message.md](./docs/commit-message.md)
 
+## Sherlock (Inlang) in VS Code
+
+This repository is preconfigured for Sherlock with `project.inlang/settings.json`.
+
+1. Install the extension: [inlang.vs-code-extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)
+2. Open the repo in VS Code and open the `Sherlock` tab.
+3. Use translation keys via `t()`, `useTranslations()`, or `getTranslations()` and Sherlock will show inline previews/editing backed by `messages/{locale}.json`.
+
+If Sherlock does not load, ensure Node.js is v18+ and the workspace is opened as a Git repository.
+
 ## License
 
 This project is licensed under the MIT License.  

--- a/project.inlang/project_id
+++ b/project.inlang/project_id
@@ -1,0 +1,1 @@
+TFr1rRTTyAwwU3y4TN

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://inlang.com/schema/project-settings",
+  "baseLocale": "en",
+  "locales": ["en", "pt-BR", "de", "fr", "it", "zh", "ja", "ar", "es"],
+  "sourceLanguageTag": "en",
+  "languageTags": ["en", "pt-BR", "de", "fr", "it", "zh", "ja", "ar", "es"],
+  "modules": ["https://cdn.jsdelivr.net/npm/@inlang/plugin-next-intl@latest/dist/index.js"],
+  "plugin.inlang.nextIntl": {
+    "pathPattern": "./messages/{languageTag}.json",
+    "variableReferencePattern": ["{", "}"]
+  }
+}


### PR DESCRIPTION
- Added Sherlock extension related files to .gitignore.
- Updated README to include setup instructions for the Sherlock extension in VS Code.
- Introduced new project settings and project ID files for Sherlock integration.