### PR TITLE
fix(ui): use DialogFooter for restore dialog button layout, update input style

### DIFF
--- a/src/components/molecules/WordSlot/WordSlot.tsx
+++ b/src/components/molecules/WordSlot/WordSlot.tsx
@@ -10,7 +10,7 @@ export const WordSlot = (props: Types.WordSlotProps) => {
     const hasError = isError && showError;
 
     const containerClasses = Libs.cn(
-      'flex-row px-3 py-2 rounded-md border overflow-hidden relative',
+      'flex-row px-3 py-2 rounded-md border border-dashed overflow-hidden relative',
       'inline-flex w-full items-center bg-transparent transition-colors',
       hasError && 'border-red-500 bg-red-500/10',
       !hasError && 'border-border hover:bg-secondary/50',

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.test.tsx
@@ -84,6 +84,11 @@ vi.mock('@/components/atoms', () => ({
       {children}
     </div>
   ),
+  DialogFooter: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="dialog-footer" className={className}>
+      {children}
+    </div>
+  ),
   Button: ({
     children,
     variant,

--- a/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
+++ b/src/components/organisms/DialogRestoreEncryptedFile/DialogRestoreEncryptedFile.tsx
@@ -191,11 +191,12 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
         </Atoms.Container>
 
         {/* Action Buttons */}
-        <Atoms.Container className="justify-between gap-4 sm:gap-3 md:flex-row">
+        <Atoms.DialogFooter>
           <Atoms.DialogClose asChild>
             <Atoms.Button
               variant="outline"
-              className="order-2 h-10 flex-1 rounded-full px-4 py-2.5 md:order-0 md:px-12 md:py-6"
+              size="lg"
+              className="order-2 sm:order-1"
               onClick={handleReset}
               disabled={isRestoring}
             >
@@ -204,7 +205,8 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
           </Atoms.DialogClose>
           <Atoms.Button
             id="encrypted-file-restore-btn"
-            className="order-1 h-10 flex-1 rounded-full px-4 py-2.5 md:px-12 md:py-6"
+            size="lg"
+            className="order-1 sm:order-2"
             onClick={handleRestore}
             disabled={!isFormValid()}
           >
@@ -215,12 +217,12 @@ export function DialogRestoreEncryptedFile({ onRestore }: { onRestore: () => voi
               </>
             ) : (
               <>
-                <Libs.RotateCcw className="mr-2 h-4 w-4" />
+                <Libs.RotateCcw className="mr-2 h-4 w-4 rotate-180" />
                 {tRestore('restore')}
               </>
             )}
           </Atoms.Button>
-        </Atoms.Container>
+        </Atoms.DialogFooter>
       </Atoms.DialogContent>
     </Atoms.Dialog>
   );

--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.test.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.test.tsx
@@ -49,6 +49,11 @@ vi.mock('@/atoms', () => ({
       {children}
     </div>
   )),
+  DialogFooter: vi.fn(({ children, className }) => (
+    <div data-testid="dialog-footer" className={className}>
+      {children}
+    </div>
+  )),
   Button: vi.fn(({ children, variant, className, size, onClick, disabled, ...props }) => (
     <button
       data-testid="button"

--- a/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
+++ b/src/components/organisms/DialogRestoreRecoveryPhrase/DialogRestoreRecoveryPhrase.tsx
@@ -234,15 +234,16 @@ function RestoreForm({
         )}
       </Atoms.Container>
 
-      <Atoms.Container className="flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4">
+      <Atoms.DialogFooter>
         <Atoms.DialogClose asChild>
-          <Atoms.Button variant="outline" className="h-10 flex-1 rounded-full px-4 py-2.5 md:px-12 md:py-6">
+          <Atoms.Button variant="outline" size="lg" className="order-2 sm:order-1">
             {t('cancel')}
           </Atoms.Button>
         </Atoms.DialogClose>
         <Atoms.Button
           id="recovery-phrase-restore-btn"
-          className="h-10 flex-1 rounded-full px-4 py-2.5 md:px-12 md:py-6"
+          size="lg"
+          className="order-1 sm:order-2"
           onClick={onRestore}
           disabled={!isFormValid()}
         >
@@ -253,12 +254,12 @@ function RestoreForm({
             </>
           ) : (
             <>
-              <Libs.RotateCcw className="mr-2 h-4 w-4" />
+              <Libs.RotateCcw className="mr-2 h-4 w-4 rotate-180" />
               {t('restore')}
             </>
           )}
         </Atoms.Button>
-      </Atoms.Container>
+      </Atoms.DialogFooter>
     </>
   );
 }


### PR DESCRIPTION
## Changes
- Replace manual Container with `DialogFooter` for equal-width button layout in `DialogRestoreRecoveryPhrase` and `DialogRestoreEncryptedFile`                                     
- Use size="lg" instead of custom sizing classes for consistency with other dialogs                                               
- Rotate `restore` button icon 180 degrees in both dialogs                                                                                                                            
- Add `dashed border` style to `WordSlot` input                                                                                                                                  
- Add `DialogFooter` mock to both test files  

## Test (Result)
https://github.com/user-attachments/assets/b068fbe1-663d-4867-a4be-f6751dd28bfd

