### PR TITLE
feat(ui): add Plausible Analytics script injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,12 @@ SUPPORT_ACCOUNT_ID=123
 SUPPORT_FEEDBACK_INBOX_ID=26
 
 # =============================================================================
+# Analytics (Plausible)
+# =============================================================================
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=pubky.app
+NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL=https://_analytics.synonym.to/js/script.js
+
+# =============================================================================
 # Metadata Configuration (optional - all have defaults)
 # =============================================================================
 # NEXT_PUBLIC_PREVIEW_IMAGE=/preview.webp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Use `Err.*` factories (never raw `Error`). Factories log automatically — don't
 ## Learned Workspace Facts
 
 - Config constants in `src/config/` (e.g., `USER_LIST_TAGS_MAX_TOTAL_CHARS`, tag limits) are project-wide hard limits — do not modify them for individual component fixes
+- This project uses Zod v4 — use `z.url()` for URL validation, not the deprecated `z.string().url()`
 
 ## Documentation
 

--- a/src/components/molecules/ContainerRoot/ContainerRoot.tsx
+++ b/src/components/molecules/ContainerRoot/ContainerRoot.tsx
@@ -1,7 +1,9 @@
 import { Inter_Tight } from 'next/font/google';
+import Script from 'next/script';
 
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
+import { Env } from '@/libs/env';
 import { isRtlLocale } from '@/i18n';
 
 const interTight = Inter_Tight({
@@ -20,6 +22,13 @@ export function RootContainer({ children, locale = 'en' }: RootContainerProps) {
   return (
     <Atoms.Container as="html" lang={locale} dir={dir}>
       <Atoms.Container as="body" className={`${interTight.variable} antialiased`}>
+        {Env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && Env.NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL && (
+          <Script
+            data-domain={Env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
+            src={Env.NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL}
+            strategy="afterInteractive"
+          />
+        )}
         <Molecules.PageContainer>{children}</Molecules.PageContainer>
       </Atoms.Container>
     </Atoms.Container>

--- a/src/libs/env/env.ts
+++ b/src/libs/env/env.ts
@@ -184,6 +184,12 @@ const envSchema = z.object({
     .default('26')
     .transform((val) => parseInt(val, 10)),
 
+  // =============================================================================
+  // ANALYTICS (Plausible)
+  // =============================================================================
+  NEXT_PUBLIC_PLAUSIBLE_DOMAIN: z.string().optional(),
+  NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL: z.url().optional(),
+
   NEXT_PUBLIC_PREVIEW_IMAGE: z.string().optional().default('/preview.webp'),
   NEXT_PUBLIC_SITE_NAME: z.string().optional().default('Pubky App'),
   NEXT_PUBLIC_LOCALE: z.string().optional().default('en_US'),
@@ -322,6 +328,8 @@ function parseEnv(): z.infer<typeof envSchema> {
     SUPPORT_API_ACCESS_TOKEN: process.env.SUPPORT_API_ACCESS_TOKEN,
     SUPPORT_ACCOUNT_ID: process.env.SUPPORT_ACCOUNT_ID,
     SUPPORT_FEEDBACK_INBOX_ID: process.env.SUPPORT_FEEDBACK_INBOX_ID,
+    NEXT_PUBLIC_PLAUSIBLE_DOMAIN: process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN,
+    NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL: process.env.NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL,
     NEXT_PUBLIC_PREVIEW_IMAGE: process.env.NEXT_PUBLIC_PREVIEW_IMAGE,
     NEXT_PUBLIC_DEFAULT_URL: process.env.NEXT_PUBLIC_DEFAULT_URL,
     NEXT_PUBLIC_LOCALE: process.env.NEXT_PUBLIC_LOCALE,


### PR DESCRIPTION
## Summary
- fix #1521
- Add Plausible Analytics tracking to Pubky App via environment-driven script injection
- Script only loads when both env vars are configured, keeping dev/test environments clean by default

## Changes
- Add `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` and `NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL` optional env vars to Zod schema and `parseEnv()` in `src/libs/env/env.ts`
- Inject Plausible `<Script>` via `next/script` with `strategy="afterInteractive"` in `ContainerRoot.tsx`, conditionally rendered when both env vars are set
- Add Analytics section to `.env.example` with production values (`pubky.app` / `https://_analytics.synonym.to/js/script.js`)

## Test plan
- [x] Built locally and verified script loads with 200 from `https://_analytics.synonym.to/js/script.js`
- [x] Confirmed Plausible client correctly skips event reporting on localhost (expected behavior)
- [x] Verified no lint or type errors introduced
- [ ] Deploy to staging and confirm pageviews appear in Plausible dashboard

## Notes
- No npm packages added — Plausible works as a standalone script tag
- The Plausible client ignores `localhost` by design, so real dashboard data requires deployment to the `pubky.app` domain