### PR TITLE
Fix responsive Hot tag avatar placement

### DIFF
--- a/src/components/molecules/HotTagCard/HotTagCard.test.tsx
+++ b/src/components/molecules/HotTagCard/HotTagCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HotTagCard } from './HotTagCard';
 
@@ -78,9 +78,8 @@ describe('HotTagCard', () => {
 
     render(<HotTagCard {...defaultProps} taggers={taggers} />);
 
-    // The avatars should be rendered
-    const card = screen.getByTestId('hot-tag-card-1');
-    expect(card).toBeInTheDocument();
+    expect(screen.getByTestId('hot-tag-card-mobile-avatars')).toHaveClass('sm:hidden');
+    expect(screen.getByTestId('hot-tag-card-desktop-avatars')).toHaveClass('hidden', 'sm:flex');
   });
 
   it('shows overflow based on postCount minus visible avatars', () => {
@@ -92,7 +91,8 @@ describe('HotTagCard', () => {
     // postCount is 371 (default), showing 6 avatars → overflow is 371 - 6 = 365 → +99
     render(<HotTagCard {...defaultProps} taggers={taggers} maxAvatars={6} />);
 
-    expect(screen.getByText('+99')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-mobile-avatars')).getByText('+99')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-desktop-avatars')).getByText('+99')).toBeInTheDocument();
   });
 
   it('shows correct overflow for smaller postCount', () => {
@@ -104,7 +104,8 @@ describe('HotTagCard', () => {
     // postCount is 50, showing 6 avatars → overflow is 50 - 6 = 44
     render(<HotTagCard {...defaultProps} postCount={50} taggers={taggers} maxAvatars={6} />);
 
-    expect(screen.getByText('+44')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-mobile-avatars')).getByText('+44')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-desktop-avatars')).getByText('+44')).toBeInTheDocument();
   });
 
   it('does not show overflow when postCount equals visible avatars', () => {
@@ -116,7 +117,8 @@ describe('HotTagCard', () => {
     // postCount is 6, showing 6 avatars → no overflow
     render(<HotTagCard {...defaultProps} postCount={6} taggers={taggers} maxAvatars={6} />);
 
-    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-mobile-avatars')).queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-desktop-avatars')).queryByText(/^\+/)).not.toBeInTheDocument();
   });
 
   it('caps overflow display at +99 for large postCounts', () => {
@@ -128,7 +130,8 @@ describe('HotTagCard', () => {
     // postCount is 500, showing 6 avatars → overflow is 494 → +99
     render(<HotTagCard {...defaultProps} postCount={500} taggers={taggers} maxAvatars={6} />);
 
-    expect(screen.getByText('+99')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-mobile-avatars')).getByText('+99')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hot-tag-card-desktop-avatars')).getByText('+99')).toBeInTheDocument();
   });
 
   it('renders different ranks correctly', () => {

--- a/src/components/molecules/HotTagCard/HotTagCard.test.tsx.snap
+++ b/src/components/molecules/HotTagCard/HotTagCard.test.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`HotTagCard - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-wrap justify-between gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90 lg:flex-col"
+  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-col gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90"
   data-testid="hot-tag-card-1"
   style="background: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), rgb(255, 153, 0);"
 >
   <div
-    class="flex w-full flex-col gap-2.5 px-6"
+    class="flex w-full flex-col gap-1 px-6 sm:gap-2.5"
     data-testid="container"
   >
     <div
-      class="flex w-full items-center gap-3"
+      class="flex w-full items-center gap-2 sm:gap-3"
       data-testid="container"
     >
       <div
-        class="flex w-full items-center gap-3"
+        class="flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
         data-testid="container"
       >
         <div
@@ -49,20 +49,20 @@ exports[`HotTagCard - Snapshots > matches snapshot with default props 1`] = `
 
 exports[`HotTagCard - Snapshots > matches snapshot with overflow taggers 1`] = `
 <div
-  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-wrap justify-between gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90 lg:flex-col"
+  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-col gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90"
   data-testid="hot-tag-card-3"
   style="background: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), rgb(255, 0, 4);"
 >
   <div
-    class="flex w-full flex-col gap-2.5 px-6"
+    class="flex w-full flex-col gap-1 px-6 sm:gap-2.5"
     data-testid="container"
   >
     <div
-      class="flex w-full items-center gap-3"
+      class="flex w-full items-center gap-2 sm:gap-3"
       data-testid="container"
     >
       <div
-        class="flex w-full items-center gap-3"
+        class="flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
         data-testid="container"
       >
         <div
@@ -84,485 +84,490 @@ exports[`HotTagCard - Snapshots > matches snapshot with overflow taggers 1`] = `
         </h4>
       </div>
       <div
-        class="flex items-center"
-        data-testid="container"
+        class="flex shrink-0 items-center sm:hidden"
+        data-testid="hot-tag-card-mobile-avatars"
       >
         <div
-          class="relative rounded-full shadow-xs"
+          class="flex items-center"
           data-testid="container"
-          style="margin-left: 0px; z-index: 6;"
         >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: 0px; z-index: 6;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 255, 93);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 255, 93);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 63 15"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
-                    >
-                      <circle
-                        cx="55.2"
-                        cy="7.2"
-                        fill="currentColor"
-                        r="7.2"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
-                    >
-                      <circle
-                        cx="7.2"
-                        cy="7.2"
-                        fill="currentColor"
-                        r="7.2"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 63 15"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
+                      >
+                        <circle
+                          cx="55.2"
+                          cy="7.2"
+                          fill="currentColor"
+                          r="7.2"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
+                      >
+                        <circle
+                          cx="7.2"
+                          cy="7.2"
+                          fill="currentColor"
+                          r="7.2"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 7;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 7;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 71 23"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="8"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="0"
-                        y="8"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="55.2"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="47.3"
-                        y="8"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 71 23"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="8"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="0"
+                          y="8"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="55.2"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="47.3"
+                          y="8"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 8;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 8;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 82 8"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="6.9"
-                        x="0.07"
-                        y="0.16"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="20.7"
-                        x="7.9"
-                        y="0.16"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="6.9"
-                        x="74.7"
-                        y="0.16"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="20.7"
-                        x="53.1"
-                        y="0.16"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 82 8"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="6.9"
+                          x="0.07"
+                          y="0.16"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="20.7"
+                          x="7.9"
+                          y="0.16"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="6.9"
+                          x="74.7"
+                          y="0.16"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="20.7"
+                          x="53.1"
+                          y="0.16"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 9;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 9;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(252, 0, 255);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(252, 0, 255);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 63 9"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
-                    >
-                      <path
-                        d="M0 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C2.4 2.2 6 0 10.5 0S18.6 2.2 20.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C15 6.7 12.8 6 10.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
-                        fill="currentColor"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
-                    >
-                      <path
-                        d="M42 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C44.4 2.2 48 0 52.5 0S60.6 2.2 62.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C57 6.7 54.8 6 52.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
-                        fill="currentColor"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 63 9"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
+                      >
+                        <path
+                          d="M0 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C2.4 2.2 6 0 10.5 0S18.6 2.2 20.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C15 6.7 12.8 6 10.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
+                          fill="currentColor"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
+                      >
+                        <path
+                          d="M42 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C44.4 2.2 48 0 52.5 0S60.6 2.2 62.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C57 6.7 54.8 6 52.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 10;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 10;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 0, 0);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 0, 0);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 63 15"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
-                    >
-                      <circle
-                        cx="55.2"
-                        cy="7.2"
-                        fill="currentColor"
-                        r="7.2"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
-                    >
-                      <circle
-                        cx="7.2"
-                        cy="7.2"
-                        fill="currentColor"
-                        r="7.2"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 63 15"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
+                      >
+                        <circle
+                          cx="55.2"
+                          cy="7.2"
+                          fill="currentColor"
+                          r="7.2"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
+                      >
+                        <circle
+                          cx="7.2"
+                          cy="7.2"
+                          fill="currentColor"
+                          r="7.2"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 11;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 11;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 153, 0);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 153, 0);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 71 23"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="8"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="0"
-                        y="8"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="55.2"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="47.3"
-                        y="8"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 71 23"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      U
-                    </span>
+                      <g
+                        style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="8"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="0"
+                          y="8"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="55.2"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="47.3"
+                          y="8"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        U
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 7;"
-        >
-          +94
+          </div>
+          <div
+            class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 7;"
+          >
+            +94
+          </div>
         </div>
       </div>
     </div>
@@ -573,25 +578,512 @@ exports[`HotTagCard - Snapshots > matches snapshot with overflow taggers 1`] = `
       100 posts this month
     </p>
   </div>
+  <div
+    class="hidden px-6 sm:flex"
+    data-testid="hot-tag-card-desktop-avatars"
+  >
+    <div
+      class="flex items-center"
+      data-testid="container"
+    >
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: 0px; z-index: 6;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 255, 93);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 63 15"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="55.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 2.8s ease-in-out 0.8s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="7.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 7;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 71 23"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="8"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="0"
+                      y="8"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="55.2"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="47.3"
+                      y="8"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 8;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 82 8"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="6.9"
+                      x="0.07"
+                      y="0.16"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="20.7"
+                      x="7.9"
+                      y="0.16"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="6.9"
+                      x="74.7"
+                      y="0.16"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="20.7"
+                      x="53.1"
+                      y="0.16"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 9;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(252, 0, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 63 9"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
+                  >
+                    <path
+                      d="M0 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C2.4 2.2 6 0 10.5 0S18.6 2.2 20.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C15 6.7 12.8 6 10.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
+                      fill="currentColor"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 4.1s ease-in-out 2.1s infinite; transform-origin: center center;"
+                  >
+                    <path
+                      d="M42 5.1c0-.1 0-.2 0-.3.1-.5.3-1 .7-1.3.1 0 .1-.1.2-.1C44.4 2.2 48 0 52.5 0S60.6 2.2 62.2 3.3c.1 0 .1.1.1.1.4.3.7.9.7 1.3v.3c0 1 0 1.4 0 1.7-.2 1.3-1.2 1.9-2.5 1.6-.2 0-.7-.3-1.8-.8C57 6.7 54.8 6 52.5 6s-4.5.7-6.3 1.5c-1 .5-1.5.7-1.8.8-1.3.3-2.3-.3-2.5-1.6v-1.7z"
+                      fill="currentColor"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 10;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 0, 0);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 63 15"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="55.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 3.2s ease-in-out 1.2s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="7.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 11;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(255, 153, 0);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 71 23"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="8"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="0"
+                      y="8"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 2.3s ease-in-out 0.3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="55.2"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="47.3"
+                      y="8"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 7;"
+      >
+        +94
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`HotTagCard - Snapshots > matches snapshot with small postCount 1`] = `
 <div
-  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-wrap justify-between gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90 lg:flex-col"
+  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-col gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90"
   data-testid="hot-tag-card-1"
   style="background: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), rgb(0, 188, 255);"
 >
   <div
-    class="flex w-full flex-col gap-2.5 px-6"
+    class="flex w-full flex-col gap-1 px-6 sm:gap-2.5"
     data-testid="container"
   >
     <div
-      class="flex w-full items-center gap-3"
+      class="flex w-full items-center gap-2 sm:gap-3"
       data-testid="container"
     >
       <div
-        class="flex w-full items-center gap-3"
+        class="flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
         data-testid="container"
       >
         <div
@@ -625,20 +1117,20 @@ exports[`HotTagCard - Snapshots > matches snapshot with small postCount 1`] = `
 
 exports[`HotTagCard - Snapshots > matches snapshot with taggers 1`] = `
 <div
-  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-wrap justify-between gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90 lg:flex-col"
+  class="relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-col gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90"
   data-testid="hot-tag-card-2"
   style="background: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), rgb(255, 9, 0);"
 >
   <div
-    class="flex w-full flex-col gap-2.5 px-6"
+    class="flex w-full flex-col gap-1 px-6 sm:gap-2.5"
     data-testid="container"
   >
     <div
-      class="flex w-full items-center gap-3"
+      class="flex w-full items-center gap-2 sm:gap-3"
       data-testid="container"
     >
       <div
-        class="flex w-full items-center gap-3"
+        class="flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
         data-testid="container"
       >
         <div
@@ -660,193 +1152,198 @@ exports[`HotTagCard - Snapshots > matches snapshot with taggers 1`] = `
         </h4>
       </div>
       <div
-        class="flex items-center"
-        data-testid="container"
+        class="flex shrink-0 items-center sm:hidden"
+        data-testid="hot-tag-card-mobile-avatars"
       >
         <div
-          class="relative rounded-full shadow-xs"
+          class="flex items-center"
           data-testid="container"
-          style="margin-left: 0px; z-index: 2;"
         >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: 0px; z-index: 2;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 71 23"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="8"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="0"
-                        y="8"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="23"
-                        rx="3.5"
-                        width="7"
-                        x="55.2"
-                        y="0"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="7"
-                        rx="3.5"
-                        width="23"
-                        x="47.3"
-                        y="8"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 71 23"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      A
-                    </span>
+                      <g
+                        style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="8"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="0"
+                          y="8"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="23"
+                          rx="3.5"
+                          width="7"
+                          x="55.2"
+                          y="0"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="7"
+                          rx="3.5"
+                          width="23"
+                          x="47.3"
+                          y="8"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        A
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative rounded-full shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 3;"
-        >
-          <span
-            class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+          </div>
+          <div
+            class="relative rounded-full shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 3;"
           >
             <span
-              class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+              class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
             >
-              <div
-                class="facehash h-full w-full rounded-full text-background"
-                data-facehash=""
-                data-interactive="true"
-                style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+              <span
+                class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
               >
                 <div
-                  data-facehash-gradient=""
-                  style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
-                />
-                <div
-                  data-facehash-face=""
-                  style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+                  class="facehash h-full w-full rounded-full text-background"
+                  data-facehash=""
+                  data-interactive="true"
+                  style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
                 >
-                  <svg
-                    aria-hidden="true"
-                    fill="none"
-                    style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
-                    viewBox="0 0 82 8"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="6.9"
-                        x="0.07"
-                        y="0.16"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="20.7"
-                        x="7.9"
-                        y="0.16"
-                      />
-                    </g>
-                    <g
-                      style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
-                    >
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="6.9"
-                        x="74.7"
-                        y="0.16"
-                      />
-                      <rect
-                        fill="currentColor"
-                        height="6.9"
-                        rx="3.5"
-                        width="20.7"
-                        x="53.1"
-                        y="0.16"
-                      />
-                    </g>
-                  </svg>
                   <div
-                    data-facehash-mouth=""
-                    style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    data-facehash-gradient=""
+                    style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+                  />
+                  <div
+                    data-facehash-face=""
+                    style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
                   >
-                    <span
-                      data-testid="avatar-fallback-initial"
-                      style="font-size: 26cqw; line-height: 1;"
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                      viewBox="0 0 82 8"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      B
-                    </span>
+                      <g
+                        style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="6.9"
+                          x="0.07"
+                          y="0.16"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="20.7"
+                          x="7.9"
+                          y="0.16"
+                        />
+                      </g>
+                      <g
+                        style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                      >
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="6.9"
+                          x="74.7"
+                          y="0.16"
+                        />
+                        <rect
+                          fill="currentColor"
+                          height="6.9"
+                          rx="3.5"
+                          width="20.7"
+                          x="53.1"
+                          y="0.16"
+                        />
+                      </g>
+                    </svg>
+                    <div
+                      data-facehash-mouth=""
+                      style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                    >
+                      <span
+                        data-testid="avatar-fallback-initial"
+                        style="font-size: 26cqw; line-height: 1;"
+                      >
+                        B
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </span>
             </span>
-          </span>
-        </div>
-        <div
-          class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
-          data-testid="container"
-          style="margin-left: -8px; z-index: 3;"
-        >
-          +99
+          </div>
+          <div
+            class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
+            data-testid="container"
+            style="margin-left: -8px; z-index: 3;"
+          >
+            +99
+          </div>
         </div>
       </div>
     </div>
@@ -856,6 +1353,201 @@ exports[`HotTagCard - Snapshots > matches snapshot with taggers 1`] = `
     >
       250 posts this month
     </p>
+  </div>
+  <div
+    class="hidden px-6 sm:flex"
+    data-testid="hot-tag-card-desktop-avatars"
+  >
+    <div
+      class="flex items-center"
+      data-testid="container"
+    >
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: 0px; z-index: 2;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 240, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 71 23"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="8"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="0"
+                      y="8"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 5.9s ease-in-out 3.9s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="55.2"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="47.3"
+                      y="8"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    A
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative rounded-full shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 3;"
+      >
+        <span
+          class="relative flex shrink-0 overflow-hidden rounded-full h-8 w-8"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(0deg) rotateY(0deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 82 8"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="6.9"
+                      x="0.07"
+                      y="0.16"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="20.7"
+                      x="7.9"
+                      y="0.16"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 5s ease-in-out 3s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="6.9"
+                      x="74.7"
+                      y="0.16"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="6.9"
+                      rx="3.5"
+                      width="20.7"
+                      x="53.1"
+                      y="0.16"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    B
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="relative flex size-8 items-center justify-center rounded-full border border-muted-foreground bg-background text-sm font-medium shadow-xs"
+        data-testid="container"
+        style="margin-left: -8px; z-index: 3;"
+      >
+        +99
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/molecules/HotTagCard/HotTagCard.tsx
+++ b/src/components/molecules/HotTagCard/HotTagCard.tsx
@@ -90,11 +90,7 @@ export function HotTagCard({
 
       {/* Card Footer - Avatar Group */}
       {taggers.length > 0 && (
-        <Atoms.Container
-          overrideDefaults
-          className="hidden px-6 sm:flex"
-          data-testid="hot-tag-card-desktop-avatars"
-        >
+        <Atoms.Container overrideDefaults className="hidden px-6 sm:flex" data-testid="hot-tag-card-desktop-avatars">
           <Molecules.AvatarGroup items={taggers} totalCount={postCount} maxAvatars={maxAvatars} />
         </Atoms.Container>
       )}

--- a/src/components/molecules/HotTagCard/HotTagCard.tsx
+++ b/src/components/molecules/HotTagCard/HotTagCard.tsx
@@ -41,7 +41,7 @@ export function HotTagCard({
     <Atoms.Container
       overrideDefaults
       className={Libs.cn(
-        'relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-wrap justify-between gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90 lg:flex-col',
+        'relative flex min-h-fit min-w-0 flex-1 cursor-pointer flex-col gap-4 overflow-hidden rounded-md px-0 py-6 shadow-sm transition-opacity hover:opacity-90',
         className,
       )}
       style={{
@@ -54,10 +54,10 @@ export function HotTagCard({
       data-testid={dataTestId || `hot-tag-card-${rank}`}
     >
       {/* Card Content */}
-      <Atoms.Container overrideDefaults className="flex w-full flex-col gap-2.5 px-6">
+      <Atoms.Container overrideDefaults className="flex w-full flex-col gap-1 px-6 sm:gap-2.5">
         {/* Rank and Tag Name */}
-        <Atoms.Container overrideDefaults className="flex w-full items-center gap-3">
-          <Atoms.Container overrideDefaults className="flex w-full items-center gap-3">
+        <Atoms.Container overrideDefaults className="flex w-full items-center gap-2 sm:gap-3">
+          <Atoms.Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
             <Atoms.Container
               overrideDefaults
               className="flex size-6 shrink-0 items-center justify-center rounded-full border border-accent-foreground"
@@ -71,7 +71,15 @@ export function HotTagCard({
             </Atoms.Typography>
           </Atoms.Container>
 
-          <Molecules.AvatarGroup items={taggers} totalCount={postCount} maxAvatars={maxAvatars} />
+          {taggers.length > 0 && (
+            <Atoms.Container
+              overrideDefaults
+              className="flex shrink-0 items-center sm:hidden"
+              data-testid="hot-tag-card-mobile-avatars"
+            >
+              <Molecules.AvatarGroup items={taggers} totalCount={postCount} maxAvatars={maxAvatars} />
+            </Atoms.Container>
+          )}
         </Atoms.Container>
 
         {/* Post Count */}
@@ -81,6 +89,15 @@ export function HotTagCard({
       </Atoms.Container>
 
       {/* Card Footer - Avatar Group */}
+      {taggers.length > 0 && (
+        <Atoms.Container
+          overrideDefaults
+          className="hidden px-6 sm:flex"
+          data-testid="hot-tag-card-desktop-avatars"
+        >
+          <Molecules.AvatarGroup items={taggers} totalCount={postCount} maxAvatars={maxAvatars} />
+        </Atoms.Container>
+      )}
     </Atoms.Container>
   );
 }

--- a/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.skeleton.tsx
+++ b/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.skeleton.tsx
@@ -2,13 +2,7 @@ import * as Atoms from '@/atoms';
 import { HOT_TAGS_FEATURED_COUNT } from '@/config';
 import { MAX_AVATARS_DEFAULT } from './HotTagsCardsSection.constants';
 
-function HotTagsCardAvatarSkeletonRow({
-  index,
-  maxAvatars,
-}: {
-  index: number;
-  maxAvatars: number;
-}) {
+function HotTagsCardAvatarSkeletonRow({ index, maxAvatars }: { index: number; maxAvatars: number }) {
   return (
     <Atoms.Container overrideDefaults className="flex items-center gap-1.5">
       {Array.from({ length: maxAvatars }).map((__, avatarIndex) => (

--- a/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.skeleton.tsx
+++ b/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.skeleton.tsx
@@ -2,6 +2,25 @@ import * as Atoms from '@/atoms';
 import { HOT_TAGS_FEATURED_COUNT } from '@/config';
 import { MAX_AVATARS_DEFAULT } from './HotTagsCardsSection.constants';
 
+function HotTagsCardAvatarSkeletonRow({
+  index,
+  maxAvatars,
+}: {
+  index: number;
+  maxAvatars: number;
+}) {
+  return (
+    <Atoms.Container overrideDefaults className="flex items-center gap-1.5">
+      {Array.from({ length: maxAvatars }).map((__, avatarIndex) => (
+        <Atoms.Skeleton
+          key={`hot-tags-cards-skeleton-avatar-${index}-${avatarIndex}`}
+          className="size-7 rounded-full"
+        />
+      ))}
+    </Atoms.Container>
+  );
+}
+
 export function HotTagsCardsSectionSkeleton({ maxAvatars = MAX_AVATARS_DEFAULT }: { maxAvatars?: number }) {
   return (
     <Atoms.Container overrideDefaults className="flex flex-col gap-3 sm:flex-row">
@@ -9,23 +28,24 @@ export function HotTagsCardsSectionSkeleton({ maxAvatars = MAX_AVATARS_DEFAULT }
         <Atoms.Container
           key={`hot-tags-cards-skeleton-${index}`}
           overrideDefaults
-          className="flex min-h-[148px] min-w-0 flex-1 flex-col justify-between gap-4 rounded-md bg-card px-6 py-6 shadow-sm"
+          className="flex min-h-[148px] min-w-0 flex-1 flex-col gap-4 overflow-hidden rounded-md bg-card py-6 shadow-sm"
           data-testid={`hot-tags-card-skeleton-${index}`}
         >
-          <Atoms.Container overrideDefaults className="flex flex-col gap-2.5">
-            <Atoms.Container overrideDefaults className="flex items-center gap-3">
-              <Atoms.Skeleton className="size-6 rounded-full" />
-              <Atoms.Skeleton className="h-6 w-28 rounded-md" />
+          <Atoms.Container overrideDefaults className="flex flex-col gap-1 px-6 sm:gap-2.5">
+            <Atoms.Container overrideDefaults className="flex items-center gap-2 sm:gap-3">
+              <Atoms.Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
+                <Atoms.Skeleton className="size-6 rounded-full" />
+                <Atoms.Skeleton className="h-6 w-28 rounded-md" />
+              </Atoms.Container>
+              <Atoms.Container overrideDefaults className="flex shrink-0 items-center sm:hidden">
+                <HotTagsCardAvatarSkeletonRow index={index} maxAvatars={maxAvatars} />
+              </Atoms.Container>
             </Atoms.Container>
             <Atoms.Skeleton className="h-5 w-20 rounded-md" />
           </Atoms.Container>
-          <Atoms.Container overrideDefaults className="flex items-center gap-1.5">
-            {Array.from({ length: maxAvatars }).map((__, avatarIndex) => (
-              <Atoms.Skeleton
-                key={`hot-tags-cards-skeleton-avatar-${index}-${avatarIndex}`}
-                className="size-7 rounded-full"
-              />
-            ))}
+
+          <Atoms.Container overrideDefaults className="hidden px-6 sm:flex">
+            <HotTagsCardAvatarSkeletonRow index={index} maxAvatars={maxAvatars} />
           </Atoms.Container>
         </Atoms.Container>
       ))}

--- a/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.test.tsx
+++ b/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.test.tsx
@@ -39,9 +39,7 @@ vi.mock('@/atoms', () => ({
     children: React.ReactNode;
     overrideDefaults?: boolean;
     [key: string]: unknown;
-  }) => (
-    <div {...props}>{children}</div>
-  ),
+  }) => <div {...props}>{children}</div>,
   Heading: ({ children }: { children: React.ReactNode }) => <h5>{children}</h5>,
   Typography: ({ children, className }: { children: React.ReactNode; className?: string }) => (
     <p className={className}>{children}</p>

--- a/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.test.tsx
+++ b/src/components/organisms/HotTagsCardsSection/HotTagsCardsSection.test.tsx
@@ -31,7 +31,15 @@ vi.mock('@/config', () => ({
 }));
 
 vi.mock('@/atoms', () => ({
-  Container: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => (
+  Container: ({
+    children,
+    overrideDefaults: _overrideDefaults,
+    ...props
+  }: {
+    children: React.ReactNode;
+    overrideDefaults?: boolean;
+    [key: string]: unknown;
+  }) => (
     <div {...props}>{children}</div>
   ),
   Heading: ({ children }: { children: React.ReactNode }) => <h5>{children}</h5>,


### PR DESCRIPTION
## Summary
- fix #1575
- Hot tag card avatars now display correctly across all screen sizes with a responsive layout that places avatars inline on mobile and in a separate footer row on desktop

## Changes
- Refactored `HotTagCard` layout from `flex-wrap justify-between` to `flex-col` with separate mobile (`sm:hidden`) and desktop (`hidden sm:flex`) avatar group placements
- Tightened mobile spacing with responsive gap utilities (`gap-1 sm:gap-2.5`, `gap-2 sm:gap-3`)
- Prevented tag name overflow by adding `min-w-0 flex-1` to the text container and `shrink-0` to the avatar container
- Updated `HotTagsCardsSectionSkeleton` to match the new responsive structure, extracting a reusable `HotTagsCardAvatarSkeletonRow` component
- Updated tests and snapshots to reflect the new layout

## Test plan
- [ ] Verify hot tag cards render avatars inline next to the tag name on mobile viewports
- [ ] Verify hot tag cards render avatars in a separate row below the post count on `sm` and larger viewports
- [ ] Verify long tag names truncate properly without pushing avatars off-screen
- [ ] Verify skeleton loading state matches the responsive avatar layout
- [ ] Run `vitest` for HotTagCard and HotTagsCardsSection tests

## Notes
- The avatar group is conditionally rendered only when `taggers.length > 0` to avoid empty containers
- Skeleton component was refactored to extract `HotTagsCardAvatarSkeletonRow` to avoid duplication between mobile and desktop slots