### PR TITLE
fix(ui): enable username truncation to nested reply column

### DIFF
--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
@@ -205,6 +205,14 @@ describe('ReplyWithNested', () => {
     expect(mocks.mockOnPostClick).toHaveBeenCalledWith('author:reply-1');
   });
 
+  it('applies min-w-0 to the nested sub-reply column so long usernames truncate', () => {
+    render(<ReplyWithNested replyId="author:reply-1" onPostClick={mocks.mockOnPostClick} />);
+
+    const nestedPost = screen.getByText('author:nested-1');
+    const nestedColumn = nestedPost.closest('.flex-1.min-w-0');
+    expect(nestedColumn).toBeInTheDocument();
+  });
+
   it('passes depth options to useNestedReplies', () => {
     // depth=0 so the mock wrapper passes through to mockUseNestedReplies
     render(<ReplyWithNested replyId="author:reply-1" onPostClick={mocks.mockOnPostClick} depth={0} maxDepth={2} />);

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx.snap
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ReplyWithNested - Snapshots > matches snapshot for expanded nested repl
           class="w-3 shrink-0 border-l border-border"
         />
         <div
-          class="ml-3 flex-1"
+          class="ml-3 min-w-0 flex-1"
         >
           <div>
             <div

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx.snap
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ReplyWithNested - Snapshots > matches snapshot for expanded nested repl
           class="w-3 shrink-0 border-l border-border"
         />
         <div
-          class="ml-3 min-w-0 flex-1"
+          class="min-w-0 flex-1 ml-3"
         >
           <div>
             <div

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.tsx
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.tsx
@@ -79,7 +79,7 @@ export function ReplyWithNested({
               {!isLastReply && <Atoms.Container overrideDefaults className="w-3 shrink-0 border-l border-border" />}
 
               {/* Indented sub-replies */}
-              <Atoms.Container overrideDefaults className={isLastReply ? 'ml-6 flex-1' : 'ml-3 flex-1'}>
+              <Atoms.Container overrideDefaults className={isLastReply ? 'ml-6 min-w-0 flex-1' : 'ml-3 min-w-0 flex-1'}>
                 {nestedReplyIds.map((nestedId, index) => {
                   const isLastNested = index === nestedReplyIds.length - 1 && !hasMoreReplies;
                   return (

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.tsx
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import * as Libs from '@/libs';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
@@ -79,7 +80,7 @@ export function ReplyWithNested({
               {!isLastReply && <Atoms.Container overrideDefaults className="w-3 shrink-0 border-l border-border" />}
 
               {/* Indented sub-replies */}
-              <Atoms.Container overrideDefaults className={isLastReply ? 'ml-6 min-w-0 flex-1' : 'ml-3 min-w-0 flex-1'}>
+              <Atoms.Container overrideDefaults className={Libs.cn('min-w-0 flex-1', isLastReply ? 'ml-6' : 'ml-3')}>
                 {nestedReplyIds.map((nestedId, index) => {
                   const isLastNested = index === nestedReplyIds.length - 1 && !hasMoreReplies;
                   return (


### PR DESCRIPTION
## Summary
- fix #1566
- Long usernames in nested sub-replies were not truncating, pushing action buttons (tags, bookmark, repost) off-screen
- Root cause: the sub-reply flex column in `ReplyWithNested` was missing `min-w-0`, breaking the CSS min-width constraint chain

## Changes
- Add `min-w-0` to the nested sub-reply `Container` in `ReplyWithNested.tsx` (both `isLastReply` and non-last branches)
- Add test verifying the truncation constraint class is applied to the nested column
- Update snapshot

## Test plan
- [ ] Open a post with deeply nested replies where a user has a very long username
- [ ] Verify the username truncates with ellipsis and action buttons remain visible
- [ ] Verify top-level replies still truncate correctly
- [ ] `vitest run ReplyWithNested` — 11 tests pass

## Notes
- This is a single `min-w-0` addition — the flex truncation chain was intact from `PostMain` down through `PostHeaderUserInfo`, but broken at the `ReplyWithNested` nesting container level