### PR TITLE
fix(i18n): clarify edited post notification text (#1063)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -743,7 +743,7 @@
       "repostedPost": "اعاد نشر منشورك",
       "mentionedYou": "ذكرك في منشور",
       "deletedPost": "حذف منشورا",
-      "editedPost": "عدّل منشوراً",
+      "editedPost": "عدّل منشوراً تفاعلت معه",
       "fallback": "إشعار جديد"
     },
     "settings": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -743,7 +743,7 @@
       "repostedPost": "hat Ihren Beitrag repostet",
       "mentionedYou": "hat Sie in einem Beitrag erwaehnt",
       "deletedPost": "hat einen Beitrag gelöscht",
-      "editedPost": "hat einen Beitrag bearbeitet",
+      "editedPost": "hat einen Beitrag bearbeitet, mit dem Sie interagiert haben",
       "fallback": "Neue Benachrichtigung"
     },
     "settings": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -737,7 +737,7 @@
       "repostedPost": "reposted your post",
       "mentionedYou": "mentioned you in post",
       "deletedPost": "deleted a post",
-      "editedPost": "edited a post",
+      "editedPost": "edited a post you have interacted with",
       "fallback": "New notification"
     },
     "settings": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -743,7 +743,7 @@
       "repostedPost": "republicó tu publicación",
       "mentionedYou": "te mencionó en una publicación",
       "deletedPost": "eliminó una publicación",
-      "editedPost": "editó una publicación",
+      "editedPost": "editó una publicación con la que interactuaste",
       "fallback": "Nueva notificación"
     },
     "settings": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -743,7 +743,7 @@
       "repostedPost": "a republie votre publication",
       "mentionedYou": "vous a mentionne dans une publication",
       "deletedPost": "a supprimé une publication",
-      "editedPost": "a modifié une publication",
+      "editedPost": "a modifié une publication avec laquelle vous avez interagi",
       "fallback": "Nouvelle notification"
     },
     "settings": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -743,7 +743,7 @@
       "repostedPost": "ha ripubblicato il tuo post",
       "mentionedYou": "ti ha menzionato in un post",
       "deletedPost": "ha eliminato un post",
-      "editedPost": "ha modificato un post",
+      "editedPost": "ha modificato un post con cui hai interagito",
       "fallback": "Nuova notifica"
     },
     "settings": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -743,7 +743,7 @@
       "repostedPost": "あなたの投稿をリポストしました",
       "mentionedYou": "投稿であなたをメンションしました",
       "deletedPost": "投稿を削除しました",
-      "editedPost": "投稿を編集しました",
+      "editedPost": "関わった投稿を編集しました",
       "fallback": "新しい通知"
     },
     "settings": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -743,7 +743,7 @@
       "repostedPost": "repostou seu post",
       "mentionedYou": "mencionou você em um post",
       "deletedPost": "excluiu um post",
-      "editedPost": "editou um post",
+      "editedPost": "editou um post com que você interagiu",
       "fallback": "Nova notificação"
     },
     "settings": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -743,7 +743,7 @@
       "repostedPost": "转发了您的帖子",
       "mentionedYou": "在帖子中提到了您",
       "deletedPost": "删除了一条帖子",
-      "editedPost": "编辑了一条帖子",
+      "editedPost": "编辑了您互动过的帖子",
       "fallback": "新通知"
     },
     "settings": {


### PR DESCRIPTION
Update notification action text from "edited a post" to "edited a post you have interacted with" across all 9 languages.

## Updated result
<img width="695" height="200" alt="Screenshot 2026-03-25 at 17 29 41" src="https://github.com/user-attachments/assets/dcfa8d98-cc88-424a-84c8-e0f3f5f89957" />
<img width="681" height="187" alt="Screenshot 2026-03-25 at 17 29 52" src="https://github.com/user-attachments/assets/5500aa32-7df1-4466-80c7-9afeff117d93" />
<img width="687" height="190" alt="Screenshot 2026-03-25 at 17 30 01" src="https://github.com/user-attachments/assets/789e6121-2cc0-479b-b1ad-02ef67a9f114" />
<img width="683" height="196" alt="Screenshot 2026-03-25 at 17 30 11" src="https://github.com/user-attachments/assets/75109671-4553-4043-ac33-0c0efab631a6" />
<img width="680" height="190" alt="Screenshot 2026-03-25 at 17 30 19" src="https://github.com/user-attachments/assets/513411d5-a704-40e1-9bc6-7283dcf282a6" />
<img width="683" height="214" alt="Screenshot 2026-03-25 at 17 30 47" src="https://github.com/user-attachments/assets/ddf82a07-53fe-4518-ae9f-c2e5d2f9ec4f" />
<img width="674" height="191" alt="Screenshot 2026-03-25 at 17 31 01" src="https://github.com/user-attachments/assets/c7e62ce3-dccd-45e8-8210-5685728a68e3" />
<img width="677" height="190" alt="Screenshot 2026-03-25 at 17 31 19" src="https://github.com/user-attachments/assets/342a3216-626e-4dd8-82b2-12c2123b81fb" />
<img width="678" height="182" alt="Screenshot 2026-03-25 at 17 31 30" src="https://github.com/user-attachments/assets/5acf8ed4-d4e3-4c37-841d-fb893057d993" />


## Mobile get cut in most case since text is long and screen is small
<img width="370" height="654" alt="Screenshot 2026-03-25 at 17 33 09" src="https://github.com/user-attachments/assets/5a4386ec-5453-4466-921c-a989e0fb4598" />



