### PR TITLE
feat: text as urls for articles with link confirmation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -428,6 +428,83 @@ body {
   .mdxeditor.dark-theme .cm-activeLineGutter {
     background-color: var(--muted) !important;
   }
+
+  /**
+   * MDXEditor link dialog dark mode fixes
+   * The link dialog is portaled via Radix Popover outside the editor DOM,
+   * so we target elements by their hashed class name patterns directly.
+   * Organized from outermost container to innermost elements:
+   * 1. Popover content (dialog container)
+   * 2. Form field labels
+   * 3. Text inputs (default + focus)
+   * 4. Action buttons (primary + secondary)
+   * 5. Link preview anchor
+   * 6. Popover arrow
+   */
+
+  /* 1. Link dialog popover container */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'][role='dialog'] {
+    background-color: var(--card) !important;
+    border: 1px solid var(--border) !important;
+    border-radius: var(--radius-md) !important;
+    color: var(--card-foreground) !important;
+  }
+
+  /* 2. Form field labels */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='formField'] label {
+    color: var(--muted-foreground) !important;
+  }
+
+  /* 3a. Text inputs - default state */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='textInput'] {
+    background-color: var(--background) !important;
+    border: 1px solid var(--border) !important;
+    border-radius: var(--radius-sm) !important;
+    color: var(--card-foreground) !important;
+    padding: 0.5rem !important;
+  }
+
+  /* 3b. Text inputs - focus state */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='textInput']:focus {
+    border-color: var(--ring) !important;
+    outline: none !important;
+  }
+
+  /* 4a. Primary button (Save) */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='primaryButton'] {
+    background-color: var(--brand) !important;
+    color: var(--background) !important;
+    border: none !important;
+    border-radius: var(--radius-sm) !important;
+  }
+
+  /* 4b. Primary button hover */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='primaryButton']:hover {
+    opacity: 0.9 !important;
+  }
+
+  /* 4c. Secondary button (Cancel) */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='secondaryButton'] {
+    background-color: var(--secondary) !important;
+    color: var(--secondary-foreground) !important;
+    border: 1px solid var(--border) !important;
+    border-radius: var(--radius-sm) !important;
+  }
+
+  /* 4d. Secondary button hover */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='secondaryButton']:hover {
+    background-color: var(--muted) !important;
+  }
+
+  /* 5. Link preview anchor - brand color */
+  .mdxeditor-popup-container [class*='linkDialogPreviewAnchor'] {
+    color: var(--brand) !important;
+  }
+
+  /* 6. Popover arrow - match dialog background */
+  .mdxeditor-popup-container [class*='linkDialogPopoverContent'] [class*='popoverArrow'] polygon {
+    fill: var(--card) !important;
+  }
 }
 
 @layer utilities {

--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx
@@ -62,6 +62,7 @@ vi.mock('@mdxeditor/editor', () => {
     listsPlugin: vi.fn(() => ({ type: 'lists' })),
     thematicBreakPlugin: vi.fn(() => ({ type: 'thematicBreak' })),
     linkPlugin: vi.fn(() => ({ type: 'link' })),
+    linkDialogPlugin: vi.fn(() => ({ type: 'linkDialog' })),
     codeBlockPlugin: vi.fn(() => ({ type: 'codeBlock' })),
     codeMirrorPlugin: vi.fn(() => ({ type: 'codeMirror' })),
     maxLengthPlugin: vi.fn(() => ({ type: 'maxLength' })),
@@ -90,6 +91,7 @@ vi.mock('@mdxeditor/editor', () => {
         {children}
       </button>
     ),
+    CreateLink: () => <button data-testid="create-link">Create Link</button>,
     CodeToggle: () => <button data-testid="code-toggle">Code</button>,
     InsertCodeBlock: () => <button data-testid="insert-code-block">Insert Code Block</button>,
     InsertThematicBreak: () => <button data-testid="insert-thematic-break">Insert Break</button>,
@@ -289,8 +291,8 @@ describe('InitializedMDXEditor', () => {
       render(<InitializedMDXEditor editorRef={null} markdown="" />);
 
       const editor = screen.getByTestId('mdx-editor');
-      // The editor should have 9 plugins configured
-      expect(editor).toHaveAttribute('data-plugins-count', '9');
+      // The editor should have 10 plugins configured
+      expect(editor).toHaveAttribute('data-plugins-count', '10');
     });
 
     it('passes additional props to MDXEditor', () => {
@@ -317,6 +319,7 @@ describe('InitializedMDXEditor', () => {
       expect(screen.getByTestId('strikethrough-toggle')).toBeInTheDocument();
       expect(screen.getByTestId('lists-toggle')).toBeInTheDocument();
       expect(screen.getByTestId('insert-thematic-break')).toBeInTheDocument();
+      expect(screen.getByTestId('create-link')).toBeInTheDocument();
       expect(screen.getByTestId('code-toggle')).toBeInTheDocument();
       expect(screen.getByTestId('insert-code-block')).toBeInTheDocument();
     });

--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx.snap
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot in markdown mode 1`
     class="dark-theme cursor-auto hidden"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-testid="mdx-editor"
     markdown=""
   >
@@ -95,6 +95,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot in markdown mode 1`
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"
@@ -203,7 +208,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with approaching ma
       class="dark-theme cursor-auto"
       data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
       data-placeholder="Start writing your masterpiece"
-      data-plugins-count="9"
+      data-plugins-count="10"
       data-testid="mdx-editor"
       markdown=""
     >
@@ -239,6 +244,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with approaching ma
           data-testid="insert-thematic-break"
         >
           Insert Break
+        </button>
+        <button
+          data-testid="create-link"
+        >
+          Create Link
         </button>
         <button
           data-testid="code-toggle"
@@ -367,7 +377,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with custom classNa
     class="custom-editor-class"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-testid="mdx-editor"
     markdown=""
   >
@@ -403,6 +413,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with custom classNa
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"
@@ -510,7 +525,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with default props 
     class="dark-theme cursor-auto"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-testid="mdx-editor"
     markdown=""
   >
@@ -546,6 +561,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with default props 
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"
@@ -653,7 +673,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with emoji picker o
     class="dark-theme cursor-auto"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-testid="mdx-editor"
     markdown=""
   >
@@ -689,6 +709,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with emoji picker o
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"
@@ -805,7 +830,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with markdown conte
     class="dark-theme cursor-auto"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-testid="mdx-editor"
     markdown="# Test Content"
   >
@@ -841,6 +866,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with markdown conte
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"
@@ -950,7 +980,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with reached max le
       class="dark-theme cursor-auto"
       data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
       data-placeholder="Start writing your masterpiece"
-      data-plugins-count="9"
+      data-plugins-count="10"
       data-testid="mdx-editor"
       markdown=""
     >
@@ -986,6 +1016,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with reached max le
           data-testid="insert-thematic-break"
         >
           Insert Break
+        </button>
+        <button
+          data-testid="create-link"
+        >
+          Create Link
         </button>
         <button
           data-testid="code-toggle"
@@ -1117,7 +1152,7 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with readOnly prop 
     class="dark-theme cursor-auto"
     data-content-editable-class="prose prose-neutral prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none px-0! pb-0! pt-4! max-h-[60dvh] overflow-y-auto"
     data-placeholder="Start writing your masterpiece"
-    data-plugins-count="9"
+    data-plugins-count="10"
     data-readonly="true"
     data-testid="mdx-editor"
     markdown=""
@@ -1154,6 +1189,11 @@ exports[`InitializedMDXEditor - Snapshots > matches snapshot with readOnly prop 
         data-testid="insert-thematic-break"
       >
         Insert Break
+      </button>
+      <button
+        data-testid="create-link"
+      >
+        Create Link
       </button>
       <button
         data-testid="code-toggle"

--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.tsx
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.tsx
@@ -9,9 +9,11 @@ import {
   codeBlockPlugin,
   codeMirrorPlugin,
   CodeToggle,
+  CreateLink,
   headingsPlugin,
   InsertCodeBlock,
   InsertThematicBreak,
+  linkDialogPlugin,
   linkPlugin,
   listsPlugin,
   ListsToggle,
@@ -235,6 +237,7 @@ export default function InitializedMDXEditor({
                 <StrikeThroughSupSubToggles options={['Strikethrough']} />
                 <ListsToggle options={['bullet', 'number']} />
                 <InsertThematicBreak />
+                <CreateLink />
                 <CodeToggle />
                 <InsertCodeBlock />
                 <ButtonWithTooltip title={t('emoji')} onClick={() => setShowEmojiPicker(true)}>
@@ -256,6 +259,7 @@ export default function InitializedMDXEditor({
           listsPlugin(),
           thematicBreakPlugin(),
           linkPlugin(),
+          linkDialogPlugin({ showLinkTitleField: false }),
           codeBlockPlugin({ defaultCodeBlockLanguage: 'plaintext' }),
           codeMirrorPlugin({
             codeBlockLanguages: CODE_BLOCK_LANGUAGES,

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -244,6 +244,25 @@ describe('PostText', () => {
 
         expect(handleParentClick).not.toHaveBeenCalled();
       });
+
+      it('calls onLinkClick handler when provided and link is clicked', () => {
+        const handleLinkClick = vi.fn();
+        render(<PostText content="Visit https://example.com" onLinkClick={handleLinkClick} />);
+
+        const link = screen.getByRole('link');
+        fireEvent.click(link);
+
+        expect(handleLinkClick).toHaveBeenCalledTimes(1);
+        expect(handleLinkClick).toHaveBeenCalledWith('https://example.com', expect.any(Object));
+      });
+
+      it('does not call onLinkClick when not provided', () => {
+        render(<PostText content="Visit https://example.com" />);
+
+        const link = screen.getByRole('link');
+        // Should not throw
+        fireEvent.click(link);
+      });
     });
 
     describe('Markdown links (disallowed)', () => {
@@ -429,6 +448,15 @@ describe('PostText', () => {
       // The isArticle prop only prevents the "Show more" button, not the truncation itself
       expect(container.textContent).toContain('...');
       expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+    });
+
+    it('allows markdown links when isArticle is true', () => {
+      render(<PostText content="Check out [example](https://example.com)" isArticle />);
+
+      const link = screen.getByRole('link');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveTextContent('example');
     });
   });
 

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -36,7 +36,7 @@ import { POST_ROUTES } from '@/app/routes';
  * Memoization prevents unnecessary re-renders when TTL refreshes update IndexedDB records
  * without changes to the actual post content.
  */
-export const PostText = memo(function PostText({ content, isArticle, className }: PostTextProps) {
+export const PostText = memo(function PostText({ content, isArticle, onLinkClick, className }: PostTextProps) {
   const pathname = usePathname();
 
   const contentTruncated =
@@ -46,7 +46,7 @@ export const PostText = memo(function PostText({ content, isArticle, className }
 
   const remarkPlugins = [
     remarkGfm,
-    remarkDisallowMarkdownLinks,
+    ...(isArticle ? [] : [remarkDisallowMarkdownLinks]),
     remarkPlaintextCodeblock,
     remarkHashtags,
     remarkMentions,
@@ -98,7 +98,13 @@ export const PostText = memo(function PostText({ content, isArticle, className }
                 {...rest}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+
+                  if (onLinkClick && rest.href) {
+                    onLinkClick(rest.href, e);
+                  }
+                }}
                 className={Libs.cn(className, 'cursor-pointer text-brand transition-colors hover:text-brand/80')}
               >
                 {children}

--- a/src/components/molecules/PostText/PostText.types.ts
+++ b/src/components/molecules/PostText/PostText.types.ts
@@ -1,9 +1,11 @@
+import type React from 'react';
 import { AnchorHTMLAttributes, ClassAttributes } from 'react';
 import { ExtraProps } from 'react-markdown';
 
 export interface PostTextProps {
   content: string;
   isArticle?: boolean;
+  onLinkClick?: (url: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
   className?: string;
 }
 

--- a/src/components/molecules/ProfilePageLinks/ProfilePageLinks.tsx
+++ b/src/components/molecules/ProfilePageLinks/ProfilePageLinks.tsx
@@ -1,22 +1,19 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import * as Atoms from '@/atoms';
 import * as Libs from '@/libs';
-import * as Core from '@/core';
 import * as Organisms from '@/organisms';
+import * as Hooks from '@/hooks';
 import { SETTINGS_ROUTES } from '@/app/routes';
 import type { ProfilePageLinksProps } from './ProfilePageLinks.types';
 
 export function ProfilePageLinks({ links, isOwnProfile = false }: ProfilePageLinksProps) {
   const t = useTranslations('profile.sidebar');
   const router = useRouter();
-  const { privacy } = Core.useSettingsStore();
-  const checkLinkEnabled = privacy.showConfirm;
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [clickedLink, setClickedLink] = useState('');
+  const { dialogOpen, setDialogOpen, clickedLink, handleLinkClick } = Hooks.useLinkConfirmation();
 
   const handleAddLinkClick = () => {
     router.push(SETTINGS_ROUTES.EDIT);
@@ -32,20 +29,6 @@ export function ProfilePageLinks({ links, isOwnProfile = false }: ProfilePageLin
       })) || [],
     [links],
   );
-
-  const handleLinkClick = (url: string, e: React.MouseEvent) => {
-    e.preventDefault();
-
-    // If link should bypass confirmation or checkLink is disabled, open directly
-    if (Libs.shouldBypassLinkConfirmation(url) || !checkLinkEnabled) {
-      window.open(url, '_blank', 'noopener,noreferrer');
-      return;
-    }
-
-    // Show dialog for external links
-    setClickedLink(url);
-    setDialogOpen(true);
-  };
 
   return (
     <>

--- a/src/components/organisms/DialogCheckLink/DialogCheckLink.test.tsx
+++ b/src/components/organisms/DialogCheckLink/DialogCheckLink.test.tsx
@@ -21,12 +21,14 @@ vi.mock('@/atoms', () => ({
     children,
     className,
     hiddenTitle,
+    onClick,
   }: {
     children: React.ReactNode;
     className?: string;
     hiddenTitle?: string;
+    onClick?: (e: React.MouseEvent) => void;
   }) => (
-    <div data-testid="dialog-content" className={className} data-hidden-title={hiddenTitle}>
+    <div data-testid="dialog-content" className={className} data-hidden-title={hiddenTitle} onClick={onClick}>
       {hiddenTitle && (
         <h2 className="sr-only" data-testid="dialog-hidden-title">
           {hiddenTitle}
@@ -238,6 +240,20 @@ describe('DialogCheckLink', () => {
     fireEvent.click(continueButton);
 
     expect(mockSetShowConfirm).toHaveBeenCalledWith(false);
+  });
+
+  it('stops event propagation when dialog content is clicked', () => {
+    const handleParentClick = vi.fn();
+    render(
+      <div onClick={handleParentClick}>
+        <DialogCheckLink {...defaultProps} />
+      </div>,
+    );
+
+    const dialogContent = screen.getByTestId('dialog-content');
+    fireEvent.click(dialogContent);
+
+    expect(handleParentClick).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/organisms/DialogCheckLink/DialogCheckLink.tsx
+++ b/src/components/organisms/DialogCheckLink/DialogCheckLink.tsx
@@ -40,7 +40,7 @@ export function DialogCheckLink({ open, onOpenChangeAction, linkUrl }: DialogChe
 
   return (
     <Atoms.Dialog open={open} onOpenChange={onOpenChangeAction}>
-      <Atoms.DialogContent className="w-2xl" hiddenTitle="Double-check this link">
+      <Atoms.DialogContent className="w-2xl" hiddenTitle="Double-check this link" onClick={(e) => e.stopPropagation()}>
         <Atoms.DialogHeader>
           <Atoms.DialogTitle>Double-check this link</Atoms.DialogTitle>
           <Atoms.DialogDescription>The link is taking you to another site:</Atoms.DialogDescription>

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx
@@ -6,10 +6,18 @@ import * as Core from '@/core';
 
 // Mock hooks
 const mockUsePostArticle = vi.fn();
+const mockHandleLinkClick = vi.fn();
+const mockSetDialogOpen = vi.fn();
 
 vi.mock('@/hooks', () => ({
   usePostArticle: (params: { content: string; attachments: string[]; coverImageVariant: Core.FileVariant }) =>
     mockUsePostArticle(params),
+  useLinkConfirmation: () => ({
+    dialogOpen: false,
+    setDialogOpen: mockSetDialogOpen,
+    clickedLink: '',
+    handleLinkClick: mockHandleLinkClick,
+  }),
 }));
 
 // Mock atoms
@@ -41,9 +49,38 @@ vi.mock('@/atoms', () => ({
 
 // Mock molecules
 vi.mock('@/molecules', () => ({
-  PostText: ({ content, isArticle, className }: { content: string; isArticle?: boolean; className?: string }) => (
-    <div data-testid="post-text" data-is-article={isArticle} className={className}>
+  PostText: ({
+    content,
+    isArticle,
+    onLinkClick,
+    className,
+  }: {
+    content: string;
+    isArticle?: boolean;
+    onLinkClick?: (url: string, e: React.MouseEvent) => void;
+    className?: string;
+  }) => (
+    <div data-testid="post-text" data-is-article={isArticle} data-has-link-click={!!onLinkClick} className={className}>
       {content}
+    </div>
+  ),
+}));
+
+// Mock organisms
+vi.mock('@/organisms', () => ({
+  DialogCheckLink: ({
+    open,
+    onOpenChangeAction,
+    linkUrl,
+  }: {
+    open: boolean;
+    onOpenChangeAction: (open: boolean) => void;
+    linkUrl: string;
+  }) => (
+    <div data-testid="dialog-check-link" data-open={open} data-link-url={linkUrl}>
+      <button data-testid="dialog-close" onClick={() => onOpenChangeAction(false)}>
+        Close
+      </button>
     </div>
   ),
 }));
@@ -136,6 +173,21 @@ describe('PostArticle', () => {
 
       const postText = screen.getByTestId('post-text');
       expect(postText).toHaveAttribute('data-is-article', 'true');
+    });
+
+    it('passes onLinkClick handler to PostText', () => {
+      render(<PostArticle {...defaultProps} />);
+
+      const postText = screen.getByTestId('post-text');
+      expect(postText).toHaveAttribute('data-has-link-click', 'true');
+    });
+
+    it('renders DialogCheckLink dialog', () => {
+      render(<PostArticle {...defaultProps} />);
+
+      const dialog = screen.getByTestId('dialog-check-link');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).toHaveAttribute('data-open', 'false');
     });
 
     it('applies muted-foreground class to PostText', () => {

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
@@ -33,6 +34,17 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
       src="https://example.com/cover-image.jpg"
       width="180"
     />
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;
@@ -56,6 +68,7 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
@@ -70,6 +83,17 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
       src="https://example.com/cover-image.jpg"
       width="180"
     />
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;
@@ -93,6 +117,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
@@ -107,6 +132,17 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
       src="blob:http://localhost/local-cover-image"
       width="180"
     />
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;
@@ -130,6 +166,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
@@ -144,6 +181,17 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
       src="https://example.com/cover-image.jpg"
       width="180"
     />
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;
@@ -167,6 +215,7 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
@@ -181,6 +230,17 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
       src="https://example.com/cover-image.jpg"
       width="180"
     />
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;
@@ -204,12 +264,24 @@ exports[`PostArticle > Snapshots > matches snapshot without cover image 1`] = `
       </span>
       <div
         class="text-muted-foreground"
+        data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
       >
         This is the article body content.
       </div>
     </div>
+  </div>
+  <div
+    data-link-url=""
+    data-open="false"
+    data-testid="dialog-check-link"
+  >
+    <button
+      data-testid="dialog-close"
+    >
+      Close
+    </button>
   </div>
 </div>
 `;

--- a/src/components/organisms/PostArticle/PostArticle.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.tsx
@@ -4,6 +4,7 @@ import type { PostDetailsModel } from '@/core';
 import type { AttachmentConstructed } from '../PostAttachments/PostAttachments.types';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
+import * as Organisms from '@/organisms';
 import * as Core from '@/core';
 import * as Libs from '@/libs';
 import * as Hooks from '@/hooks';
@@ -22,6 +23,8 @@ export const PostArticle = ({ content, attachments, localAttachments, className 
     coverImageVariant: Core.FileVariant.FEED,
   });
 
+  const { dialogOpen, setDialogOpen, clickedLink, handleLinkClick } = Hooks.useLinkConfirmation();
+
   const localCoverImage = localAttachments?.[0]?.type.startsWith('image')
     ? { src: localAttachments[0].urls.main, alt: localAttachments[0].name }
     : null;
@@ -29,24 +32,33 @@ export const PostArticle = ({ content, attachments, localAttachments, className 
   const finalCoverImage = localCoverImage || coverImage;
 
   return (
-    <Atoms.Container className={Libs.cn('justify-between gap-6 lg:flex-row', className)}>
-      <Atoms.Container className="gap-y-1">
-        <Atoms.Typography size="lg" className="wrap-anywhere hyphens-auto">
-          {title}
-        </Atoms.Typography>
+    <>
+      <Atoms.Container className={Libs.cn('justify-between gap-6 lg:flex-row', className)}>
+        <Atoms.Container className="gap-y-1">
+          <Atoms.Typography size="lg" className="wrap-anywhere hyphens-auto">
+            {title}
+          </Atoms.Typography>
 
-        <Molecules.PostText content={body} isArticle className="text-muted-foreground" />
+          <Molecules.PostText
+            content={body}
+            isArticle
+            onLinkClick={handleLinkClick}
+            className="text-muted-foreground"
+          />
+        </Atoms.Container>
+
+        {finalCoverImage && (
+          <Atoms.Image
+            src={finalCoverImage.src}
+            alt={finalCoverImage.alt}
+            className="h-25 w-45 rounded-md object-cover object-center"
+            width={180}
+            height={100}
+          />
+        )}
       </Atoms.Container>
 
-      {finalCoverImage && (
-        <Atoms.Image
-          src={finalCoverImage.src}
-          alt={finalCoverImage.alt}
-          className="h-25 w-45 rounded-md object-cover object-center"
-          width={180}
-          height={100}
-        />
-      )}
-    </Atoms.Container>
+      <Organisms.DialogCheckLink open={dialogOpen} onOpenChangeAction={setDialogOpen} linkUrl={clickedLink} />
+    </>
   );
 };

--- a/src/components/organisms/SinglePostArticle/SinglePostArticle.test.tsx
+++ b/src/components/organisms/SinglePostArticle/SinglePostArticle.test.tsx
@@ -11,6 +11,12 @@ vi.mock('@/hooks', async (importOriginal) => {
   return {
     ...actual,
     usePostArticle: vi.fn(),
+    useLinkConfirmation: vi.fn().mockReturnValue({
+      dialogOpen: false,
+      setDialogOpen: vi.fn(),
+      clickedLink: '',
+      handleLinkClick: vi.fn(),
+    }),
   };
 });
 
@@ -43,8 +49,16 @@ vi.mock('@/atoms', () => ({
 
 // Mock molecules
 vi.mock('@/molecules', () => ({
-  PostText: ({ content, isArticle }: { content: string; isArticle?: boolean }) => (
-    <div data-testid="post-text" data-is-article={isArticle}>
+  PostText: ({
+    content,
+    isArticle,
+    onLinkClick,
+  }: {
+    content: string;
+    isArticle?: boolean;
+    onLinkClick?: (url: string, e: React.MouseEvent) => void;
+  }) => (
+    <div data-testid="post-text" data-is-article={isArticle} data-has-link-click={!!onLinkClick}>
       {content}
     </div>
   ),
@@ -117,6 +131,21 @@ vi.mock('@/organisms', async (importOriginal) => {
       <div data-testid="dialog-repost" data-post-id={postId} data-open={open}>
         <button data-testid="close-repost-dialog" onClick={() => onOpenChangeAction(false)}>
           Close Repost
+        </button>
+      </div>
+    ),
+    DialogCheckLink: ({
+      open,
+      onOpenChangeAction,
+      linkUrl,
+    }: {
+      open: boolean;
+      onOpenChangeAction: (open: boolean) => void;
+      linkUrl: string;
+    }) => (
+      <div data-testid="dialog-check-link" data-open={open} data-link-url={linkUrl}>
+        <button data-testid="dialog-check-link-close" onClick={() => onOpenChangeAction(false)}>
+          Close Check Link
         </button>
       </div>
     ),
@@ -231,6 +260,14 @@ describe('SinglePostArticle', () => {
 
     expect(screen.getByTestId('dialog-reply')).toHaveAttribute('data-open', 'false');
     expect(screen.getByTestId('dialog-repost')).toHaveAttribute('data-open', 'false');
+    expect(screen.getByTestId('dialog-check-link')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('passes onLinkClick handler to PostText', () => {
+    render(<SinglePostArticle {...defaultProps} />);
+
+    const postText = screen.getByTestId('post-text');
+    expect(postText).toHaveAttribute('data-has-link-click', 'true');
   });
 
   describe('cover image', () => {

--- a/src/components/organisms/SinglePostArticle/SinglePostArticle.test.tsx.snap
+++ b/src/components/organisms/SinglePostArticle/SinglePostArticle.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`SinglePostArticle - Snapshots > matches snapshot with cover image 1`] =
       src="https://example.com/cover.jpg"
     />
     <div
+      data-has-link-click="true"
       data-is-article="true"
       data-testid="post-text"
     >
@@ -175,6 +176,7 @@ exports[`SinglePostArticle - Snapshots > matches snapshot with default props (no
       </button>
     </div>
     <div
+      data-has-link-click="true"
       data-is-article="true"
       data-testid="post-text"
     >

--- a/src/components/organisms/SinglePostArticle/SinglePostArticle.tsx
+++ b/src/components/organisms/SinglePostArticle/SinglePostArticle.tsx
@@ -46,6 +46,8 @@ export const SinglePostArticle = ({ postId, content, attachments, isBlurred }: S
     coverImageVariant: Core.FileVariant.MAIN,
   });
 
+  const { dialogOpen, setDialogOpen, clickedLink, handleLinkClick } = Hooks.useLinkConfirmation();
+
   const localAttachments = Core.useLocalFilesStore((s) => s.posts[postId]);
 
   const localCoverImage = localAttachments?.[0]?.type.startsWith('image')
@@ -81,7 +83,7 @@ export const SinglePostArticle = ({ postId, content, attachments, isBlurred }: S
                 <Atoms.Image src={finalCoverImage.src} alt={finalCoverImage.alt} className="mb-6 w-full rounded-md" />
               )}
 
-              <Molecules.PostText content={body} isArticle />
+              <Molecules.PostText content={body} isArticle onLinkClick={handleLinkClick} />
             </>
           )}
 
@@ -105,6 +107,7 @@ export const SinglePostArticle = ({ postId, content, attachments, isBlurred }: S
 
       <Organisms.DialogReply postId={postId} open={replyDialogOpen} onOpenChangeAction={setReplyDialogOpen} />
       <Organisms.DialogRepost postId={postId} open={repostDialogOpen} onOpenChangeAction={setRepostDialogOpen} />
+      <Organisms.DialogCheckLink open={dialogOpen} onOpenChangeAction={setDialogOpen} linkUrl={clickedLink} />
 
       <Atoms.Typography className="text-2xl font-light text-muted-foreground">Replies</Atoms.Typography>
     </>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -94,3 +94,4 @@ export * from './useCustomFeed';
 export * from './useCustomStreamId';
 export * from './useSettingsActions';
 export * from './useLocalFirstQuery';
+export * from './useLinkConfirmation';

--- a/src/hooks/useLinkConfirmation/index.ts
+++ b/src/hooks/useLinkConfirmation/index.ts
@@ -1,0 +1,1 @@
+export { useLinkConfirmation } from './useLinkConfirmation';

--- a/src/hooks/useLinkConfirmation/useLinkConfirmation.test.ts
+++ b/src/hooks/useLinkConfirmation/useLinkConfirmation.test.ts
@@ -1,0 +1,229 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defaultPrivacyPreferences } from '@/core/stores/settings/settings.types';
+import { useLinkConfirmation } from './useLinkConfirmation';
+
+const mockUseSettingsStore = vi.fn();
+
+vi.mock('@/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core')>();
+  return {
+    ...actual,
+    useSettingsStore: () => mockUseSettingsStore(),
+  };
+});
+
+const createMockEvent = () =>
+  ({
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+  }) as unknown as React.MouseEvent<HTMLAnchorElement>;
+
+describe('useLinkConfirmation', () => {
+  let windowOpenSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { hostname: 'localhost' },
+    });
+
+    mockUseSettingsStore.mockReturnValue({
+      privacy: { ...defaultPrivacyPreferences, showConfirm: true },
+    });
+  });
+
+  it('returns correct initial state', () => {
+    const { result } = renderHook(() => useLinkConfirmation());
+
+    expect(result.current.dialogOpen).toBe(false);
+    expect(result.current.clickedLink).toBe('');
+  });
+
+  describe('handleLinkClick with showConfirm enabled and external link', () => {
+    it('should prevent default behavior and stop propagation', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(mockEvent.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set clickedLink to the URL and open dialog', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(result.current.clickedLink).toBe('https://external-site.com');
+      expect(result.current.dialogOpen).toBe(true);
+    });
+
+    it('should NOT call window.open', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(windowOpenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleLinkClick with showConfirm disabled', () => {
+    beforeEach(() => {
+      mockUseSettingsStore.mockReturnValue({
+        privacy: { ...defaultPrivacyPreferences, showConfirm: false },
+      });
+    });
+
+    it('should prevent default behavior and stop propagation', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(mockEvent.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('should open the link directly via window.open', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(windowOpenSpy).toHaveBeenCalledWith('https://external-site.com', '_blank', 'noopener,noreferrer');
+    });
+
+    it('should NOT open the dialog', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://external-site.com', mockEvent);
+      });
+
+      expect(result.current.dialogOpen).toBe(false);
+      expect(result.current.clickedLink).toBe('');
+    });
+  });
+
+  describe('handleLinkClick with bypass protocols', () => {
+    it('should open mailto: links directly even when showConfirm is enabled', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('mailto:test@example.com', mockEvent);
+      });
+
+      expect(windowOpenSpy).toHaveBeenCalledWith('mailto:test@example.com', '_blank', 'noopener,noreferrer');
+      expect(result.current.dialogOpen).toBe(false);
+      expect(result.current.clickedLink).toBe('');
+    });
+
+    it('should open tel: links directly even when showConfirm is enabled', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('tel:+1234567890', mockEvent);
+      });
+
+      expect(windowOpenSpy).toHaveBeenCalledWith('tel:+1234567890', '_blank', 'noopener,noreferrer');
+      expect(result.current.dialogOpen).toBe(false);
+      expect(result.current.clickedLink).toBe('');
+    });
+  });
+
+  describe('handleLinkClick with same-domain URL', () => {
+    it('should open directly even when showConfirm is enabled', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://localhost/some-page', mockEvent);
+      });
+
+      expect(windowOpenSpy).toHaveBeenCalledWith('https://localhost/some-page', '_blank', 'noopener,noreferrer');
+      expect(result.current.dialogOpen).toBe(false);
+      expect(result.current.clickedLink).toBe('');
+    });
+  });
+
+  describe('handleLinkClick with different-domain URL when showConfirm is enabled', () => {
+    it('should show dialog instead of opening the link', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+      const mockEvent = createMockEvent();
+
+      act(() => {
+        result.current.handleLinkClick('https://different-domain.com/page', mockEvent);
+      });
+
+      expect(windowOpenSpy).not.toHaveBeenCalled();
+      expect(result.current.dialogOpen).toBe(true);
+      expect(result.current.clickedLink).toBe('https://different-domain.com/page');
+    });
+  });
+
+  describe('setDialogOpen', () => {
+    it('can toggle dialog state', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+
+      expect(result.current.dialogOpen).toBe(false);
+
+      act(() => {
+        result.current.setDialogOpen(true);
+      });
+
+      expect(result.current.dialogOpen).toBe(true);
+
+      act(() => {
+        result.current.setDialogOpen(false);
+      });
+
+      expect(result.current.dialogOpen).toBe(false);
+    });
+  });
+
+  describe('multiple clicks update clickedLink', () => {
+    it('clicking different links updates the stored URL', () => {
+      const { result } = renderHook(() => useLinkConfirmation());
+
+      act(() => {
+        result.current.handleLinkClick('https://first-external.com', createMockEvent());
+      });
+
+      expect(result.current.clickedLink).toBe('https://first-external.com');
+      expect(result.current.dialogOpen).toBe(true);
+
+      // Close the dialog, then click another link
+      act(() => {
+        result.current.setDialogOpen(false);
+      });
+
+      act(() => {
+        result.current.handleLinkClick('https://second-external.com', createMockEvent());
+      });
+
+      expect(result.current.clickedLink).toBe('https://second-external.com');
+      expect(result.current.dialogOpen).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useLinkConfirmation/useLinkConfirmation.ts
+++ b/src/hooks/useLinkConfirmation/useLinkConfirmation.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { useSettingsStore } from '@/core';
+import { shouldBypassLinkConfirmation } from '@/libs';
+
+interface UseLinkConfirmationReturn {
+  /** Whether the confirmation dialog is open */
+  dialogOpen: boolean;
+  /** Setter for dialogOpen state (passed to dialog's onOpenChangeAction) */
+  setDialogOpen: (open: boolean) => void;
+  /** The URL that was clicked (passed to the dialog) */
+  clickedLink: string;
+  /** Click handler for intercepting link clicks. Call this from the anchor's onClick. */
+  handleLinkClick: (url: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
+}
+
+/**
+ * Hook for managing external link confirmation dialog behavior.
+ *
+ * Reads the `privacy.showConfirm` setting from the settings store and
+ * provides a click handler that either opens links directly or shows a
+ * confirmation dialog for external links.
+ *
+ * Links that use bypass protocols (mailto:, tel:) or point to the same
+ * domain always open directly regardless of the setting.
+ *
+ * @returns Dialog state and a link click handler
+ *
+ * @example
+ * ```tsx
+ * const { dialogOpen, setDialogOpen, clickedLink, handleLinkClick } = useLinkConfirmation();
+ *
+ * // In your link's onClick:
+ * <a onClick={(e) => handleLinkClick(href, e)}>...</a>
+ *
+ * // Render the dialog:
+ * <DialogCheckLink open={dialogOpen} onOpenChangeAction={setDialogOpen} linkUrl={clickedLink} />
+ * ```
+ */
+export function useLinkConfirmation(): UseLinkConfirmationReturn {
+  const { privacy } = useSettingsStore();
+  const checkLinkEnabled = privacy.showConfirm;
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [clickedLink, setClickedLink] = useState('');
+
+  const handleLinkClick = (url: string, e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    // If link should bypass confirmation or setting is disabled, open directly
+    if (shouldBypassLinkConfirmation(url) || !checkLinkEnabled) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    // Show confirmation dialog for external links
+    setClickedLink(url);
+    setDialogOpen(true);
+  };
+
+  return {
+    dialogOpen,
+    setDialogOpen,
+    clickedLink,
+    handleLinkClick,
+  };
+}


### PR DESCRIPTION
## 🔗 Allow text as URLs in articles with redirect warning

Closes #1477

### Summary

This PR enables `[text](url)` Markdown link syntax in articles, adds a link insertion button to the rich text editor toolbar, and displays a redirect confirmation dialog when users click external links within article content.

### Changes

#### 🪝 New `useLinkConfirmation` Hook
- Extracted reusable link confirmation logic into a new `useLinkConfirmation` hook (`src/hooks/useLinkConfirmation/`)
- Encapsulates `dialogOpen`, `clickedLink` state, and `handleLinkClick` handler
- Reads the `privacy.showConfirm` setting from the settings store
- Bypasses confirmation for same-domain links and special protocols (`mailto:`, `tel:`)
- Refactored `ProfilePageLinks` to consume the new shared hook, removing duplicated logic

#### ✏️ Rich Text Editor — Link Support
- Added `CreateLink` toolbar button and `linkDialogPlugin` (with title field hidden) to the MDXEditor
- Added comprehensive dark mode CSS overrides for the MDXEditor link dialog popover (container, inputs, buttons, labels, arrow)

#### 📄 Article Link Rendering
- Conditionally removed `remarkDisallowMarkdownLinks` for article content, allowing `[text](url)` Markdown links to render as clickable anchors
- Added `onLinkClick` callback prop to `PostText` component, invoked when a rendered link is clicked
- Wired `useLinkConfirmation` + `DialogCheckLink` into both `PostArticle` (feed view) and `SinglePostArticle` (detail view)

#### 🛡️ Dialog Improvements
- Added `onClick` `stopPropagation` to `DialogCheckLink` content to prevent click events from bubbling through to parent post cards

### Related

- Closes https://github.com/pubky/pubky-app/issues/1477

### Screenshots

<img width="2321" height="1297" alt="image" src="https://github.com/user-attachments/assets/f2f1cab9-d71a-4fa3-a42d-a622eac52e27" />
<img width="2321" height="1297" alt="image" src="https://github.com/user-attachments/assets/6a897022-86bd-4812-ae92-29485b816c79" />
<img width="2321" height="1297" alt="image" src="https://github.com/user-attachments/assets/2a99e6ca-3c7c-458e-afab-ff0c43bdf100" />
<img width="2321" height="1297" alt="image" src="https://github.com/user-attachments/assets/3a0c5964-f69d-4468-9881-3f4ad768ce43" />
<img width="2321" height="1297" alt="image" src="https://github.com/user-attachments/assets/047cfe9f-d927-4441-b89f-543c8d986a87" />

### Testing

Tests have been created, updated, or deleted as necessary to reflect the changes:

- `src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx` (+ snapshot)
- `src/components/molecules/PostText/PostText.test.tsx`
- `src/components/organisms/DialogCheckLink/DialogCheckLink.test.tsx`
- `src/components/organisms/PostArticle/PostArticle.test.tsx` (+ snapshot)
- `src/components/organisms/SinglePostArticle/SinglePostArticle.test.tsx` (+ snapshot)
- `src/hooks/useLinkConfirmation/useLinkConfirmation.test.ts`

---

_This pull request summary was generated, for full implementation details please reference the file changes._
