### PR TITLE
fix(ui): prevent search tags from overflowing on mobile and desktop

### DIFF
--- a/src/components/molecules/Header/Header.test.tsx.snap
+++ b/src/components/molecules/Header/Header.test.tsx.snap
@@ -521,7 +521,7 @@ exports[`Header Components - Snapshots > matches snapshot for HeaderOnboarding 1
 
 exports[`Header Components - Snapshots > matches snapshot for HeaderSignIn 1`] = `
 <div
-  class="mx-auto w-full flex flex-1 flex-row items-center justify-end gap-3"
+  class="mx-auto w-full flex min-w-0 flex-1 flex-row items-center justify-end gap-3"
   data-testid="container"
 >
   <div

--- a/src/components/molecules/HeaderSignIn/HeaderSignIn.test.tsx.snap
+++ b/src/components/molecules/HeaderSignIn/HeaderSignIn.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HeaderSignIn - Snapshots > matches snapshot for default HeaderSignIn 1`] = `
 <div
-  class="flex-1 flex-row items-center justify-end gap-3"
+  class="min-w-0 flex-1 flex-row items-center justify-end gap-3"
 >
   <div
     data-testid="search-input"

--- a/src/components/molecules/HeaderSignIn/HeaderSignIn.tsx
+++ b/src/components/molecules/HeaderSignIn/HeaderSignIn.tsx
@@ -12,7 +12,7 @@ export const HeaderSignIn = ({ ...props }: React.HTMLAttributes<HTMLDivElement>)
   const unreadNotifications = Core.useNotificationStore((state) => state.selectUnread());
 
   return (
-    <Atoms.Container className="flex-1 flex-row items-center justify-end gap-3" {...props}>
+    <Atoms.Container className="min-w-0 flex-1 flex-row items-center justify-end gap-3" {...props}>
       <Organisms.SearchInput />
       <Molecules.HeaderNavigationButtons
         avatarImage={

--- a/src/components/molecules/SearchInputBar/SearchInputBar.test.tsx.snap
+++ b/src/components/molecules/SearchInputBar/SearchInputBar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - default state 1`] = `
 <div
-  class="relative flex h-12 items-center gap-3 border border-border px-6 py-3 rounded-full"
+  class="relative flex h-12 min-w-0 items-center gap-3 border border-border px-6 py-3 rounded-full"
   data-cy="header-search"
   data-testid="search-input-bar"
   style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
@@ -11,7 +11,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - defaul
     aria-autocomplete="list"
     aria-expanded="false"
     aria-label="Search input"
-    class="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base pl-0"
+    class="h-auto flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base min-w-20 pl-0"
     data-cy="header-search-input"
     placeholder="Search"
     type="text"
@@ -44,7 +44,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - defaul
 
 exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - focused state 1`] = `
 <div
-  class="relative flex h-12 items-center gap-3 border border-border px-6 py-3 rounded-t-2xl rounded-b-none border-b-transparent"
+  class="relative flex h-12 min-w-0 items-center gap-3 border border-border px-6 py-3 rounded-t-2xl rounded-b-none border-b-transparent"
   data-cy="header-search"
   data-testid="search-input-bar"
   style="background: linear-gradient(180deg, var(--background) 0%, var(--background) 100%);"
@@ -53,7 +53,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - focuse
     aria-autocomplete="list"
     aria-expanded="false"
     aria-label="Search input"
-    class="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base pl-0"
+    class="h-auto flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base min-w-20 pl-0"
     data-cy="header-search-input"
     placeholder="Search"
     type="text"
@@ -86,14 +86,14 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - focuse
 
 exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - with active tags 1`] = `
 <div
-  class="relative flex h-12 items-center gap-3 border border-border px-6 py-3 rounded-full"
+  class="relative flex h-12 min-w-0 items-center gap-3 border border-border px-6 py-3 rounded-full"
   data-cy="header-search"
   data-testid="search-input-bar"
   style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
 >
   <div
     aria-label="Active search tags"
-    class="flex shrink-0 items-center gap-2.5 py-2"
+    class="flex min-w-0 items-center gap-2.5 overflow-x-auto py-2"
     role="list"
   >
     <span
@@ -121,7 +121,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - with a
     aria-autocomplete="list"
     aria-expanded="false"
     aria-label="Search input"
-    class="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base pl-2.5"
+    class="h-auto flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base min-w-8 pl-2.5"
     data-cy="header-search-input"
     placeholder=""
     type="text"
@@ -154,7 +154,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - with a
 
 exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - with input value 1`] = `
 <div
-  class="relative flex h-12 items-center gap-3 border border-border px-6 py-3 rounded-full"
+  class="relative flex h-12 min-w-0 items-center gap-3 border border-border px-6 py-3 rounded-full"
   data-cy="header-search"
   data-testid="search-input-bar"
   style="background: linear-gradient(180deg, rgb(7, 4, 10) 0%, rgb(27, 24, 32) 100%); backdrop-filter: blur(20px);"
@@ -163,7 +163,7 @@ exports[`SearchInputBar > SearchInputBar - Snapshots > matches snapshot - with i
     aria-autocomplete="list"
     aria-expanded="false"
     aria-label="Search input"
-    class="h-auto min-w-20 flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base pl-0"
+    class="h-auto flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base min-w-20 pl-0"
     data-cy="header-search-input"
     placeholder="Search"
     type="text"

--- a/src/components/molecules/SearchInputBar/SearchInputBar.tsx
+++ b/src/components/molecules/SearchInputBar/SearchInputBar.tsx
@@ -29,7 +29,7 @@ export function SearchInputBar({
       data-testid="search-input-bar"
       data-cy="header-search"
       className={Libs.cn(
-        'relative flex h-12 items-center gap-3 border border-border px-6 py-3',
+        'relative flex h-12 min-w-0 items-center gap-3 border border-border px-6 py-3',
         isFocused ? 'rounded-t-2xl rounded-b-none border-b-transparent' : 'rounded-full',
       )}
       style={isFocused ? SEARCH_INPUT_EXPANDED_STYLE : SEARCH_CLOSED_STYLE}
@@ -38,12 +38,18 @@ export function SearchInputBar({
       {hasActiveTags && (
         <Atoms.Container
           overrideDefaults
-          className="flex shrink-0 items-center gap-2.5 py-2"
+          className="flex min-w-0 items-center gap-2.5 overflow-x-auto py-2"
           role="list"
           aria-label={t('activeTags')}
         >
           {activeTags.map((tag) => (
-            <Molecules.PostTag key={tag} label={tag} showClose onClose={() => onTagRemove(tag)} />
+            <Molecules.PostTag
+              key={tag}
+              label={tag}
+              showClose
+              onClose={() => onTagRemove(tag)}
+              className="max-w-none shrink-0"
+            />
           ))}
         </Atoms.Container>
       )}
@@ -65,8 +71,8 @@ export function SearchInputBar({
         aria-expanded={isExpanded}
         aria-haspopup={suggestionsId ? 'dialog' : undefined}
         className={Libs.cn(
-          'h-auto min-w-20 flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base',
-          hasActiveTags ? 'pl-2.5' : 'pl-0',
+          'h-auto flex-1 border-none bg-transparent pr-0 text-base font-medium text-foreground md:text-base',
+          hasActiveTags ? 'min-w-8 pl-2.5' : 'min-w-20 pl-0',
         )}
       />
 

--- a/src/components/organisms/SearchInput/SearchInput.test.tsx.snap
+++ b/src/components/organisms/SearchInput/SearchInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchInput > SearchInput - Snapshots > matches snapshot - default state 1`] = `
 <div
-  class="relative"
+  class="relative min-w-0"
   data-testid="search-input"
 >
   <div
@@ -26,7 +26,7 @@ exports[`SearchInput > SearchInput - Snapshots > matches snapshot - default stat
 
 exports[`SearchInput > SearchInput - Snapshots > matches snapshot - focused with suggestions 1`] = `
 <div
-  class="relative"
+  class="relative min-w-0"
   data-testid="search-input"
 >
   <div
@@ -72,7 +72,7 @@ exports[`SearchInput > SearchInput - Snapshots > matches snapshot - focused with
 
 exports[`SearchInput > SearchInput - Snapshots > matches snapshot - with active tags 1`] = `
 <div
-  class="relative"
+  class="relative min-w-0"
   data-testid="search-input"
 >
   <div

--- a/src/components/organisms/SearchInput/SearchInput.tsx
+++ b/src/components/organisms/SearchInput/SearchInput.tsx
@@ -83,7 +83,7 @@ export function SearchInput({ autoFocus = false }: SearchInputProps) {
   const suggestionsId = 'search-suggestions';
 
   return (
-    <Atoms.Container ref={containerRef} data-testid="search-input" className="relative">
+    <Atoms.Container ref={containerRef} data-testid="search-input" className="relative min-w-0">
       {/* Input bar with active tags */}
       <Molecules.SearchInputBar
         activeTags={activeTags}


### PR DESCRIPTION
## Summary
- fix #999
- Active search tags with longer values overflow the viewport on mobile and push the logo off-screen on desktop
- Tags now scroll horizontally within a contained search bar on both viewports

## Changes
- Replace `shrink-0` with `min-w-0 overflow-x-auto` on the active tags container in `SearchInputBar` to enable horizontal scrolling
- Add `shrink-0 max-w-none` to each `PostTag` inside the search bar so tags display at full width instead of truncating
- Reduce input `min-width` from `min-w-20` to `min-w-8` when tags are active to reclaim space
- Propagate `min-w-0` through the flex chain (`HeaderSignIn` → `SearchInput` → `SearchInputBar`) so the search bar respects parent width constraints on desktop

https://github.com/user-attachments/assets/10ed8444-f939-45c6-8b96-6da43e45d32d

## Test plan
- [ ] On mobile, search for 3 tags with long values — tags should be horizontally scrollable, not truncated or overflowing off-screen
- [ ] On desktop, search for 3 tags with long values — search bar should stay within the header, logo remains visible
- [ ] Verify single short tag still displays correctly without scroll on both mobile and desktop
- [ ] Verify search input is still tappable/focusable when tags are present

## Notes
- The global CSS already hides nested scrollbars, so the horizontal scroll area has no visible scrollbar