### PR TITLE
docs(privacy): disclose privacy-focused analytics (#1604)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Use `Err.*` factories (never raw `Error`). Factories log automatically — don't
 
 - Config constants in `src/config/` (e.g., `USER_LIST_TAGS_MAX_TOTAL_CHARS`, tag limits) are project-wide hard limits — do not modify them for individual component fixes
 - This project uses Zod v4 — use `z.url()` for URL validation, not the deprecated `z.string().url()`
+- PWA / service worker: Serwist via `@serwist/next` in `next.config` (core package `serwist`), not Workbox or `next-pwa`
 
 ## Documentation
 

--- a/src/components/organisms/DialogPrivacy/DialogPrivacy.test.tsx.snap
+++ b/src/components/organisms/DialogPrivacy/DialogPrivacy.test.tsx.snap
@@ -228,6 +228,12 @@ exports[`DialogPrivacy - Snapshots > matches snapshot for default DialogPrivacy 
             </strong>
              We may combine information that we collect offline with information we collect through our Platform. We may also combine information we collect about you from the different devices you use to access our Platform.
           </li>
+          <li>
+            <strong>
+              Privacy-Focused Analytics, to help operate, secure, and improve the Platform.
+            </strong>
+             We may use privacy-focused analytics service providers to measure aggregate usage of the Platform, such as page views, referral sources, device types, and general usage trends. Such services operate without advertising cookies or cross-site tracking.
+          </li>
         </ul>
         <p
           class="text-muted-foreground text-base font-normal"

--- a/src/components/organisms/DialogPrivacy/DialogPrivacy.tsx
+++ b/src/components/organisms/DialogPrivacy/DialogPrivacy.tsx
@@ -165,6 +165,12 @@ export function DialogPrivacy({ trigger }: DialogPrivacyProps) {
                 information we collect through our Platform. We may also combine information we collect about you from
                 the different devices you use to access our Platform.
               </li>
+              <li>
+                <strong>Privacy-Focused Analytics, to help operate, secure, and improve the Platform.</strong> We may
+                use privacy-focused analytics service providers to measure aggregate usage of the Platform, such as page
+                views, referral sources, device types, and general usage trends. Such services operate without
+                advertising cookies or cross-site tracking.
+              </li>
             </Atoms.List>
 
             {/** Section 6 */}


### PR DESCRIPTION
## Summary
- fix #1604
- Updates in-app Privacy Policy copy so users are informed before privacy-focused analytics (e.g. Plausible-style) is introduced.
- Records Serwist as the PWA stack in `AGENTS.md` for agent context (continual-learning).

## Changes
- Add a **HOW WE COLLECT YOUR INFORMATION** list item describing aggregate, privacy-focused analytics without ad cookies or cross-site tracking.
- Refresh `DialogPrivacy` Vitest snapshot.
- Add a **Learned Workspace Facts** bullet: PWA uses Serwist (`@serwist/next` / `serwist`), not Workbox or `next-pwa`.

## Test plan
- [ ] Open Privacy Policy from Settings (e.g. `/settings/account` sidebar) and confirm the new bullet appears under **HOW WE COLLECT YOUR INFORMATION**.
- [ ] `pnpm vitest run src/components/organisms/DialogPrivacy/DialogPrivacy.test.tsx`
- [ ] Not run (CI will cover full suite)

## Notes
- The `AGENTS.md` Serwist line is unrelated to #1604; drop that commit or revert that hunk if you want a PR scoped only to the privacy policy.