### PR TITLE
fix(notifications): resolve pubky mentions to user names in notification previews (#487)

### DIFF
--- a/src/components/molecules/PostText/PostText.utils.ts
+++ b/src/components/molecules/PostText/PostText.utils.ts
@@ -1,6 +1,7 @@
 import type { Root, Paragraph, Text, Link, PhrasingContent, Parent, RootContent } from 'mdast';
 import { ReactNode } from 'react';
 import { visit } from 'unist-util-visit';
+import { Identity } from '@/libs';
 import { TRUNCATION_LIMIT } from './PostText.constants';
 
 // We assign full code blocks without a language specified as plaintext (ex. ```...```)
@@ -154,7 +155,7 @@ export const remarkHashtags = createPatternPlugin({
 // Mention pattern: pk: or pubky followed by exactly 52 lowercase alphanumeric characters
 // Must be at start of text or preceded by whitespace (standalone)
 export const remarkMentions = createPatternPlugin({
-  regex: /(^|\s)((?:pk:|pubky)[a-z0-9]{52})/g,
+  regex: new RegExp(`(^|\\s)(${Identity.PUBKY_IDENTIFIER_WITH_PREFIX_SOURCE})`, 'g'),
   getUrl: (mention: string) => {
     // Extract the public key without the prefix (pk: or pubky)
     const publicKey = mention.startsWith('pk:') ? mention.slice(3) : mention.slice(5);

--- a/src/components/organisms/NotificationItem/NotificationItem.helpers.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.helpers.test.ts
@@ -32,7 +32,7 @@ describe('resolvePubkyToNames', () => {
     const result = await resolvePubkyToNames(`pk:${PUBKY_A} said hello`);
 
     expect(mockGetOrFetchDetails).toHaveBeenCalledWith({ userId: PUBKY_A });
-    expect(result).toBe('Alice said hello');
+    expect(result).toBe('@Alice said hello');
   });
 
   it('resolves pubky prefixed mention to user name', async () => {
@@ -41,7 +41,7 @@ describe('resolvePubkyToNames', () => {
     const result = await resolvePubkyToNames(`pubky${PUBKY_A} said hello`);
 
     expect(mockGetOrFetchDetails).toHaveBeenCalledWith({ userId: PUBKY_A });
-    expect(result).toBe('Bob said hello');
+    expect(result).toBe('@Bob said hello');
   });
 
   it('resolves multiple different mentions', async () => {
@@ -50,7 +50,7 @@ describe('resolvePubkyToNames', () => {
     const result = await resolvePubkyToNames(`pk:${PUBKY_A} and pubky${PUBKY_B} are friends`);
 
     expect(mockGetOrFetchDetails).toHaveBeenCalledTimes(2);
-    expect(result).toBe('Alice and Bob are friends');
+    expect(result).toBe('@Alice and @Bob are friends');
   });
 
   it('deduplicates repeated mentions and fetches each user only once', async () => {
@@ -61,7 +61,7 @@ describe('resolvePubkyToNames', () => {
     );
 
     expect(mockGetOrFetchDetails).toHaveBeenCalledTimes(2);
-    expect(result).toBe('Alice tagged Bob then Bob replied to Alice and Alice joined');
+    expect(result).toBe('@Alice tagged @Bob then @Bob replied to @Alice and @Alice joined');
   });
 
   it('keeps original mention when fetchDetails returns no name', async () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.helpers.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.helpers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolvePubkyToNames } from './NotificationItem.helpers';
+
+// Valid 52-char lowercase alphanumeric keys for testing
+const PUBKY_A = 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop';
+const PUBKY_B = 'zyxwvutsrqponmlkjihgfedcba9876543210zyxwvutsrqponmlk';
+
+const { mockGetOrFetchDetails } = vi.hoisted(() => ({
+  mockGetOrFetchDetails: vi.fn(),
+}));
+
+vi.mock('@/core/controllers/user/user', () => ({
+  UserController: {
+    getOrFetchDetails: mockGetOrFetchDetails,
+  },
+}));
+
+describe('resolvePubkyToNames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns content unchanged when there are no mentions', async () => {
+    const result = await resolvePubkyToNames('Hello world');
+    expect(result).toBe('Hello world');
+    expect(mockGetOrFetchDetails).not.toHaveBeenCalled();
+  });
+
+  it('resolves pk: prefixed mention to user name', async () => {
+    mockGetOrFetchDetails.mockResolvedValue({ name: 'Alice' });
+
+    const result = await resolvePubkyToNames(`pk:${PUBKY_A} said hello`);
+
+    expect(mockGetOrFetchDetails).toHaveBeenCalledWith({ userId: PUBKY_A });
+    expect(result).toBe('Alice said hello');
+  });
+
+  it('resolves pubky prefixed mention to user name', async () => {
+    mockGetOrFetchDetails.mockResolvedValue({ name: 'Bob' });
+
+    const result = await resolvePubkyToNames(`pubky${PUBKY_A} said hello`);
+
+    expect(mockGetOrFetchDetails).toHaveBeenCalledWith({ userId: PUBKY_A });
+    expect(result).toBe('Bob said hello');
+  });
+
+  it('resolves multiple different mentions', async () => {
+    mockGetOrFetchDetails.mockResolvedValueOnce({ name: 'Alice' }).mockResolvedValueOnce({ name: 'Bob' });
+
+    const result = await resolvePubkyToNames(`pk:${PUBKY_A} and pubky${PUBKY_B} are friends`);
+
+    expect(mockGetOrFetchDetails).toHaveBeenCalledTimes(2);
+    expect(result).toBe('Alice and Bob are friends');
+  });
+
+  it('deduplicates repeated mentions and fetches each user only once', async () => {
+    mockGetOrFetchDetails.mockResolvedValueOnce({ name: 'Alice' }).mockResolvedValueOnce({ name: 'Bob' });
+
+    const result = await resolvePubkyToNames(
+      `pk:${PUBKY_A} tagged pk:${PUBKY_B} then pk:${PUBKY_B} replied to pk:${PUBKY_A} and pk:${PUBKY_A} joined`,
+    );
+
+    expect(mockGetOrFetchDetails).toHaveBeenCalledTimes(2);
+    expect(result).toBe('Alice tagged Bob then Bob replied to Alice and Alice joined');
+  });
+
+  it('keeps original mention when fetchDetails returns no name', async () => {
+    mockGetOrFetchDetails.mockResolvedValue({ name: null });
+
+    const mention = `pk:${PUBKY_A}`;
+    const result = await resolvePubkyToNames(`${mention} said hello`);
+
+    expect(result).toBe(`${mention} said hello`);
+  });
+
+  it('keeps original mention when fetchDetails throws', async () => {
+    mockGetOrFetchDetails.mockRejectedValue(new Error('Network error'));
+
+    const mention = `pk:${PUBKY_A}`;
+    const result = await resolvePubkyToNames(`${mention} said hello`);
+
+    expect(result).toBe(`${mention} said hello`);
+  });
+});

--- a/src/components/organisms/NotificationItem/NotificationItem.helpers.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.helpers.ts
@@ -1,0 +1,53 @@
+import { Identity, Logger } from '@/libs';
+import { UserController } from '@/core/controllers/user/user';
+
+// Mention pattern: pk: or pubky followed by exactly 52 lowercase alphanumeric characters
+const mentionInTextRegex = new RegExp(`(^|\\s)(${Identity.PUBKY_IDENTIFIER_WITH_PREFIX_SOURCE})`, 'g');
+
+/**
+ * Replaces `pk:<key>` / `pubky<key>` tokens with display names when available.
+ * Keeps the original token when resolution fails.
+ */
+export async function resolvePubkyToNames(content: string): Promise<string> {
+  if (!content) return content;
+
+  // 1) Scan for mention-like tokens (same boundary rule as `remarkMentions`).
+  const mentions = new Set<string>();
+  for (const match of content.matchAll(mentionInTextRegex)) {
+    // Regex: (^|\s)(pk:abc... | pubkyabc...)
+    // match[0] = " pk:abc..."   — full match including leading whitespace
+    // match[1] = " "            — leading boundary (start-of-string or whitespace)
+    // match[2] = "pk:abc..."    — mention token without boundary
+    mentions.add(match[2]);
+  }
+
+  // 2) Fast-path: nothing to resolve.
+  if (mentions.size === 0) return content;
+
+  // 3) Resolve each mention to a display name (local-first; falls back to original mention on failure).
+  const resolvedPairs = await Promise.all(
+    [...mentions].map(async (mention) => {
+      const key = Identity.extractPubkyPublicKey(mention);
+      if (!key) return null;
+
+      try {
+        const details = await UserController.getOrFetchDetails({ userId: key });
+        return details?.name ? { mention, name: details.name } : null;
+      } catch (error) {
+        Logger.debug('Failed to resolve mention', { mention, error });
+        return null;
+      }
+    }),
+  );
+
+  // 4) Build an O(1) lookup map from mention token to display name.
+  const mentionToName = new Map<string, string>();
+  for (const pair of resolvedPairs) {
+    if (pair) mentionToName.set(pair.mention, pair.name);
+  }
+
+  // 5) Replace mentions while preserving the captured leading boundary (start/whitespace).
+  return content.replace(mentionInTextRegex, (_full, leading: string, mention: string) => {
+    return leading + (mentionToName.get(mention) ?? mention);
+  });
+}

--- a/src/components/organisms/NotificationItem/NotificationItem.helpers.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.helpers.ts
@@ -48,6 +48,6 @@ export async function resolvePubkyToNames(content: string): Promise<string> {
 
   // 5) Replace mentions while preserving the captured leading boundary (start/whitespace).
   return content.replace(mentionInTextRegex, (_full, leading: string, mention: string) => {
-    return leading + (mentionToName.get(mention) ?? mention);
+    return leading + (mentionToName.has(mention) ? `@${mentionToName.get(mention)}` : mention);
   });
 }

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -22,6 +22,7 @@ import {
   formatPreviewText,
   hasPostPreview,
 } from './NotificationItem.utils';
+import { resolvePubkyToNames } from './NotificationItem.helpers';
 import type { NotificationItemProps } from './NotificationItem.types';
 
 export function NotificationItem({ notification, isUnread }: NotificationItemProps) {
@@ -63,7 +64,7 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     // 2. If missing, fetch from Nexus
     // 3. Write to local DB
     Core.PostController.getOrFetch({ compositeId: postCompositeId, viewerId })
-      .then((post) => {
+      .then(async (post) => {
         if (!isCancelled && post?.content) {
           if (Libs.isPostDeleted(post.content)) {
             setPostContent(tPost('deleted'));
@@ -79,7 +80,8 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
               });
             }
           } else {
-            setPostContent(post.content);
+            const content = await resolvePubkyToNames(post.content);
+            if (!isCancelled) setPostContent(content);
           }
         }
       })

--- a/src/libs/identity/identity.ts
+++ b/src/libs/identity/identity.ts
@@ -6,6 +6,9 @@ import { Err, ErrorService, ValidationErrorCode, ServerErrorCode, ClientErrorCod
 import type { TMnemonicWords, TCreateRecoveryFileParams, TDecryptRecoveryFileParams } from './identity.types';
 
 export class Identity {
+  // Mention pattern: pk: or pubky followed by exactly 52 lowercase alphanumeric characters
+  static readonly PUBKY_IDENTIFIER_WITH_PREFIX_SOURCE = '(?:pk:|pubky)[a-z0-9]{52}';
+
   /**
    * Creates and downloads a recovery file for the keypair
    * @param keypair - The keypair to create the recovery file for


### PR DESCRIPTION
## Description
 - Add `resolvePubkyToNames` helper that replaces `pk:/pubky` in notification post previews with display names
  - Resolve mentions async when loading notification post content in NotificationItem
  - Add unit tests for `resolvePubkyToNames` (empty input, both prefixes, multiple mentions, deduplication, fallback on failure)
  - Extract shared mention regex source (`PUBKY_IDENTIFIER_WITH_PREFIX_SOURCE`) to Identity class, reuse in `remarkMentions`

## Result
<img width="1281" height="902" alt="Screenshot 2026-03-31 at 12 25 13" src="https://github.com/user-attachments/assets/ab0da27a-135e-4fc3-af93-84a94b9a125c" />
