### PR TITLE
fix(ui): align right-sidebar layout with Figma design

### DIFF
--- a/src/components/organisms/ActiveUsers/ActiveUsers.constants.ts
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.constants.ts
@@ -1,1 +1,0 @@
-export const USERS_LIMIT = 3;

--- a/src/components/organisms/ActiveUsers/ActiveUsers.test.tsx
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.test.tsx
@@ -133,3 +133,61 @@ describe('ActiveUsers', () => {
     });
   });
 });
+
+describe('ActiveUsers - Snapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooksMocks.useUserStream.mockReset();
+  });
+
+  it('matches snapshot when loading', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [],
+      userIds: [],
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<ActiveUsers />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with users', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [
+        { id: 'user-1', name: 'User One', image: null, avatarUrl: null, isFollowing: false },
+        { id: 'user-2', name: 'User Two', image: null, avatarUrl: null, isFollowing: true },
+      ],
+      userIds: ['user-1', 'user-2'],
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<ActiveUsers />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot when empty', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [],
+      userIds: [],
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<ActiveUsers />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/ActiveUsers/ActiveUsers.test.tsx.snap
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.test.tsx.snap
@@ -1,0 +1,661 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ActiveUsers - Snapshots > matches snapshot when empty 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-2"
+  data-testid="active-users"
+>
+  <div
+    class="flex w-full items-center justify-between"
+    data-testid="container"
+  >
+    <h2
+      class="text-2xl font-light text-muted-foreground"
+      data-testid="heading-2"
+    >
+      Active users
+    </h2>
+  </div>
+  <div
+    class="flex w-full min-w-0 flex-col gap-2"
+    data-testid="container"
+  >
+    <p
+      class="text-base font-light text-muted-foreground"
+      data-testid="typography"
+    >
+      No users to show
+    </p>
+  </div>
+  <button
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-white hover:bg-neutral-800 h-8 gap-1.5 px-3 has-[>svg]:px-2.5 w-full border-border bg-white/5 text-xs font-bold"
+    data-size="sm"
+    data-slot="button"
+    data-variant="dark-outline"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-users-round size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 21a8 8 0 0 0-16 0"
+      />
+      <circle
+        cx="10"
+        cy="8"
+        r="5"
+      />
+      <path
+        d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
+      />
+    </svg>
+    See all
+  </button>
+</div>
+`;
+
+exports[`ActiveUsers - Snapshots > matches snapshot when loading 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-2"
+  data-testid="active-users"
+>
+  <div
+    class="flex w-full items-center justify-between"
+    data-testid="container"
+  >
+    <h2
+      class="text-2xl font-light text-muted-foreground"
+      data-testid="heading-2"
+    >
+      Active users
+    </h2>
+  </div>
+  <div
+    class="flex w-full min-w-0 flex-col gap-2"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-white hover:bg-neutral-800 h-8 gap-1.5 px-3 has-[>svg]:px-2.5 w-full border-border bg-white/5 text-xs font-bold"
+    data-size="sm"
+    data-slot="button"
+    data-variant="dark-outline"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-users-round size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 21a8 8 0 0 0-16 0"
+      />
+      <circle
+        cx="10"
+        cy="8"
+        r="5"
+      />
+      <path
+        d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
+      />
+    </svg>
+    See all
+  </button>
+</div>
+`;
+
+exports[`ActiveUsers - Snapshots > matches snapshot with users 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-2"
+  data-testid="active-users"
+>
+  <div
+    class="flex w-full items-center justify-between"
+    data-testid="container"
+  >
+    <h2
+      class="text-2xl font-light text-muted-foreground"
+      data-testid="heading-2"
+    >
+      Active users
+    </h2>
+  </div>
+  <div
+    class="flex w-full min-w-0 flex-col gap-2"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full items-center gap-2"
+      data-testid="user-list-item-user-1"
+    >
+      <button
+        aria-label="View User One's profile"
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+        data-slot="button"
+      >
+        <span
+          class="relative flex overflow-hidden rounded-full h-8 w-8 shrink-0"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(252, 0, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 71 23"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 3.5s ease-in-out 1.5s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="8"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="0"
+                      y="8"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 3.5s ease-in-out 1.5s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="55.2"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="47.3"
+                      y="8"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+        <div
+          class="flex min-w-0 flex-1 flex-col"
+          data-testid="container"
+        >
+          <span
+            class="truncate text-sm font-bold text-foreground"
+            data-testid="typography"
+          >
+            User One
+          </span>
+          <div
+            class="flex items-center gap-3 text-xs font-medium tracking-[1.2px] text-muted-foreground"
+            data-testid="container"
+          >
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-tag size-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
+                />
+                <circle
+                  cx="7.5"
+                  cy="7.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+              </svg>
+              <span
+                data-testid="typography"
+              >
+                0
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-sticky-note size-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+                />
+                <path
+                  d="M15 3v5a1 1 0 0 0 1 1h5"
+                />
+              </svg>
+              <span
+                data-testid="typography"
+              >
+                0
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        aria-label="Follow User One"
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-slot="button"
+        data-variant="secondary"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-user-round-plus size-5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 21a8 8 0 0 1 13.292-6"
+          />
+          <circle
+            cx="10"
+            cy="8"
+            r="5"
+          />
+          <path
+            d="M19 16v6"
+          />
+          <path
+            d="M22 19h-6"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="flex w-full items-center gap-2"
+      data-testid="user-list-item-user-2"
+    >
+      <button
+        aria-label="View User Two's profile"
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+        data-slot="button"
+      >
+        <span
+          class="relative flex overflow-hidden rounded-full h-8 w-8 shrink-0"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 63 15"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 4.4s ease-in-out 2.4s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="55.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 4.4s ease-in-out 2.4s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="7.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+        <div
+          class="flex min-w-0 flex-1 flex-col"
+          data-testid="container"
+        >
+          <span
+            class="truncate text-sm font-bold text-foreground"
+            data-testid="typography"
+          >
+            User Two
+          </span>
+          <div
+            class="flex items-center gap-3 text-xs font-medium tracking-[1.2px] text-muted-foreground"
+            data-testid="container"
+          >
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-tag size-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
+                />
+                <circle
+                  cx="7.5"
+                  cy="7.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+              </svg>
+              <span
+                data-testid="typography"
+              >
+                0
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-sticky-note size-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+                />
+                <path
+                  d="M15 3v5a1 1 0 0 0 1 1h5"
+                />
+              </svg>
+              <span
+                data-testid="typography"
+              >
+                0
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        aria-label="Unfollow User Two"
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-slot="button"
+        data-variant="secondary"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-check size-5 group-hover:hidden"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 6 9 17l-5-5"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-user-minus hidden size-5 group-hover:block"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"
+          />
+          <circle
+            cx="9"
+            cy="7"
+            r="4"
+          />
+          <line
+            x1="22"
+            x2="16"
+            y1="11"
+            y2="11"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <button
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-white hover:bg-neutral-800 h-8 gap-1.5 px-3 has-[>svg]:px-2.5 w-full border-border bg-white/5 text-xs font-bold"
+    data-size="sm"
+    data-slot="button"
+    data-variant="dark-outline"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-users-round size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 21a8 8 0 0 0-16 0"
+      />
+      <circle
+        cx="10"
+        cy="8"
+        r="5"
+      />
+      <path
+        d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
+      />
+    </svg>
+    See all
+  </button>
+</div>
+`;

--- a/src/components/organisms/ActiveUsers/ActiveUsers.tsx
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.tsx
@@ -47,7 +47,7 @@ export function ActiveUsers({ className }: ActiveUsersProps) {
   return (
     <Molecules.SidebarSection
       title={t('activeUsers')}
-      footerIcon={Libs.Users}
+      footerIcon={Libs.UsersRound}
       footerText={tCommon('seeAll')}
       onFooterClick={handleSeeAll}
       className={className}

--- a/src/components/organisms/ActiveUsers/ActiveUsers.tsx
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.tsx
@@ -9,8 +9,7 @@ import * as Libs from '@/libs';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
 import { APP_ROUTES } from '@/app/routes';
-import type { ActiveUsersProps } from './ActiveUsers.types';
-import { USERS_LIMIT } from './ActiveUsers.constants';
+const USERS_LIMIT = 3;
 
 /**
  * ActiveUsers
@@ -20,7 +19,7 @@ import { USERS_LIMIT } from './ActiveUsers.constants';
  *
  * Note: This is an Organism because it interacts with Core via hooks (useUserStream, useFollowUser).
  */
-export function ActiveUsers({ className }: ActiveUsersProps) {
+export function ActiveUsers() {
   const t = useTranslations('sidebar');
   const tCommon = useTranslations('common');
   const router = useRouter();
@@ -50,7 +49,6 @@ export function ActiveUsers({ className }: ActiveUsersProps) {
       footerIcon={Libs.UsersRound}
       footerText={tCommon('seeAll')}
       onFooterClick={handleSeeAll}
-      className={className}
       data-testid="active-users"
     >
       {isStreamLoading ? (

--- a/src/components/organisms/ActiveUsers/ActiveUsers.types.ts
+++ b/src/components/organisms/ActiveUsers/ActiveUsers.types.ts
@@ -1,3 +1,0 @@
-export interface ActiveUsersProps {
-  className?: string;
-}

--- a/src/components/organisms/ActiveUsers/index.ts
+++ b/src/components/organisms/ActiveUsers/index.ts
@@ -1,2 +1,1 @@
 export * from './ActiveUsers';
-export * from './ActiveUsers.types';

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -180,7 +180,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
                     </>
                   ) : (
                     <>
-                      <Icons.UserPlus className="size-4" />
+                      <Icons.UserRoundPlus className="size-4" />
                       {t('follow')}
                     </>
                   )}

--- a/src/components/organisms/UserListItem/UserListItem.test.tsx
+++ b/src/components/organisms/UserListItem/UserListItem.test.tsx
@@ -163,3 +163,32 @@ describe('UserListItem - followButtonVariant', () => {
     expect(screen.getByText('Me')).toBeInTheDocument();
   });
 });
+
+describe('UserListItem - Snapshots', () => {
+  it('matches snapshot for compact variant', () => {
+    const { container } = render(<UserListItem user={mockUser} variant="compact" onFollowClick={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for compact variant with stats', () => {
+    const { container } = render(<UserListItem user={mockUser} variant="compact" showStats onFollowClick={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for compact variant when following', () => {
+    const { container } = render(
+      <UserListItem user={{ ...mockUser, isFollowing: true }} variant="compact" onFollowClick={vi.fn()} />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for compact variant as current user', () => {
+    const { container } = render(<UserListItem user={mockUser} variant="compact" isCurrentUser />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for full variant', () => {
+    const { container } = render(<UserListItem user={mockUser} variant="full" onFollowClick={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/UserListItem/UserListItem.test.tsx
+++ b/src/components/organisms/UserListItem/UserListItem.test.tsx
@@ -57,9 +57,11 @@ vi.mock('@/libs', () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
   Check: (props: Record<string, unknown>) => <svg data-testid="check-icon" {...props} />,
   UserMinus: (props: Record<string, unknown>) => <svg data-testid="user-minus-icon" {...props} />,
-  UserPlus: (props: Record<string, unknown>) => <svg data-testid="user-plus-icon" {...props} />,
   UserRoundPlus: (props: Record<string, unknown>) => <svg data-testid="user-round-plus-icon" {...props} />,
   CircleUserRound: (props: Record<string, unknown>) => <svg data-testid="circle-user-round" {...props} />,
+  Tag: (props: Record<string, unknown>) => <svg data-testid="tag-icon" {...props} />,
+  StickyNote: (props: Record<string, unknown>) => <svg data-testid="sticky-note-icon" {...props} />,
+  Loader2: (props: Record<string, unknown>) => <svg data-testid="loader-icon" {...props} />,
 }));
 
 // Mock Core

--- a/src/components/organisms/UserListItem/UserListItem.test.tsx.snap
+++ b/src/components/organisms/UserListItem/UserListItem.test.tsx.snap
@@ -1,0 +1,306 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UserListItem - Snapshots > matches snapshot for compact variant 1`] = `
+<div
+  class="flex w-full items-center gap-2"
+  data-testid="user-list-item-test-user-pubky-123456"
+>
+  <button
+    aria-label="View Test User's profile"
+    class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+  >
+    <div
+      data-testid="avatar"
+    />
+    <div
+      class="flex min-w-0 flex-1 flex-col"
+    >
+      <span
+        class="truncate text-sm font-bold text-foreground"
+      >
+        Test User
+      </span>
+      <span
+        class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+      >
+        pk:test-use
+      </span>
+    </div>
+  </button>
+  <button
+    aria-label="Follow Test User"
+    class="group size-8 shrink-0 rounded-full"
+    data-cy="user-list-item-follow-toggle-btn"
+    data-size="icon"
+    data-variant="secondary"
+  >
+    <svg
+      class="size-5"
+      data-testid="user-round-plus-icon"
+    />
+  </button>
+</div>
+`;
+
+exports[`UserListItem - Snapshots > matches snapshot for compact variant as current user 1`] = `
+<div
+  class="flex w-full items-center gap-2"
+  data-testid="user-list-item-test-user-pubky-123456"
+>
+  <button
+    aria-label="View Test User's profile"
+    class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+  >
+    <div
+      data-testid="avatar"
+    />
+    <div
+      class="flex min-w-0 flex-1 flex-col"
+    >
+      <span
+        class="truncate text-sm font-bold text-foreground"
+      >
+        Test User
+      </span>
+      <span
+        class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+      >
+        pk:test-use
+      </span>
+    </div>
+  </button>
+  <button
+    aria-label="This is you"
+    class="size-8 shrink-0 cursor-not-allowed rounded-full opacity-50"
+    data-cy="user-list-item-me-btn"
+    data-size="icon"
+    data-variant="secondary"
+    disabled=""
+  >
+    <svg
+      class="size-5 text-muted-foreground"
+      data-testid="circle-user-round"
+    />
+  </button>
+</div>
+`;
+
+exports[`UserListItem - Snapshots > matches snapshot for compact variant when following 1`] = `
+<div
+  class="flex w-full items-center gap-2"
+  data-testid="user-list-item-test-user-pubky-123456"
+>
+  <button
+    aria-label="View Test User's profile"
+    class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+  >
+    <div
+      data-testid="avatar"
+    />
+    <div
+      class="flex min-w-0 flex-1 flex-col"
+    >
+      <span
+        class="truncate text-sm font-bold text-foreground"
+      >
+        Test User
+      </span>
+      <span
+        class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+      >
+        pk:test-use
+      </span>
+    </div>
+  </button>
+  <button
+    aria-label="Unfollow Test User"
+    class="group size-8 shrink-0 rounded-full"
+    data-cy="user-list-item-follow-toggle-btn"
+    data-size="icon"
+    data-variant="secondary"
+  >
+    <svg
+      class="size-5 group-hover:hidden"
+      data-testid="check-icon"
+    />
+    <svg
+      class="hidden size-5 group-hover:block"
+      data-testid="user-minus-icon"
+    />
+  </button>
+</div>
+`;
+
+exports[`UserListItem - Snapshots > matches snapshot for compact variant with stats 1`] = `
+<div
+  class="flex w-full items-center gap-2"
+  data-testid="user-list-item-test-user-pubky-123456"
+>
+  <button
+    aria-label="View Test User's profile"
+    class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+  >
+    <div
+      data-testid="avatar"
+    />
+    <div
+      class="flex min-w-0 flex-1 flex-col"
+    >
+      <span
+        class="truncate text-sm font-bold text-foreground"
+      >
+        Test User
+      </span>
+      <div
+        class="flex items-center gap-3 text-xs font-medium tracking-[1.2px] text-muted-foreground"
+      >
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            class="size-3"
+            data-testid="tag-icon"
+          />
+          <span>
+            5
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            class="size-3"
+            data-testid="sticky-note-icon"
+          />
+          <span>
+            10
+          </span>
+        </div>
+      </div>
+    </div>
+  </button>
+  <button
+    aria-label="Follow Test User"
+    class="group size-8 shrink-0 rounded-full"
+    data-cy="user-list-item-follow-toggle-btn"
+    data-size="icon"
+    data-variant="secondary"
+  >
+    <svg
+      class="size-5"
+      data-testid="user-round-plus-icon"
+    />
+  </button>
+</div>
+`;
+
+exports[`UserListItem - Snapshots > matches snapshot for full variant 1`] = `
+<div
+  class="gap-3 rounded-md bg-card p-6 lg:bg-transparent lg:p-0"
+  data-testid="user-list-item-test-user-pubky-123456"
+>
+  <div
+    class="flex flex-wrap items-center justify-between gap-6 lg:flex-nowrap"
+  >
+    <a
+      class="flex min-w-0 flex-1 items-center gap-2"
+      href="/profile/test-user-pubky-123456"
+    >
+      <div
+        data-testid="avatar"
+      />
+      <div
+        class="min-w-0 flex-1 truncate"
+      >
+        <span
+          class="truncate font-bold"
+          data-cy="profile-follower-item-name"
+        >
+          Test User
+        </span>
+        <span
+          class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+        >
+          pk:test-use
+        </span>
+      </div>
+    </a>
+    <div
+      data-testid="tags-list"
+    />
+    <div
+      class="flex shrink-0 items-center gap-3"
+    >
+      <div
+        class="items-start"
+      >
+        <span
+          class="text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+        >
+          TAGS
+        </span>
+        <span
+          class="font-bold"
+          data-cy="profile-follower-item-tags-count"
+        >
+          5
+        </span>
+      </div>
+      <div
+        class="items-start"
+      >
+        <span
+          class="text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+        >
+          POSTS
+        </span>
+        <span
+          class="font-bold"
+          data-cy="profile-follower-item-posts-count"
+        >
+          10
+        </span>
+      </div>
+    </div>
+    <div
+      class="hidden lg:flex"
+    >
+      <button
+        aria-label="Follow Test User"
+        class="group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-variant="secondary"
+      >
+        <svg
+          class="size-5"
+          data-testid="user-round-plus-icon"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="flex flex-wrap items-center gap-3 lg:hidden"
+  >
+    <div
+      data-testid="tags-list"
+    />
+    <div
+      class="ml-auto"
+    >
+      <button
+        aria-label="Follow Test User"
+        class="group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-variant="secondary"
+      >
+        <svg
+          class="size-5"
+          data-testid="user-round-plus-icon"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/organisms/UserListItem/UserListItem.tsx
+++ b/src/components/organisms/UserListItem/UserListItem.tsx
@@ -47,7 +47,7 @@ function FollowButton({ isFollowing, isLoading, isStatusLoading, displayName, va
             <Libs.UserMinus className="hidden size-5 group-hover:block" />
           </>
         ) : (
-          <Libs.UserPlus className="size-5" />
+          <Libs.UserRoundPlus className="size-5" />
         )}
       </Atoms.Button>
     );
@@ -136,15 +136,18 @@ function MeButton({ variant = 'icon', className }: { variant?: 'iconWithText' | 
  */
 function StatsSubtitle({ tags, posts }: StatsSubtitleProps) {
   return (
-    <Atoms.Container overrideDefaults className="flex items-center gap-2 text-sm text-muted-foreground">
+    <Atoms.Container
+      overrideDefaults
+      className="flex items-center gap-3 text-xs font-medium tracking-[1.2px] text-muted-foreground"
+    >
       <Atoms.Container overrideDefaults className="flex items-center gap-1">
-        <Libs.Tag className="size-3.5" />
+        <Libs.Tag className="size-3" />
         <Atoms.Typography as="span" overrideDefaults>
           {tags}
         </Atoms.Typography>
       </Atoms.Container>
       <Atoms.Container overrideDefaults className="flex items-center gap-1">
-        <Libs.StickyNote className="size-3.5" />
+        <Libs.StickyNote className="size-3" />
         <Atoms.Typography as="span" overrideDefaults>
           {posts}
         </Atoms.Typography>
@@ -230,14 +233,14 @@ function CompactVariant({
     <Atoms.Container
       ref={ttlRef}
       overrideDefaults
-      className={Libs.cn('flex w-full items-center gap-3', className)}
+      className={Libs.cn('flex w-full items-center gap-2', className)}
       data-testid={dataTestId || `user-list-item-${user.id}`}
     >
       {/* Clickable user area */}
       <Atoms.Button
         overrideDefaults
         onClick={onUserClick}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left transition-opacity hover:opacity-80"
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
         aria-label={`View ${displayName}'s profile`}
       >
         <Organisms.AvatarWithFallback
@@ -249,13 +252,17 @@ function CompactVariant({
         />
 
         <Atoms.Container overrideDefaults className="flex min-w-0 flex-1 flex-col">
-          <Atoms.Typography as="span" overrideDefaults className="truncate text-base font-bold text-foreground">
+          <Atoms.Typography as="span" overrideDefaults className="truncate text-sm font-bold text-foreground">
             {displayName}
           </Atoms.Typography>
           {showStats ? (
             <StatsSubtitle tags={stats.tags} posts={stats.posts} />
           ) : (
-            <Atoms.Typography as="span" overrideDefaults className="truncate text-sm text-muted-foreground uppercase">
+            <Atoms.Typography
+              as="span"
+              overrideDefaults
+              className="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+            >
               {formattedPublicKey}
             </Atoms.Typography>
           )}

--- a/src/components/organisms/WhoToFollow/WhoToFollow.constants.ts
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.constants.ts
@@ -1,1 +1,0 @@
-export const USERS_LIMIT = 3;

--- a/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WhoToFollow } from './WhoToFollow';
+
+const hooksMocks = vi.hoisted(() => ({
+  useUserStream: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual('@/hooks');
+  return {
+    ...actual,
+    useUserStream: hooksMocks.useUserStream,
+    useFollowUser: () => ({
+      toggleFollow: vi.fn(),
+      isUserLoading: () => false,
+    }),
+  };
+});
+
+describe('WhoToFollow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooksMocks.useUserStream.mockReset();
+  });
+
+  it('shows loading skeletons while stream is loading', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [],
+      userIds: [],
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    render(<WhoToFollow />);
+
+    expect(screen.getAllByTestId('user-list-item-skeleton-compact')).toHaveLength(3);
+  });
+
+  it('should display users when stream returns user details', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [
+        { id: 'user-1', name: 'User One', image: null, avatarUrl: null, isFollowing: false },
+        { id: 'user-2', name: 'User Two', image: null, avatarUrl: null, isFollowing: false },
+        { id: 'user-3', name: 'User Three', image: null, avatarUrl: null, isFollowing: false },
+      ],
+      userIds: ['user-1', 'user-2', 'user-3'],
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    render(<WhoToFollow />);
+
+    expect(screen.getByText('User One')).toBeInTheDocument();
+    expect(screen.getByText('User Two')).toBeInTheDocument();
+    expect(screen.getByText('User Three')).toBeInTheDocument();
+  });
+});
+
+describe('WhoToFollow - Snapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooksMocks.useUserStream.mockReset();
+  });
+
+  it('matches snapshot when loading', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [],
+      userIds: [],
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<WhoToFollow />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with users', () => {
+    hooksMocks.useUserStream.mockReturnValue({
+      users: [
+        { id: 'user-1', name: 'User One', image: null, avatarUrl: null, isFollowing: false },
+        { id: 'user-2', name: 'User Two', image: null, avatarUrl: null, isFollowing: true },
+      ],
+      userIds: ['user-1', 'user-2'],
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      error: null,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<WhoToFollow />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx.snap
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx.snap
@@ -1,0 +1,478 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`WhoToFollow - Snapshots > matches snapshot when loading 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-2"
+  data-cy="who-to-follow"
+  data-testid="who-to-follow"
+>
+  <div
+    class="flex w-full items-center justify-between"
+    data-testid="container"
+  >
+    <h2
+      class="text-2xl font-light text-muted-foreground"
+      data-testid="heading-2"
+    >
+      Who to follow
+    </h2>
+  </div>
+  <div
+    class="flex w-full min-w-0 flex-col gap-2"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="flex w-full items-center gap-3"
+      data-testid="user-list-item-skeleton-compact"
+    >
+      <div
+        class="animate-pulse bg-muted size-10 shrink-0 rounded-full"
+        data-slot="skeleton"
+      />
+      <div
+        class="flex min-w-0 flex-1 flex-col gap-2"
+        data-testid="container"
+      >
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[150px] rounded-md"
+          data-slot="skeleton"
+        />
+        <div
+          class="animate-pulse bg-muted h-4 w-full max-w-[130px] rounded-md"
+          data-slot="skeleton"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-white hover:bg-neutral-800 h-8 gap-1.5 px-3 has-[>svg]:px-2.5 w-full border-border bg-white/5 text-xs font-bold"
+    data-cy="who-to-follow-see-all"
+    data-size="sm"
+    data-slot="button"
+    data-variant="dark-outline"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-users-round size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 21a8 8 0 0 0-16 0"
+      />
+      <circle
+        cx="10"
+        cy="8"
+        r="5"
+      />
+      <path
+        d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
+      />
+    </svg>
+    See all
+  </button>
+</div>
+`;
+
+exports[`WhoToFollow - Snapshots > matches snapshot with users 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-2"
+  data-cy="who-to-follow"
+  data-testid="who-to-follow"
+>
+  <div
+    class="flex w-full items-center justify-between"
+    data-testid="container"
+  >
+    <h2
+      class="text-2xl font-light text-muted-foreground"
+      data-testid="heading-2"
+    >
+      Who to follow
+    </h2>
+  </div>
+  <div
+    class="flex w-full min-w-0 flex-col gap-2"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full items-center gap-2"
+      data-testid="user-list-item-user-1"
+    >
+      <button
+        aria-label="View User One's profile"
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+        data-slot="button"
+      >
+        <span
+          class="relative flex overflow-hidden rounded-full h-8 w-8 shrink-0"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(252, 0, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(-15deg) rotateY(15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 71 23"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 3.5s ease-in-out 1.5s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="8"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="0"
+                      y="8"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 3.5s ease-in-out 1.5s infinite; transform-origin: center center;"
+                  >
+                    <rect
+                      fill="currentColor"
+                      height="23"
+                      rx="3.5"
+                      width="7"
+                      x="55.2"
+                      y="0"
+                    />
+                    <rect
+                      fill="currentColor"
+                      height="7"
+                      rx="3.5"
+                      width="23"
+                      x="47.3"
+                      y="8"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+        <div
+          class="flex min-w-0 flex-1 flex-col"
+          data-testid="container"
+        >
+          <span
+            class="truncate text-sm font-bold text-foreground"
+            data-testid="typography"
+          >
+            User One
+          </span>
+          <span
+            class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+            data-testid="typography"
+          >
+            user-1
+          </span>
+        </div>
+      </button>
+      <button
+        aria-label="Follow User One"
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-slot="button"
+        data-variant="secondary"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-user-round-plus size-5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 21a8 8 0 0 1 13.292-6"
+          />
+          <circle
+            cx="10"
+            cy="8"
+            r="5"
+          />
+          <path
+            d="M19 16v6"
+          />
+          <path
+            d="M22 19h-6"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="flex w-full items-center gap-2"
+      data-testid="user-list-item-user-2"
+    >
+      <button
+        aria-label="View User Two's profile"
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left transition-opacity hover:opacity-80"
+        data-slot="button"
+      >
+        <span
+          class="relative flex overflow-hidden rounded-full h-8 w-8 shrink-0"
+        >
+          <span
+            class="flex h-full w-full items-center justify-center rounded-full border border-muted-foreground bg-muted overflow-hidden border-none"
+          >
+            <div
+              class="facehash h-full w-full rounded-full text-background"
+              data-facehash=""
+              data-interactive="true"
+              style="width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; container-type: size; perspective: 300px; transform-style: preserve-3d; background-color: rgb(0, 75, 255);"
+            >
+              <div
+                data-facehash-gradient=""
+                style="position: absolute; inset: 0px; pointer-events: none; z-index: 1; background: radial-gradient(100% 100% at 50% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 60%);"
+              />
+              <div
+                data-facehash-face=""
+                style="position: absolute; inset: 0px; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 2; transform: rotateX(15deg) rotateY(-15deg) translateZ(12px); transform-style: preserve-3d; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  style="width: 60%; height: auto; max-width: 90%; max-height: 40%;"
+                  viewBox="0 0 63 15"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    style="animation: facehash-blink 4.4s ease-in-out 2.4s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="55.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                  <g
+                    style="animation: facehash-blink 4.4s ease-in-out 2.4s infinite; transform-origin: center center;"
+                  >
+                    <circle
+                      cx="7.2"
+                      cy="7.2"
+                      fill="currentColor"
+                      r="7.2"
+                    />
+                  </g>
+                </svg>
+                <div
+                  data-facehash-mouth=""
+                  style="margin-top: 8%; display: flex; align-items: center; justify-content: center;"
+                >
+                  <span
+                    data-testid="avatar-fallback-initial"
+                    style="font-size: 26cqw; line-height: 1;"
+                  >
+                    U
+                  </span>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+        <div
+          class="flex min-w-0 flex-1 flex-col"
+          data-testid="container"
+        >
+          <span
+            class="truncate text-sm font-bold text-foreground"
+            data-testid="typography"
+          >
+            User Two
+          </span>
+          <span
+            class="truncate text-xs font-medium tracking-[1.2px] text-muted-foreground uppercase"
+            data-testid="typography"
+          >
+            user-2
+          </span>
+        </div>
+      </button>
+      <button
+        aria-label="Unfollow User Two"
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent group size-8 shrink-0 rounded-full"
+        data-cy="user-list-item-follow-toggle-btn"
+        data-size="icon"
+        data-slot="button"
+        data-variant="secondary"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-check size-5 group-hover:hidden"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 6 9 17l-5-5"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-user-minus hidden size-5 group-hover:block"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"
+          />
+          <circle
+            cx="9"
+            cy="7"
+            r="4"
+          />
+          <line
+            x1="22"
+            x2="16"
+            y1="11"
+            y2="11"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <button
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-white hover:bg-neutral-800 h-8 gap-1.5 px-3 has-[>svg]:px-2.5 w-full border-border bg-white/5 text-xs font-bold"
+    data-cy="who-to-follow-see-all"
+    data-size="sm"
+    data-slot="button"
+    data-variant="dark-outline"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-users-round size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 21a8 8 0 0 0-16 0"
+      />
+      <circle
+        cx="10"
+        cy="8"
+        r="5"
+      />
+      <path
+        d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
+      />
+    </svg>
+    See all
+  </button>
+</div>
+`;

--- a/src/components/organisms/WhoToFollow/WhoToFollow.tsx
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.tsx
@@ -8,8 +8,7 @@ import * as Libs from '@/libs';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
 import { APP_ROUTES } from '@/app/routes';
-import type { WhoToFollowProps } from './WhoToFollow.types';
-import { USERS_LIMIT } from './WhoToFollow.constants';
+const USERS_LIMIT = 3;
 
 /**
  * WhoToFollow
@@ -19,7 +18,7 @@ import { USERS_LIMIT } from './WhoToFollow.constants';
  *
  * Note: This is an Organism because it interacts with Core via hooks (useUserStream, useFollowUser).
  */
-export function WhoToFollow({ className }: WhoToFollowProps) {
+export function WhoToFollow() {
   const t = useTranslations('sidebar');
   const tCommon = useTranslations('common');
   const router = useRouter();
@@ -48,7 +47,6 @@ export function WhoToFollow({ className }: WhoToFollowProps) {
       footerIcon={Libs.UsersRound}
       footerText={tCommon('seeAll')}
       onFooterClick={handleSeeAll}
-      className={className}
       dataCy="who-to-follow"
       footerDataCy="who-to-follow-see-all"
       data-testid="who-to-follow"

--- a/src/components/organisms/WhoToFollow/WhoToFollow.tsx
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.tsx
@@ -45,7 +45,7 @@ export function WhoToFollow({ className }: WhoToFollowProps) {
   return (
     <Molecules.SidebarSection
       title={t('whoToFollow')}
-      footerIcon={Libs.Users}
+      footerIcon={Libs.UsersRound}
       footerText={tCommon('seeAll')}
       onFooterClick={handleSeeAll}
       className={className}

--- a/src/components/organisms/WhoToFollow/WhoToFollow.types.ts
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.types.ts
@@ -1,3 +1,0 @@
-export interface WhoToFollowProps {
-  className?: string;
-}

--- a/src/components/organisms/WhoToFollow/index.ts
+++ b/src/components/organisms/WhoToFollow/index.ts
@@ -1,2 +1,1 @@
 export * from './WhoToFollow';
-export * from './WhoToFollow.types';


### PR DESCRIPTION
## Summary

Resolves #1611 — aligns the right-sidebar "Who to follow" and "Active users" sections with the Figma spec.

- **Typography**: compact user name from `text-base` to `text-sm` (14px); pubky key and stats subtitle to label style (`text-xs font-medium tracking-[1.2px]`); stat icons from `size-3.5` to `size-3`
- **Spacing**: outer container and inner button gap from `gap-3` to `gap-2` (8px); stats inter-group gap from `gap-2` to `gap-3`
- **Icons**: "See all" footer icons to round variants (`UsersRound`); compact follow button and profile header follow button to `UserRoundPlus`
- **Cleanup**: remove unused `className` prop and types files from `WhoToFollow`/`ActiveUsers`; inline single-use `USERS_LIMIT` constants; delete 4 redundant files
- **Tests**: add snapshot tests for `WhoToFollow`, `ActiveUsers`, and `UserListItem` (10 new snapshots)

## Before
<img width="1265" height="1164" alt="Screenshot 2026-03-31 at 17 11 03" src="https://github.com/user-attachments/assets/4a818e2e-b7fb-467d-803a-01a4fafa90a3" />


## After
<img width="1277" height="1105" alt="Screenshot 2026-03-31 at 17 10 29" src="https://github.com/user-attachments/assets/3255e1a7-3584-4d4c-800b-d6fcc063035d" />

