### PR TITLE
fix(stream): reset pagination queue on initial load (#1543)

### DIFF
--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -1439,6 +1439,14 @@ describe('PostStreamApplication', () => {
   });
 
   describe('prepareStreamForInitialLoad', () => {
+    it('should clear pagination queue before preparing the stream', async () => {
+      const removeSpy = vi.spyOn(postStreamQueue, 'remove');
+
+      await Core.PostStreamApplication.prepareStreamForInitialLoad({ streamId });
+
+      expect(removeSpy).toHaveBeenCalledWith(streamId);
+    });
+
     it('should clear both streams when main stream cache is stale', async () => {
       const now = BASE_TIMESTAMP + Config.STREAM_CACHE_MAX_AGE_MS + 10;
       const staleTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS - 1;

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -95,6 +95,9 @@ export class PostStreamApplication {
    * @param streamId - The ID of the stream to prepare
    */
   static async prepareStreamForInitialLoad({ streamId }: Core.TStreamIdParams): Promise<void> {
+    // Initial loads and pull-to-refresh should start from the real stream head,
+    // not reuse buffered overflow from a previous pagination session.
+    postStreamQueue.remove(streamId);
     const now = Date.now();
 
     // 1. Check if main stream cache is stale


### PR DESCRIPTION
Clear the buffered post stream queue before preparing the stream so pull-to-refresh and remounts start from the real head instead of reusing overflow from earlier pagination.

https://github.com/user-attachments/assets/46b9a414-d2db-4af3-aefe-5852892df10f


Resolves #1543 and #1133 and #1298