### PR TITLE
fix(users): invalidate recommended stream cache on follow

### DIFF
--- a/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.test.tsx
@@ -10,6 +10,7 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
+  usePathname: () => '/home',
 }));
 
 vi.mock('@/hooks', async () => {

--- a/src/components/organisms/WhoToFollow/WhoToFollow.tsx
+++ b/src/components/organisms/WhoToFollow/WhoToFollow.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useEffect, useRef } from 'react';
 import * as Core from '@/core';
 import * as Hooks from '@/hooks';
 import * as Libs from '@/libs';
@@ -22,12 +23,25 @@ export function WhoToFollow() {
   const t = useTranslations('sidebar');
   const tCommon = useTranslations('common');
   const router = useRouter();
-  const { users, isLoading: isStreamLoading } = Hooks.useUserStream({
+  const pathname = usePathname();
+  const {
+    users,
+    isLoading: isStreamLoading,
+    refetch,
+  } = Hooks.useUserStream({
     streamId: Core.UserStreamTypes.RECOMMENDED,
     limit: USERS_LIMIT,
     includeRelationships: true,
   });
   const { toggleFollow, isUserLoading } = Hooks.useFollowUser();
+
+  const prevPathnameRef = useRef(pathname);
+  useEffect(() => {
+    if (prevPathnameRef.current !== pathname) {
+      prevPathnameRef.current = pathname;
+      void refetch();
+    }
+  }, [pathname, refetch]);
 
   const handleUserClick = (pubky: Core.Pubky) => {
     router.push(`${APP_ROUTES.PROFILE}/${pubky}`);

--- a/src/core/services/local/follow/follow.ts
+++ b/src/core/services/local/follow/follow.ts
@@ -223,6 +223,11 @@ export class LocalFollowService {
       );
     }
 
+    // Invalidate recommended stream so next mount fetches fresh suggestions
+    if (isFollowing) {
+      ops.push(Core.LocalStreamUsersService.deleteById(Core.UserStreamTypes.RECOMMENDED));
+    }
+
     // Invalidate timeline caches
     ops.push(this.invalidateTimelineStreams({ includeFriends: friendshipChanged, activeStreamId }));
 


### PR DESCRIPTION
Clear the recommended:all:all user stream from IndexedDB when a user is followed so the Who to Follow card shows fresh suggestions on next mount.

Made-with: Cursor