### PR TITLE
fix(timeline): hide soft-deleted posts from main feed

### DIFF
--- a/src/components/organisms/Timeline/Posts/Posts.test.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import { useLiveQuery } from 'dexie-react-hooks';
+import * as Core from '@/core';
+import type { UsePostDetailsResult } from '@/hooks';
 import { TimelinePosts } from './Posts';
 import * as Hooks from '@/hooks';
 
@@ -36,6 +38,7 @@ vi.mock('@/hooks', async (importOriginal) => {
   return {
     ...actual,
     usePostNavigation: vi.fn(),
+    usePostDetails: vi.fn(),
   };
 });
 vi.mock('@/libs', async () => {
@@ -108,6 +111,17 @@ const mockPush = vi.fn();
 const mockUseLiveQuery = vi.mocked(useLiveQuery);
 const mockUseRouter = vi.mocked(useRouter);
 const mockUsePostNavigation = vi.mocked(Hooks.usePostNavigation);
+const mockUsePostDetails = vi.mocked(Hooks.usePostDetails);
+
+function defaultPostDetailsMock(compositeId: string | null | undefined): UsePostDetailsResult {
+  return {
+    postDetails:
+      compositeId != null
+        ? ({ id: compositeId, content: 'timeline test post body' } as Core.EnrichedPostDetails)
+        : undefined,
+    isLoading: false,
+  };
+}
 
 const mockPostIds = ['author1:post1', 'author2:post2', 'author3:post3'];
 describe('TimelinePosts', () => {
@@ -128,6 +142,8 @@ describe('TimelinePosts', () => {
     mockUsePostNavigation.mockReturnValue({
       navigateToPost: mockPush,
     });
+
+    mockUsePostDetails.mockImplementation(defaultPostDetailsMock);
 
     // Mock useLiveQuery to return no replies by default
     mockUseLiveQuery.mockReturnValue({ id: 'test', replies: 0, tags: 0, unique_tags: 0, reposts: 0 });
@@ -343,6 +359,59 @@ describe('TimelinePosts', () => {
       await waitFor(() => {
         const posts = container.querySelectorAll('[data-testid^="post-"]');
         expect(posts).toHaveLength(mockPostIds.length);
+      });
+    });
+  });
+
+  describe('Soft-deleted posts (feed guard)', () => {
+    it('does not render PostMain or inline replies when details content is [DELETED]', async () => {
+      mockUsePostDetails.mockImplementation((compositeId) => {
+        if (compositeId === 'author:soft-deleted') {
+          return {
+            postDetails: { content: '[DELETED]' } as Core.EnrichedPostDetails,
+            isLoading: false,
+          };
+        }
+        return defaultPostDetailsMock(compositeId);
+      });
+
+      render(
+        <TimelinePosts
+          postIds={['author:soft-deleted', 'author1:post1']}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={true}
+          loadMore={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('post-author:soft-deleted')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('replies-author:soft-deleted')).not.toBeInTheDocument();
+        expect(screen.getByTestId('post-author1:post1')).toBeInTheDocument();
+      });
+    });
+
+    it('still renders the row while post details are unresolved (loading)', async () => {
+      mockUsePostDetails.mockImplementation(() => ({
+        postDetails: undefined,
+        isLoading: true,
+      }));
+
+      render(
+        <TimelinePosts
+          postIds={['author:pending']}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={true}
+          loadMore={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('post-author:pending')).toBeInTheDocument();
       });
     });
   });
@@ -575,6 +644,8 @@ describe('TimelinePosts - Snapshots', () => {
     mockUsePostNavigation.mockReturnValue({
       navigateToPost: mockPush,
     });
+
+    mockUsePostDetails.mockImplementation(defaultPostDetailsMock);
 
     // Mock useLiveQuery
     mockUseLiveQuery.mockReturnValue({ id: 'test', replies: 0, tags: 0, unique_tags: 0, reposts: 0 });

--- a/src/components/organisms/Timeline/Posts/Posts.test.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.test.tsx
@@ -393,7 +393,7 @@ describe('TimelinePosts', () => {
       });
     });
 
-    it('still renders the row while post details are unresolved (loading)', async () => {
+    it('does not render PostMain while post details are unresolved (loading)', async () => {
       mockUsePostDetails.mockImplementation(() => ({
         postDetails: undefined,
         isLoading: true,
@@ -411,7 +411,7 @@ describe('TimelinePosts', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('post-author:pending')).toBeInTheDocument();
+        expect(screen.queryByTestId('post-author:pending')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/organisms/Timeline/Posts/Posts.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.tsx
@@ -28,9 +28,9 @@ const virtuosoComponents = { Footer: TimelineVirtuosoFooter };
 /**
  * Extracted from Virtuoso's `itemContent` callback so hooks are valid: hooks must run
  * only at the top level of a React component (or custom hook), not inside plain
- * render callbacks. Here we need `usePostDetails` / `usePostNavigation` to hide
- * soft-deleted feed items once details resolve (stream filter is fail-open when
- * details are not cached yet).
+ * render callbacks. `usePostDetails` gates each row: render nothing until details exist,
+ * then hide soft-deleted items (`[DELETED]`). The stream list itself can still contain
+ * ids before details are cached; rows stay empty until local-first details resolve.
  */
 function TimelinePostItem({ postId, tagsLayout }: { postId: string; tagsLayout?: TagsLayout }) {
   const { navigateToPost } = Hooks.usePostNavigation();

--- a/src/components/organisms/Timeline/Posts/Posts.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.tsx
@@ -37,7 +37,7 @@ function TimelinePostItem({ postId, tagsLayout }: { postId: string; tagsLayout?:
   const { postDetails } = Hooks.usePostDetails(postId);
   const isDeleted = Libs.isPostDeleted(postDetails?.content);
 
-  if (isDeleted) return null;
+  if (!postDetails || isDeleted) return null;
 
   return (
     <Atoms.Container data-cy="post-card" overrideDefaults className="pb-4">

--- a/src/components/organisms/Timeline/Posts/Posts.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.tsx
@@ -2,6 +2,7 @@
 
 import { Virtuoso } from 'react-virtuoso';
 import { TIMELINE_VIRTUOSO_OVERSCAN_PX } from '@/config';
+import * as Libs from '@/libs';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
@@ -25,6 +26,33 @@ interface TimelinePostsProps {
 const virtuosoComponents = { Footer: TimelineVirtuosoFooter };
 
 /**
+ * Extracted from Virtuoso's `itemContent` callback so hooks are valid: hooks must run
+ * only at the top level of a React component (or custom hook), not inside plain
+ * render callbacks. Here we need `usePostDetails` / `usePostNavigation` to hide
+ * soft-deleted feed items once details resolve (stream filter is fail-open when
+ * details are not cached yet).
+ */
+function TimelinePostItem({ postId, tagsLayout }: { postId: string; tagsLayout?: TagsLayout }) {
+  const { navigateToPost } = Hooks.usePostNavigation();
+  const { postDetails } = Hooks.usePostDetails(postId);
+  const isDeleted = Libs.isPostDeleted(postDetails?.content);
+
+  if (isDeleted) return null;
+
+  return (
+    <Atoms.Container data-cy="post-card" overrideDefaults className="pb-4">
+      <Organisms.PostMain
+        postId={postId}
+        onClick={() => navigateToPost(postId)}
+        isReply={false}
+        tagsLayout={tagsLayout}
+      />
+      <Organisms.TimelinePostReplies postId={postId} />
+    </Atoms.Container>
+  );
+}
+
+/**
  * TimelinePosts
  *
  * Virtualized timeline that only mounts posts near the viewport.
@@ -40,8 +68,6 @@ export function TimelinePosts({
   loadMore,
   tagsLayout,
 }: TimelinePostsProps) {
-  const { navigateToPost } = Hooks.usePostNavigation();
-
   const virtuosoContext: TimelineVirtuosoContext = {
     loadingMore,
     error,
@@ -64,17 +90,7 @@ export function TimelinePosts({
                 void loadMore();
               }
             }}
-            itemContent={(_index, postId) => (
-              <Atoms.Container data-cy="post-card" overrideDefaults className="pb-4">
-                <Organisms.PostMain
-                  postId={postId}
-                  onClick={() => navigateToPost(postId)}
-                  isReply={false}
-                  tagsLayout={tagsLayout}
-                />
-                <Organisms.TimelinePostReplies postId={postId} />
-              </Atoms.Container>
-            )}
+            itemContent={(_index, postId) => <TimelinePostItem postId={postId} tagsLayout={tagsLayout} />}
             components={virtuosoComponents}
           />
         </Atoms.Container>


### PR DESCRIPTION
Extract `TimelinePostItem` so `usePostDetails` runs at component level (not inside Virtuoso `itemContent`). Gated rows: render nothing until local post details exist, then hide rows whose content is `[DELETED]`.

Unit tests cover deleted vs loading (no `postDetails`) vs visible posts.

Resolves: #1541