### PR TITLE
feat: add this_week timeframe filter

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1072,6 +1072,7 @@
     "timeframe": {
       "title": "الفترة الزمنية",
       "today": "اليوم",
+      "thisWeek": "هذا الأسبوع",
       "thisMonth": "هذا الشهر",
       "allTime": "كل الاوقات"
     }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "Zeitraum",
       "today": "Heute",
+      "thisWeek": "Diese Woche",
       "thisMonth": "Diesen Monat",
       "allTime": "Alle Zeit"
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1072,6 +1072,7 @@
     "timeframe": {
       "title": "Timeframe",
       "today": "Today",
+      "thisWeek": "This Week",
       "thisMonth": "This Month",
       "allTime": "All Time"
     }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "Periodo",
       "today": "Hoy",
+      "thisWeek": "Esta semana",
       "thisMonth": "Este mes",
       "allTime": "Todo el tiempo"
     }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "Periode",
       "today": "Aujourd'hui",
+      "thisWeek": "Cette semaine",
       "thisMonth": "Ce mois-ci",
       "allTime": "Tout le temps"
     }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "Periodo",
       "today": "Oggi",
+      "thisWeek": "Questa settimana",
       "thisMonth": "Questo mese",
       "allTime": "Sempre"
     }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "期間",
       "today": "今日",
+      "thisWeek": "今週",
       "thisMonth": "今月",
       "allTime": "全期間"
     }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1078,6 +1078,7 @@
     "timeframe": {
       "title": "Periodo",
       "today": "Hoje",
+      "thisWeek": "Esta semana",
       "thisMonth": "Este Mes",
       "allTime": "Todo o Tempo"
     }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1072,6 +1072,7 @@
     "timeframe": {
       "title": "时间范围",
       "today": "今天",
+      "thisWeek": "本周",
       "thisMonth": "本月",
       "allTime": "全部时间"
     }

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx
@@ -7,6 +7,7 @@ import * as Core from '@/core';
 vi.mock('@/core', () => ({
   TIMEFRAME: {
     TODAY: 'today',
+    THIS_WEEK: 'this_week',
     THIS_MONTH: 'this_month',
     ALL_TIME: 'all_time',
   },
@@ -52,6 +53,7 @@ vi.mock('@/molecules', () => ({
 // Mock Libs icons
 vi.mock('@/libs', () => ({
   Star: () => <span>Star</span>,
+  CalendarRange: () => <span>CalendarRange</span>,
   Calendar: () => <span>Calendar</span>,
   Clock: () => <span>Clock</span>,
 }));
@@ -61,6 +63,7 @@ describe('FilterTimeframe', () => {
     render(<FilterTimeframe />);
 
     expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('This Week')).toBeInTheDocument();
     expect(screen.getByText('This Month')).toBeInTheDocument();
     expect(screen.getByText('All Time')).toBeInTheDocument();
   });

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx.snap
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx.snap
@@ -38,6 +38,23 @@ exports[`FilterTimeframe > matches snapshot 1`] = `
           data-testid="filter-icon"
         >
           <span>
+            CalendarRange
+          </span>
+        </span>
+        <span
+          data-testid="filter-label"
+        >
+          This Week
+        </span>
+      </li>
+      <li
+        data-selected="false"
+        data-testid="filter-item"
+      >
+        <span
+          data-testid="filter-icon"
+        >
+          <span>
             Calendar
           </span>
         </span>
@@ -105,6 +122,23 @@ exports[`HotFeedDrawer > matches snapshot 1`] = `
             data-testid="filter-label"
           >
             Today
+          </span>
+        </li>
+        <li
+          data-selected="false"
+          data-testid="filter-item"
+        >
+          <span
+            data-testid="filter-icon"
+          >
+            <span>
+              CalendarRange
+            </span>
+          </span>
+          <span
+            data-testid="filter-label"
+          >
+            This Week
           </span>
         </li>
         <li
@@ -183,6 +217,23 @@ exports[`HotFeedSidebar > matches snapshot 1`] = `
             data-testid="filter-label"
           >
             Today
+          </span>
+        </li>
+        <li
+          data-selected="false"
+          data-testid="filter-item"
+        >
+          <span
+            data-testid="filter-icon"
+          >
+            <span>
+              CalendarRange
+            </span>
+          </span>
+          <span
+            data-testid="filter-label"
+          >
+            This Week
           </span>
         </li>
         <li

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
@@ -26,6 +26,7 @@ export function FilterTimeframe({ selectedTab = Core.TIMEFRAME.THIS_MONTH, onTab
   const timeframeTabs: { key: Core.TimeframeType; label: string; icon: React.ComponentType<{ className?: string }> }[] =
     [
       { key: Core.TIMEFRAME.TODAY, label: t('today'), icon: Libs.Star },
+      { key: Core.TIMEFRAME.THIS_WEEK, label: t('thisWeek'), icon: Libs.CalendarRange },
       { key: Core.TIMEFRAME.THIS_MONTH, label: t('thisMonth'), icon: Libs.Calendar },
       { key: Core.TIMEFRAME.ALL_TIME, label: t('allTime'), icon: Libs.Clock },
     ];

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
@@ -18,7 +18,7 @@ interface FilterTimeframeProps {
 /**
  * FilterTimeframe
  *
- * Filter component for selecting timeframe (Today, This Month, All Time).
+ * Filter component for selecting timeframe (Today, This Week, This Month, All Time).
  */
 export function FilterTimeframe({ selectedTab = Core.TIMEFRAME.THIS_MONTH, onTabChange }: FilterTimeframeProps) {
   const t = useTranslations('filters.timeframe');

--- a/src/core/application/hot/hot.test.ts
+++ b/src/core/application/hot/hot.test.ts
@@ -284,10 +284,11 @@ describe('HotApplication', () => {
       const fetchSpy = vi.spyOn(Core.NexusHotService, 'fetch').mockResolvedValue(mockHotTags);
 
       await HotApplication.getOrFetch({ timeframe: Core.UserStreamTimeframe.TODAY });
+      await HotApplication.getOrFetch({ timeframe: Core.UserStreamTimeframe.THIS_WEEK });
       await HotApplication.getOrFetch({ timeframe: Core.UserStreamTimeframe.THIS_MONTH });
       await HotApplication.getOrFetch({ timeframe: Core.UserStreamTimeframe.ALL_TIME });
 
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(fetchSpy).toHaveBeenCalledTimes(4);
     });
 
     it('should strip limit from Nexus fetch on cache miss and apply it on return', async () => {

--- a/src/core/controllers/hot/hot.test.ts
+++ b/src/core/controllers/hot/hot.test.ts
@@ -278,10 +278,11 @@ describe('HotController', () => {
       const getOrFetchSpy = vi.spyOn(Core.HotApplication, 'getOrFetch').mockResolvedValue(mockHotTags);
 
       await HotController.getOrFetch({ timeframe: Core.UserStreamTimeframe.TODAY });
+      await HotController.getOrFetch({ timeframe: Core.UserStreamTimeframe.THIS_WEEK });
       await HotController.getOrFetch({ timeframe: Core.UserStreamTimeframe.THIS_MONTH });
       await HotController.getOrFetch({ timeframe: Core.UserStreamTimeframe.ALL_TIME });
 
-      expect(getOrFetchSpy).toHaveBeenCalledTimes(3);
+      expect(getOrFetchSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/core/controllers/hot/hot.ts
+++ b/src/core/controllers/hot/hot.ts
@@ -7,7 +7,7 @@ export class HotController {
    * Get or fetch hot/trending tags based on reach and timeframe
    * @param params - Parameters object
    * @param params.reach - Reach filter (followers, following, friends, wot)
-   * @param params.timeframe - Time period (today, this_month, all_time)
+   * @param params.timeframe - Time period (today, this_week, this_month, all_time)
    * @param params.limit - Maximum number of tags to return
    * @param params.skip - Number of tags to skip
    * @param params.user_id - Optional user ID for personalized results

--- a/src/core/models/stream/tag/tagStream.types.ts
+++ b/src/core/models/stream/tag/tagStream.types.ts
@@ -1,5 +1,5 @@
 // Tag Stream ID Pattern: timeframe:reach
-// TIMEFRAME: today, this_month, all_time
+// TIMEFRAME: today, this_week, this_month, all_time
 // REACH (Supported in 'influencers' source): followers, following, friends, wot (u8)
 //
 // Note: Different from TagStreamTypes pattern (timeframe:reach) to optimize for tag-centric queries

--- a/src/core/models/stream/tag/tagStream.types.ts
+++ b/src/core/models/stream/tag/tagStream.types.ts
@@ -1,5 +1,5 @@
 // Tag Stream ID Pattern: timeframe:reach
-// TIMEFRAME: today, this_week, this_month, all_time
+// TIMEFRAME: today, this_month, all_time
 // REACH (Supported in 'influencers' source): followers, following, friends, wot (u8)
 //
 // Note: Different from TagStreamTypes pattern (timeframe:reach) to optimize for tag-centric queries

--- a/src/core/models/stream/user/userStream.types.ts
+++ b/src/core/models/stream/user/userStream.types.ts
@@ -2,7 +2,7 @@ import type { Pubky, UserStreamCompositeReach } from '@/core';
 
 // User Stream ID Pattern: source:timeframe:reach
 // - SOURCE: followers, following, friends, muted, most_followed, influencers, recommended, post_replies, wot
-// - TIMEFRAME: today, this_month, all_time, all
+// - TIMEFRAME: today, this_week, this_month, all_time, all
 // - REACH (Supported in 'influencers' source): followers, following, friends, wot (u8), all
 //
 // Note: Different from PostStreamTypes pattern (sorting:source:kind) to optimize for user-centric queries

--- a/src/core/services/nexus/hot/hot.test.ts
+++ b/src/core/services/nexus/hot/hot.test.ts
@@ -234,10 +234,11 @@ describe('NexusHotService', () => {
       const queryNexusSpy = vi.spyOn(Core, 'queryNexus').mockResolvedValue(mockHotTags);
 
       await NexusHotService.fetch({ timeframe: Core.UserStreamTimeframe.TODAY });
+      await NexusHotService.fetch({ timeframe: Core.UserStreamTimeframe.THIS_WEEK });
       await NexusHotService.fetch({ timeframe: Core.UserStreamTimeframe.THIS_MONTH });
       await NexusHotService.fetch({ timeframe: Core.UserStreamTimeframe.ALL_TIME });
 
-      expect(queryNexusSpy).toHaveBeenCalledTimes(3);
+      expect(queryNexusSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/core/services/nexus/nexus.types.ts
+++ b/src/core/services/nexus/nexus.types.ts
@@ -68,6 +68,7 @@ export type UserStreamCompositeReach = Exclude<UserStreamReach, UserStreamReach.
 /** Timeframe filter for user stream endpoints */
 export enum UserStreamTimeframe {
   TODAY = 'today',
+  THIS_WEEK = 'this_week',
   THIS_MONTH = 'this_month',
   ALL_TIME = 'all_time',
 }

--- a/src/core/stores/hot/hot.store.test.ts
+++ b/src/core/stores/hot/hot.store.test.ts
@@ -66,6 +66,13 @@ describe('HotStore', () => {
       expect(useHotStore.getState().timeframe).toBe(TIMEFRAME.TODAY);
     });
 
+    it('should set timeframe to this week', () => {
+      const store = useHotStore.getState();
+
+      store.setTimeframe(TIMEFRAME.THIS_WEEK);
+      expect(useHotStore.getState().timeframe).toBe(TIMEFRAME.THIS_WEEK);
+    });
+
     it('should set timeframe to this month', () => {
       const store = useHotStore.getState();
 

--- a/src/core/stores/hot/hot.types.ts
+++ b/src/core/stores/hot/hot.types.ts
@@ -4,6 +4,7 @@ import { ReachType, REACH } from '../home/home.types';
 // Hot page constants
 export const TIMEFRAME = {
   TODAY: UserStreamTimeframe.TODAY,
+  THIS_WEEK: UserStreamTimeframe.THIS_WEEK,
   THIS_MONTH: UserStreamTimeframe.THIS_MONTH,
   ALL_TIME: UserStreamTimeframe.ALL_TIME,
 } as const;


### PR DESCRIPTION
Fixes #1458

This was blocked by https://github.com/pubky/pubky-nexus/pull/799 which I just implemented and got merged. So it will soon be on staging and prod.

Adds "This Week" (7-day) filter option to the hot page, between Today and This
   Month.

  Changes:
  - Add THIS_WEEK to timeframe enum and store
  - Add filter tab with CalendarDays icon
  - Add translations for all 9 languages
  
  Icon is not the one @aldertnl  asked for. This one is actually a weeks icon:
<img width="266" height="281" alt="image" src="https://github.com/user-attachments/assets/308dc54a-548e-45df-8f05-93ab5f4b5056" />
Aldert screenshot:
<img width="394" height="416" alt="image" src="https://github.com/user-attachments/assets/7d3e1095-c3a5-4773-a02b-2bd722032771" />
@secondl1ght please feel free to push a commit to fix this if you think it must be correct. Our current Today icon is also different from design.