### PR TITLE
feat(posts): wrap post action bar; add xxs/xs breakpoints

### DIFF
--- a/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx.snap
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PostActionsBar - Snapshots > matches snapshot loading 1`] = `
 
 exports[`PostActionsBar - Snapshots > matches snapshot with counts 1`] = `
 <div
-  data-class-name="flex gap-2 extra"
+  data-class-name="flex flex-wrap gap-2 extra"
   data-testid="actions-container"
 >
   <button

--- a/src/components/organisms/PostActionsBar/PostActionsBar.tsx
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.tsx
@@ -125,16 +125,16 @@ export function PostActionsBar({
   );
 
   return (
-    <Atoms.Container overrideDefaults className={Libs.cn('flex gap-2', className)}>
+    <Atoms.Container overrideDefaults className={Libs.cn('flex flex-wrap gap-2', className)}>
       {actionButtons.map(
-        ({ id, icon: Icon, count, onClick, ariaLabel, className: buttonClassName, iconProps, disabled }) => (
+        ({ id, icon: Icon, count, onClick, ariaLabel, className: btnClassName, iconProps, disabled }) => (
           <Atoms.Button
             key={id}
             data-cy={`post-${id}-btn`}
             {...commonButtonProps}
             onClick={onClick}
             disabled={disabled}
-            className={Libs.cn(commonButtonProps.className, buttonClassName)}
+            className={Libs.cn(commonButtonProps.className, btnClassName)}
             aria-label={ariaLabel}
           >
             <Icon {...iconProps} />

--- a/src/components/organisms/PostMain/PostMain.test.tsx.snap
+++ b/src/components/organisms/PostMain/PostMain.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`PostMain - Snapshots > matches snapshot for quote repost by current use
           me:quote-repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -108,7 +108,7 @@ exports[`PostMain - Snapshots > matches snapshot for repost by another user 1`] 
           other-user:repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -170,7 +170,7 @@ exports[`PostMain - Snapshots > matches snapshot for simple repost by current us
           me:simple-repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -233,7 +233,7 @@ exports[`PostMain - Snapshots > matches snapshot with default state 1`] = `
           post-123
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -315,7 +315,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
           post-no-reply-456
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -391,7 +391,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply true 1`] = `
           post-reply-123
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
           data-testid="post-actions"
         >
           Actions 

--- a/src/components/organisms/PostMain/PostMain.tsx
+++ b/src/components/organisms/PostMain/PostMain.tsx
@@ -143,7 +143,7 @@ export function PostMain({
                         onTagClick={() => setTagsExpanded((prev) => !prev)}
                         onReplyClick={handleReplyClick}
                         onRepostClick={handleRepostClick}
-                        className="w-full shrink-0 justify-start overflow-y-scroll sm:w-auto md:justify-end"
+                        className="w-full shrink-0 justify-start sm:w-auto md:justify-end"
                       />
                     </Atoms.Container>
                   </>

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -26,6 +26,10 @@ export const COLORS = {
  * Used for responsive design and media query hooks
  */
 export const BREAKPOINTS = {
+  /** Narrow phones — matches `body` min-width and `--breakpoint-xsm` in globals.css */
+  xxs: 375,
+  /** Compact mobile: 480px and up */
+  xs: 480,
   /** Mobile landscape: 640px and up */
   sm: 640,
   /** Tablets: 768px and up */


### PR DESCRIPTION
## Summary
- **`PostActionsBar`**: `flex flex-wrap` so tag / reply / repost / bookmark + more can wrap to a second row on narrow widths instead of feeling cramped in one line.
- **`PostMain`**: remove `overflow-y-scroll` from the desktop `PostActionsBar` row so a wrapped second row isn’t clipped.
- **`theme.ts`**: add `BREAKPOINTS.xxs` (375px) and `xs` (480px), aligned with layout/CSS (`body` min-width / `--breakpoint-xsm` where applicable) for `useIsMobile` / responsive logic.

## Notes
- A lot of the requirements for this ticket has been already done in #1268 
- Relevant Slack thread - https://synonymworkspace.slack.com/archives/C01J0QPPV08/p1775557188671809

## Video walkthrough

https://github.com/user-attachments/assets/c637a7b3-e2bb-4e11-abe4-328808ea36c1


Resolves: #1463 #1610 #1659 