### PR TITLE
fix(timeline): auto-paginate visual feed through non-media pages

### DIFF
--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
@@ -302,6 +302,30 @@ export function VisualTimelinePosts({
   const { navigateToPost } = Hooks.usePostNavigation();
   const { rows, hasPendingTiles } = useVisualFeedTiles({ postIds, hasMore });
 
+  // The visual grid only renders posts with image/video attachments. When a page of
+  // posts contains no media, the row count stays unchanged and Virtuoso won't fire
+  // endReached again (the data length didn't change). Track the row count from the
+  // last stable state so we can auto-paginate through media-less pages until visual
+  // tiles appear or the stream is exhausted.
+  const stableRowCountRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (loading) {
+      stableRowCountRef.current = 0;
+      return;
+    }
+
+    if (loadingMore || error || !hasMore || hasPendingTiles || postIds.length === 0) {
+      return;
+    }
+
+    if (rows.length <= stableRowCountRef.current) {
+      void loadMore();
+    }
+
+    stableRowCountRef.current = rows.length;
+  }, [loading, loadingMore, error, hasMore, postIds.length, rows.length, hasPendingTiles, loadMore]);
+
   const showFilteredEmptyState =
     !loading && !error && postIds.length > 0 && rows.length === 0 && !hasMore && !loadingMore && !hasPendingTiles;
 


### PR DESCRIPTION
## Summary
- fix #1661
- Visual layout feed stalls when stream pages contain only text/link posts because Virtuoso's `endReached` never re-fires for unchanged data length
- Affects both the initial load (empty grid) and mid-scroll pagination (feed stops loading at the bottom)

## Changes
- Add a `stableRowCountRef` in `VisualTimelinePosts` that tracks the grid row count at each idle state
- Add an effect that auto-triggers `loadMore` when a completed fetch didn't produce new visual rows and the stream has more pages
- Reset the ref on stream/filter changes (`loading` becomes true) to prevent stale comparisons

## Test plan
- [x] Set sort to **Recent**, layout to **Visual**, content to **All** — feed should load and display media posts even if the first pages are text-only
- [x] Scroll to the bottom of the visual feed — if the next page has no media, the feed should auto-load subsequent pages until media appears or the stream ends
- [x] Switch content filter or sort — verify the feed resets and loads correctly
- [x] Verify the filtered empty state still shows when the entire stream has no media posts

## Notes
- The root cause is that `react-virtuoso` only fires `endReached` when the user scrolls past rendered items; with 0 new rows the callback never re-triggers
- The fix is conservative: it only fires when idle, non-errored, with no pending tile probes, bounded by the stream's own `hasMore` / `reachedEnd` signal