### PR TITLE
fix: visual layout not showing all posts

### DIFF
--- a/cypress/e2e/feed.cy.ts
+++ b/cypress/e2e/feed.cy.ts
@@ -324,7 +324,7 @@ describe('visual layout', () => {
     cy.deleteDownloadsFolder();
   });
 
-  it.only('can view image-only posts in visual layout', () => {
+  it('can view image-only posts in visual layout', () => {
     const imagePostContent1 = `Image post 1 ${Date.now()}`;
     const imagePostContent2 = `Image post 2 ${Date.now()}`;
     const imagePostContent3 = `Image post 3 ${Date.now()}`;

--- a/cypress/e2e/feed.cy.ts
+++ b/cypress/e2e/feed.cy.ts
@@ -324,7 +324,7 @@ describe('visual layout', () => {
     cy.deleteDownloadsFolder();
   });
 
-  it('can view image-only posts in visual layout', () => {
+  it.only('can view image-only posts in visual layout', () => {
     const imagePostContent1 = `Image post 1 ${Date.now()}`;
     const imagePostContent2 = `Image post 2 ${Date.now()}`;
     const imagePostContent3 = `Image post 3 ${Date.now()}`;

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeedVisual.helpers.ts
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeedVisual.helpers.ts
@@ -5,6 +5,7 @@ import type { VisualRow, VisualTile, VisualTileSize } from './TimelineFeedVisual
 export const VISUAL_GRID_GAP_PX = 24;
 export const VISUAL_GRID_MAX_WIDTH_PX = 1200;
 export const VISUAL_PENDING_TAIL_LIMIT = 3;
+export const VISUAL_AUTO_PAGINATE_MIN_ROWS = 3;
 export const VISUAL_SQUARE_MAX_RATIO = 1;
 export const VISUAL_WIDE_ELIGIBLE_MIN_RATIO = 4 / 3;
 export const VISUAL_WIDE_MIN_RATIO = 16 / 9;

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
@@ -389,6 +389,48 @@ describe('VisualTimelinePosts', () => {
     expect(screen.getByTestId('visual-overlay-content-stack')).toHaveClass('flex', 'flex-col', 'gap-4');
   });
 
+  describe('auto-pagination', () => {
+    it('auto-paginates when the grid has too few rows for scroll-driven loading', () => {
+      const mockLoadMore = vi.fn().mockResolvedValue(undefined);
+      render(
+        <VisualTimelinePosts
+          postIds={['author:post1']}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={true}
+          loadMore={mockLoadMore}
+        />,
+      );
+
+      expect(mockLoadMore).toHaveBeenCalled();
+    });
+
+    it('auto-paginates even while tile probes are pending', () => {
+      mockUseVisualFeedTiles.mockReturnValue({
+        rows: createRows(),
+        tail: [],
+        tiles: [],
+        hasPendingTiles: true,
+        hasPendingFiles: false,
+      });
+
+      const mockLoadMore = vi.fn().mockResolvedValue(undefined);
+      render(
+        <VisualTimelinePosts
+          postIds={['author:post1']}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={true}
+          loadMore={mockLoadMore}
+        />,
+      );
+
+      expect(mockLoadMore).toHaveBeenCalled();
+    });
+  });
+
   describe('Virtuoso endReached', () => {
     it('calls loadMore when hasMore and not loadingMore', () => {
       const mockLoadMore = vi.fn().mockResolvedValue(undefined);
@@ -403,6 +445,7 @@ describe('VisualTimelinePosts', () => {
         />,
       );
 
+      mockLoadMore.mockClear();
       fireEvent.click(screen.getByTestId('virtuoso-end-reached'));
       expect(mockLoadMore).toHaveBeenCalledOnce();
     });

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
@@ -177,6 +177,7 @@ describe('VisualTimelinePosts', () => {
       tail: [],
       tiles: [],
       hasPendingTiles: false,
+      hasPendingFiles: false,
     });
   });
 
@@ -239,6 +240,30 @@ describe('VisualTimelinePosts', () => {
       tail: [],
       tiles: [],
       hasPendingTiles: true,
+      hasPendingFiles: false,
+    });
+
+    render(
+      <VisualTimelinePosts
+        postIds={['author:post1']}
+        loading={false}
+        loadingMore={false}
+        error={null}
+        hasMore={false}
+        loadMore={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('timeline-empty')).not.toBeInTheDocument();
+  });
+
+  it('does not render the filtered empty state while file metadata is being fetched', () => {
+    mockUseVisualFeedTiles.mockReturnValue({
+      rows: [],
+      tail: [],
+      tiles: [],
+      hasPendingTiles: false,
+      hasPendingFiles: true,
     });
 
     render(
@@ -287,6 +312,7 @@ describe('VisualTimelinePosts', () => {
       tail: [],
       tiles: [],
       hasPendingTiles: false,
+      hasPendingFiles: false,
     });
 
     render(
@@ -426,6 +452,7 @@ describe('VisualTimelinePosts - Snapshots', () => {
       tail: [],
       tiles: [],
       hasPendingTiles: false,
+      hasPendingFiles: false,
     });
   });
 
@@ -450,6 +477,7 @@ describe('VisualTimelinePosts - Snapshots', () => {
       tail: [],
       tiles: [],
       hasPendingTiles: false,
+      hasPendingFiles: false,
     });
 
     const { container } = render(

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
@@ -300,7 +300,7 @@ export function VisualTimelinePosts({
   loadMore,
 }: VisualTimelinePostsProps) {
   const { navigateToPost } = Hooks.usePostNavigation();
-  const { rows, hasPendingTiles } = useVisualFeedTiles({ postIds, hasMore });
+  const { rows, hasPendingTiles, hasPendingFiles } = useVisualFeedTiles({ postIds, hasMore });
 
   // The visual grid only renders posts with image/video attachments. When a page of
   // posts contains no media, the row count stays unchanged and Virtuoso won't fire
@@ -315,7 +315,7 @@ export function VisualTimelinePosts({
       return;
     }
 
-    if (loadingMore || error || !hasMore || hasPendingTiles || postIds.length === 0) {
+    if (loadingMore || error || !hasMore || hasPendingTiles || hasPendingFiles || postIds.length === 0) {
       return;
     }
 
@@ -324,10 +324,17 @@ export function VisualTimelinePosts({
     }
 
     stableRowCountRef.current = rows.length;
-  }, [loading, loadingMore, error, hasMore, postIds.length, rows.length, hasPendingTiles, loadMore]);
+  }, [loading, loadingMore, error, hasMore, postIds.length, rows.length, hasPendingTiles, hasPendingFiles, loadMore]);
 
   const showFilteredEmptyState =
-    !loading && !error && postIds.length > 0 && rows.length === 0 && !hasMore && !loadingMore && !hasPendingTiles;
+    !loading &&
+    !error &&
+    postIds.length > 0 &&
+    rows.length === 0 &&
+    !hasMore &&
+    !loadingMore &&
+    !hasPendingTiles &&
+    !hasPendingFiles;
 
   const virtuosoContext: TimelineVirtuosoContext = {
     loadingMore,

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
@@ -10,6 +10,7 @@ import * as Libs from '@/libs';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
 import {
+  VISUAL_AUTO_PAGINATE_MIN_ROWS,
   VISUAL_GRID_MAX_WIDTH_PX,
   VISUAL_TILE_ASPECT_RATIOS,
   VISUAL_TILE_COLUMN_SPANS,
@@ -302,11 +303,20 @@ export function VisualTimelinePosts({
   const { navigateToPost } = Hooks.usePostNavigation();
   const { rows, hasPendingTiles, hasPendingFiles } = useVisualFeedTiles({ postIds, hasMore });
 
-  // The visual grid only renders posts with image/video attachments. When a page of
-  // posts contains no media, the row count stays unchanged and Virtuoso won't fire
-  // endReached again (the data length didn't change). Track the row count from the
-  // last stable state so we can auto-paginate through media-less pages until visual
-  // tiles appear or the stream is exhausted.
+  // Auto-paginate when the visual grid doesn't fill the viewport. Two triggers:
+  //
+  // 1. rows.length <= stableRowCountRef — a page loaded but produced no new visual
+  //    rows (all text posts). Virtuoso won't fire endReached because the data length
+  //    didn't change, so we must load the next page ourselves.
+  //
+  // 2. rows.length < VISUAL_AUTO_PAGINATE_MIN_ROWS — the grid is too short to trigger
+  //    scroll-based loading. Virtuoso with useWindowScroll may not fire endReached when
+  //    the content doesn't fill the window (resizing the window works around this).
+  //
+  // hasPendingTiles and hasPendingFiles are deliberately excluded from the bail-out
+  // conditions. Blocking on them creates a deadlock: the effect can't fire while tiles
+  // are probing, and by the time probes finish, stableRowCountRef has been overtaken by
+  // probe-driven row growth, so the "no new rows" check no longer triggers.
   const stableRowCountRef = React.useRef(0);
 
   React.useEffect(() => {
@@ -315,16 +325,16 @@ export function VisualTimelinePosts({
       return;
     }
 
-    if (loadingMore || error || !hasMore || hasPendingTiles || hasPendingFiles || postIds.length === 0) {
+    if (loadingMore || error || !hasMore || postIds.length === 0) {
       return;
     }
 
-    if (rows.length <= stableRowCountRef.current) {
+    if (rows.length <= stableRowCountRef.current || rows.length < VISUAL_AUTO_PAGINATE_MIN_ROWS) {
       void loadMore();
     }
 
     stableRowCountRef.current = rows.length;
-  }, [loading, loadingMore, error, hasMore, postIds.length, rows.length, hasPendingTiles, hasPendingFiles, loadMore]);
+  }, [loading, loadingMore, error, hasMore, postIds.length, rows.length, loadMore]);
 
   const showFilteredEmptyState =
     !loading &&

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.test.tsx
@@ -175,9 +175,7 @@ describe('useVisualFeedTiles', () => {
       missingFileUris: ['pubky://user-1/pub/pubky.app/files/file-1'],
     });
 
-    const { result } = renderHook(() =>
-      useVisualFeedTiles({ postIds: ['author:post-1'], hasMore: false }),
-    );
+    const { result } = renderHook(() => useVisualFeedTiles({ postIds: ['author:post-1'], hasMore: false }));
 
     expect(result.current.hasPendingFiles).toBe(true);
   });

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.test.tsx
@@ -130,6 +130,58 @@ describe('useVisualFeedTiles', () => {
     });
   });
 
+  it('assigns medium fallback immediately when stream is exhausted with few tiles', () => {
+    mockUseLiveQuery.mockReturnValue({
+      tiles: [
+        createPendingTile({ id: 'tile-a', postId: 'author:post-1', attachmentName: 'a.png', previewSrc: '/a.png' }),
+        createPendingTile({ id: 'tile-b', postId: 'author:post-2', attachmentName: 'b.png', previewSrc: '/b.png' }),
+        createPendingTile({ id: 'tile-c', postId: 'author:post-3', attachmentName: 'c.png', previewSrc: '/c.png' }),
+      ],
+      missingFileUris: [],
+    });
+
+    const { result } = renderHook(() =>
+      useVisualFeedTiles({ postIds: ['author:post-1', 'author:post-2', 'author:post-3'], hasMore: false }),
+    );
+
+    expect(result.current.rows.length).toBeGreaterThan(0);
+    expect(result.current.hasPendingTiles).toBe(false);
+    result.current.tiles.forEach((tile) => {
+      expect(tile.preferredSize).toBe('medium');
+    });
+  });
+
+  it('does not assign fallback when stream has more pages', () => {
+    mockUseLiveQuery.mockReturnValue({
+      tiles: [
+        createPendingTile({ id: 'tile-a', postId: 'author:post-1', attachmentName: 'a.png', previewSrc: '/a.png' }),
+        createPendingTile({ id: 'tile-b', postId: 'author:post-2', attachmentName: 'b.png', previewSrc: '/b.png' }),
+        createPendingTile({ id: 'tile-c', postId: 'author:post-3', attachmentName: 'c.png', previewSrc: '/c.png' }),
+      ],
+      missingFileUris: [],
+    });
+
+    const { result } = renderHook(() =>
+      useVisualFeedTiles({ postIds: ['author:post-1', 'author:post-2', 'author:post-3'], hasMore: true }),
+    );
+
+    expect(result.current.rows.length).toBe(0);
+    expect(result.current.hasPendingTiles).toBe(true);
+  });
+
+  it('exposes hasPendingFiles when file metadata is missing', () => {
+    mockUseLiveQuery.mockReturnValue({
+      tiles: [],
+      missingFileUris: ['pubky://user-1/pub/pubky.app/files/file-1'],
+    });
+
+    const { result } = renderHook(() =>
+      useVisualFeedTiles({ postIds: ['author:post-1'], hasMore: false }),
+    );
+
+    expect(result.current.hasPendingFiles).toBe(true);
+  });
+
   it('resolves probed square and wide tiles into non-medium rows', async () => {
     const squareId = findIdentity({
       base: 'square-tile',

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.ts
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/useVisualFeedTiles.ts
@@ -279,17 +279,21 @@ export function useVisualFeedTiles({ postIds, hasMore }: { postIds: string[]; ha
   }, [missingFileUris, missingFileUrisKey]);
 
   const tiles = (snapshot?.tiles ?? []).map(resolveTileProbeState);
-  const pendingOverflowFallbackIds = React.useMemo(() => getVisualPendingOverflowFallbackIds(tiles), [tiles]);
+  const pendingOverflowFallbackIds = React.useMemo(
+    () => getVisualPendingOverflowFallbackIds(tiles, hasMore ? undefined : 0),
+    [tiles, hasMore],
+  );
   const pendingOverflowFallbackIdSet = React.useMemo(
     () => new Set(pendingOverflowFallbackIds),
     [pendingOverflowFallbackIds],
   );
 
   React.useEffect(() => {
+    if (!hasMore) return;
     pendingOverflowFallbackIds.forEach((tileId) => {
       setVisualTilePreferredSizeFallback(tileId, 'medium');
     });
-  }, [pendingOverflowFallbackIds]);
+  }, [pendingOverflowFallbackIds, hasMore]);
 
   const stabilizedTiles = React.useMemo(() => {
     return tiles.map((tile) => {
@@ -308,9 +312,7 @@ export function useVisualFeedTiles({ postIds, hasMore }: { postIds: string[]; ha
     if (typeof window === 'undefined') return;
 
     let isMounted = true;
-    const pendingTiles = stabilizedTiles.filter(
-      (tile) => tile.preferredSize === undefined && tile.probeState === 'pending',
-    );
+    const pendingTiles = stabilizedTiles.filter((tile) => tile.probeState === 'pending');
 
     pendingTiles.forEach((tile) => {
       void ensureVisualTileProbe(tile).finally(() => {
@@ -340,5 +342,6 @@ export function useVisualFeedTiles({ postIds, hasMore }: { postIds: string[]; ha
     tail,
     tiles: stabilizedTiles,
     hasPendingTiles: firstPendingTileIndex !== -1,
+    hasPendingFiles: missingFileUris.length > 0,
   };
 }


### PR DESCRIPTION
Fixes https://github.com/pubky/pubky-app/issues/1677 & https://github.com/pubky/pubky-app/issues/1678

This PR addresses the above bugs by ensuring that pending size category for each image are waited on and that it never fails to assign a fallback size. Also that loading of more posts is triggered on initial load, not just when resizing the viewport.