### PR TITLE
feat(notification): Filter notification list by user preferences

### DIFF
--- a/src/core/controllers/notification/notification.test.ts
+++ b/src/core/controllers/notification/notification.test.ts
@@ -11,6 +11,17 @@ const mockAuthStore = (userId: Core.Pubky = mockUserId) => {
   } as ReturnType<typeof Core.useAuthStore.getState>);
 };
 
+/**
+ * Mocks the settings store with notification preferences.
+ * The controller reads preferences to filter out disabled notification types.
+ * Defaults to all enabled; pass overrides to disable specific types (e.g., { follow: false }).
+ */
+const mockSettingsStore = (overrides: Partial<Core.NotificationPreferences> = {}) => {
+  vi.spyOn(Core.useSettingsStore, 'getState').mockReturnValue({
+    notifications: { ...Core.defaultNotificationPreferences, ...overrides },
+  } as ReturnType<typeof Core.useSettingsStore.getState>);
+};
+
 describe('NotificationController', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());
@@ -159,7 +170,10 @@ describe('NotificationController', () => {
       olderThan: 3000,
     };
 
-    beforeEach(() => mockAuthStore());
+    beforeEach(() => {
+      mockAuthStore();
+      mockSettingsStore();
+    });
 
     it.each([
       { params: {}, expectedOlderThan: Infinity, expectedLimit: Config.NEXUS_NOTIFICATIONS_LIMIT },
@@ -178,12 +192,62 @@ describe('NotificationController', () => {
       });
     });
 
-    it('should return response from application', async () => {
+    it('should return all notifications when all preferences are enabled (default)', async () => {
+      // mockSettingsStore() defaults to all preferences enabled,
+      // so no notifications should be filtered out
       vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
 
       const result = await NotificationController.getOrFetchNotifications({});
 
-      expect(result).toEqual(mockResponse);
+      expect(result.flatNotifications).toHaveLength(1);
+      expect(result.olderThan).toBe(3000);
+    });
+
+    it('should filter out disabled notification types', async () => {
+      mockSettingsStore({ follow: false });
+      vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
+
+      const result = await NotificationController.getOrFetchNotifications({});
+
+      expect(result.flatNotifications).toHaveLength(0);
+      expect(result.olderThan).toBe(3000);
+    });
+
+    it('should filter mixed notification types by preferences', async () => {
+      mockSettingsStore({ postDeleted: false });
+      const mixedResponse: Core.TGetOrFetchNotificationsResponse = {
+        flatNotifications: [
+          { id: 'follow:3000:user-1', type: Core.NotificationType.Follow, timestamp: 3000, followed_by: 'user-1' },
+          {
+            id: 'post_deleted:2000:user-2',
+            type: Core.NotificationType.PostDeleted,
+            timestamp: 2000,
+            delete_source: 'reply',
+            deleted_by: 'user-2',
+            deleted_uri: 'pubky://post/1',
+            linked_uri: 'pubky://post/2',
+          },
+          {
+            id: 'reply:1000:user-3',
+            type: Core.NotificationType.Reply,
+            timestamp: 1000,
+            replied_by: 'user-3',
+            parent_post_uri: 'pubky://post/1',
+            reply_uri: 'pubky://post/3',
+          },
+        ] as Core.FlatNotification[],
+        olderThan: 1000,
+      };
+      vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mixedResponse);
+
+      const result = await NotificationController.getOrFetchNotifications({});
+
+      expect(result.flatNotifications).toHaveLength(2);
+      expect(result.flatNotifications.map((n) => n.type)).toEqual([
+        Core.NotificationType.Follow,
+        Core.NotificationType.Reply,
+      ]);
+      expect(result.olderThan).toBe(1000);
     });
 
     it('should return empty response when no notifications', async () => {

--- a/src/core/controllers/notification/notification.ts
+++ b/src/core/controllers/notification/notification.ts
@@ -1,5 +1,6 @@
 import * as Core from '@/core';
 import * as Config from '@/config';
+import { filterByPreferences } from './notification.filters';
 
 export class NotificationController {
   private constructor() {} // Prevent instantiation
@@ -58,24 +59,35 @@ export class NotificationController {
    * Retrieves notifications from cache if available, otherwise fetches from Nexus.
    * Uses timestamp-based pagination.
    *
+   * All notifications are stored unfiltered in IndexedDB.
+   * Filtering by user preferences happens here at read time — the Controller reads
+   * NotificationPreferences from the settings store and removes disabled items before
+   * returning to the UI. This avoids accessing Zustand stores from the Application layer (ADR-0004).
+   *
    * @param params.olderThan - Unix timestamp to get notifications older than.
    *                           Defaults to Infinity for initial load (most recent notifications).
    *                           Use the timestamp of the last notification for pagination.
    * @param params.limit - Maximum number of notifications to return. Defaults to NEXUS_NOTIFICATIONS_LIMIT.
    *
-   * @returns Promise resolving to notifications and next timestamp for pagination
+   * @returns Promise resolving to filtered notifications and next timestamp for pagination
    */
   static async getOrFetchNotifications({
     olderThan = Infinity,
     limit = Config.NEXUS_NOTIFICATIONS_LIMIT,
   }: Core.TGetNotificationsParams): Promise<Core.TGetOrFetchNotificationsResponse> {
     const userId = Core.useAuthStore.getState().selectCurrentUserPubky();
+    const preferences = Core.useSettingsStore.getState().notifications;
 
-    return await Core.NotificationApplication.getOrFetchNotifications({
+    const response = await Core.NotificationApplication.getOrFetchNotifications({
       userId,
       olderThan,
       limit,
     });
+
+    return {
+      ...response,
+      flatNotifications: filterByPreferences(response.flatNotifications, preferences),
+    };
   }
 
   /**


### PR DESCRIPTION
##  Summary:
  - Apply preference-based filtering in `NotificationController.getOrFetchNotifications` at read time, keeping unfiltered data in IndexedDB so preference changes take effect immediately without re-fetching
  - Read `NotificationPreferences` from the settings store in the Controller layer, following ADR-0004 (no Zustand access from Application layer)
  - Add unit tests for the controller integration covering default, disabled, and mixed notification type scenarios

##  Impacted Area:
  - `NotificationController.getOrFetchNotifications` — now filters response through user preferences before returning to the UI. Callers receive fewer items if the user has disabled specific notification types, which may affect pagination behavior.
  -  useNotifications hook — consumes the controller; filtered results propagate to the
  notification list.
  - NotificationsContainer / ProfilePageNotifications — the notification list UI that renders the
  filtered results.

## Result

https://github.com/user-attachments/assets/e8d5d06b-e2e7-412e-a435-22ce425f9e8a

