### PR TITLE
fix: wide layout on search page

### DIFF
--- a/src/components/templates/Feed/Search/Search.test.tsx
+++ b/src/components/templates/Feed/Search/Search.test.tsx
@@ -2,12 +2,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Search } from './Search';
 
-const mockUseLayoutReset = vi.fn();
 const mockUseIsMobile = vi.fn(() => false);
 const mockUseSearchTags = vi.fn(() => ['pubky']);
 
 vi.mock('@/hooks', () => ({
-  useLayoutReset: () => mockUseLayoutReset(),
   useIsMobile: () => mockUseIsMobile(),
 }));
 
@@ -17,7 +15,11 @@ vi.mock('@/hooks/useSearchStreamId', () => ({
 
 vi.mock('@/organisms', () => ({
   DialogWelcome: () => <div data-testid="dialog-welcome">DialogWelcome</div>,
-  ContentLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="content-layout">{children}</div>,
+  ContentLayout: ({ children, feedVariant }: { children: React.ReactNode; feedVariant?: string }) => (
+    <div data-testid="content-layout" data-feed-variant={feedVariant}>
+      {children}
+    </div>
+  ),
   HomeFeedSidebar: () => <div data-testid="home-feed-sidebar">HomeFeedSidebar</div>,
   HomeFeedRightSidebar: () => <div data-testid="home-feed-right-sidebar">HomeFeedRightSidebar</div>,
   HomeFeedDrawer: () => <div data-testid="home-feed-drawer">HomeFeedDrawer</div>,
@@ -55,10 +57,10 @@ describe('Search', () => {
     mockUseSearchTags.mockReturnValue(['pubky']);
   });
 
-  it('restores the unsupported wide layout on mount', () => {
+  it('passes SEARCH feedVariant to ContentLayout', () => {
     render(<Search />);
 
-    expect(mockUseLayoutReset).toHaveBeenCalled();
+    expect(screen.getByTestId('content-layout')).toHaveAttribute('data-feed-variant', 'search');
   });
 
   it('renders search results when tags are present', () => {

--- a/src/components/templates/Feed/Search/Search.tsx
+++ b/src/components/templates/Feed/Search/Search.tsx
@@ -21,8 +21,6 @@ import { useSearchTags } from '@/hooks/useSearchStreamId';
  * - Shows SearchInput on mobile (hidden on desktop where it's in the header)
  */
 export function Search() {
-  Hooks.useLayoutReset();
-
   // Get tags from URL query params
   const tags = useSearchTags();
   const isMobile = Hooks.useIsMobile();


### PR DESCRIPTION
## 🐛 Fix Wide Layout on Search Page

### Summary

The Wide layout option has been broken on the Search page since it was first created. Users could see and click the "Wide" option in the filter sidebar, but it would immediately snap back to "Columns" due to `useLayoutReset()` forcibly resetting the layout on every mount.

### Root Cause

The Search page was created as a placeholder in commit `485c690e` (Dec 2025) with `useLayoutReset()` and a comment: *"Reset to column layout on mount (this page doesn't support wide)"*. At the time Search was just static placeholder content.

As Search matured into a full feed page, the reset was never removed. The visual feed layout PR (#1472) briefly fixed it in one commit (`741791d0`) but accidentally re-added it a few hours later in a follow-up fixup (`ab5620c2` — "Restore layout reset for Hot pages") that swept Search in along with Hot. No released version ever had Wide working on Search.

### Changes

**`src/components/templates/Feed/Search/Search.tsx`**
- ❌ Removed `Hooks.useLayoutReset()` — this was resetting `wide` → `columns` on every mount

**`src/components/templates/Feed/Search/Search.test.tsx`**
- Removed `mockUseLayoutReset` and its associated test
- Added test verifying `SEARCH` feedVariant is correctly passed to `ContentLayout`
- Updated `ContentLayout` mock to capture and expose the `feedVariant` prop

### Screenshots

<img width="2706" height="1296" alt="image" src="https://github.com/user-attachments/assets/fad2f8e0-b238-4722-ba00-59dec90e08e0" />

---

_This pull request summary was generated, for full implementation details please reference the file changes._
