### PR TITLE
feat(posts): use author avatar for Open Graph when set

### DIFF
--- a/src/app/post/[userId]/[postId]/page.tsx
+++ b/src/app/post/[userId]/[postId]/page.tsx
@@ -75,9 +75,12 @@ export async function generateMetadata({ params }: PostPageProps): Promise<NextM
     const title = `${username} on Pubky`;
     const description = postPreviewTruncated;
 
+    const previewImage = user.image ? Core.FileController.getAvatarUrl(user.id) : undefined;
+
     const { openGraph, twitter } = Metadata({
       title,
       description,
+      image: previewImage,
     });
 
     return username && postPreviewTruncated


### PR DESCRIPTION
Pass preview image from FileController.getAvatarUrl when user.image is present; otherwise keep default preview image.

Made-with: Cursor