### PR TITLE
chore(cursor): add Scrapling MCP server config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "scrapling": {
+      "type": "stdio",
+      "command": "${workspaceFolder}/.venv-scrapling/bin/scrapling",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ public/sw.js.map
 /.cursor/commands
 /.cursor/hooks
 
+# Scrapling MCP (local venv; recreate with: python3 -m venv .venv-scrapling && .venv-scrapling/bin/pip install "scrapling[ai]" && scrapling install)
+/.venv-scrapling
+
 # Claude
 .claude
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds project-level [Cursor MCP](https://cursor.com/docs/context/mcp) configuration for the [Scrapling](https://scrapling.readthedocs.io/en/latest/ai/mcp-server.html) server.

**Setup (local, one-time per machine)**

1. Create the venv and install Scrapling (from repo root):

   `python3 -m venv .venv-scrapling && .venv-scrapling/bin/pip install "scrapling[ai]" && .venv-scrapling/bin/scrapling install`

2. Restart Cursor so it loads `.cursor/mcp.json`.

`.venv-scrapling` is gitignored; the MCP config uses `${workspaceFolder}` so the path resolves per workspace.

**Note:** The cloud agent cannot invoke MCP tools from a running Cursor session; after restart, Agent can use Scrapling tools when enabled. Sites like X may still block or require login for timelines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4adadccc-ff51-41d3-bc3b-3119c492b700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4adadccc-ff51-41d3-bc3b-3119c492b700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

