### PR TITLE
refactor(ui): replace copyright role checkboxes with radio group

### DIFF
--- a/src/components/atoms/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/atoms/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadioGroup, RadioGroupItem } from './RadioGroup';
+
+const renderRadioGroup = (props?: { onValueChange?: (value: string) => void; defaultValue?: string }) =>
+  render(
+    <RadioGroup {...props}>
+      <RadioGroupItem value="one" label="One" />
+      <RadioGroupItem value="two" label="Two" />
+    </RadioGroup>,
+  );
+
+describe('RadioGroup', () => {
+  it('renders two radios', () => {
+    renderRadioGroup();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('selects an item when clicked and reports the value', () => {
+    const handleValueChange = vi.fn();
+    renderRadioGroup({ onValueChange: handleValueChange });
+
+    fireEvent.click(screen.getByLabelText('Two'));
+
+    expect(handleValueChange).toHaveBeenCalledWith('two');
+    expect(screen.getByLabelText('Two')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByLabelText('One')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('enforces mutual exclusivity', () => {
+    renderRadioGroup({ defaultValue: 'one' });
+
+    expect(screen.getByLabelText('One')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByLabelText('Two')).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(screen.getByLabelText('Two'));
+
+    expect(screen.getByLabelText('One')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByLabelText('Two')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('clicking the label selects the radio', () => {
+    const handleValueChange = vi.fn();
+    renderRadioGroup({ onValueChange: handleValueChange });
+
+    fireEvent.click(screen.getByText('One'));
+
+    expect(handleValueChange).toHaveBeenCalledWith('one');
+  });
+
+  it('renders a standalone item without label/description', () => {
+    render(
+      <RadioGroup defaultValue="solo">
+        <RadioGroupItem value="solo" />
+      </RadioGroup>,
+    );
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+  });
+});
+
+describe('RadioGroup - Snapshots', () => {
+  it('matches snapshot for default group with labels', () => {
+    const { container } = render(
+      <RadioGroup defaultValue="one">
+        <RadioGroupItem value="one" label="One" />
+        <RadioGroupItem value="two" label="Two" />
+      </RadioGroup>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for item with label and description', () => {
+    const { container } = render(
+      <RadioGroup defaultValue="one">
+        <RadioGroupItem value="one" label="One" description="The first option" />
+      </RadioGroup>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for box variant', () => {
+    const { container } = render(
+      <RadioGroup defaultValue="starter">
+        <RadioGroupItem value="starter" label="Starter Plan" description="Perfect for small businesses" variant="box" />
+        <RadioGroupItem value="pro" label="Pro Plan" description="Advanced features" variant="box" />
+      </RadioGroup>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for disabled item', () => {
+    const { container } = render(
+      <RadioGroup>
+        <RadioGroupItem value="one" label="One" disabled />
+      </RadioGroup>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/atoms/RadioGroup/RadioGroup.test.tsx.snap
+++ b/src/components/atoms/RadioGroup/RadioGroup.test.tsx.snap
@@ -1,0 +1,274 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RadioGroup - Snapshots > matches snapshot for box variant 1`] = `
+<div
+  aria-required="false"
+  class="grid gap-3"
+  dir="ltr"
+  role="radiogroup"
+  style="outline: none;"
+  tabindex="0"
+>
+  <div
+    class="rounded-lg border border-border p-4 transition-colors has-[[data-state=checked]]:border-brand has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-50"
+    data-testid="container"
+  >
+    <div
+      class="flex items-start gap-2"
+      data-testid="container"
+    >
+      <button
+        aria-checked="true"
+        class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+        data-radix-collection-item=""
+        data-state="checked"
+        id="radix-normalized"
+        role="radio"
+        tabindex="-1"
+        type="button"
+        value="starter"
+      >
+        <span
+          class="flex items-center justify-center"
+          data-state="checked"
+        >
+          <span
+            class="block size-2 rounded-full bg-background"
+          />
+        </span>
+      </button>
+      <div
+        class="flex flex-col gap-1.5"
+        data-testid="container"
+      >
+        <label
+          class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+          data-slot="label"
+          for="radix-normalized"
+        >
+          Starter Plan
+        </label>
+        <p
+          class="font-medium text-sm leading-normal text-muted-foreground"
+          data-testid="typography"
+        >
+          Perfect for small businesses
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    class="rounded-lg border border-border p-4 transition-colors has-[[data-state=checked]]:border-brand has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-50"
+    data-testid="container"
+  >
+    <div
+      class="flex items-start gap-2"
+      data-testid="container"
+    >
+      <button
+        aria-checked="false"
+        class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+        data-radix-collection-item=""
+        data-state="unchecked"
+        id="radix-normalized"
+        role="radio"
+        tabindex="-1"
+        type="button"
+        value="pro"
+      />
+      <div
+        class="flex flex-col gap-1.5"
+        data-testid="container"
+      >
+        <label
+          class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+          data-slot="label"
+          for="radix-normalized"
+        >
+          Pro Plan
+        </label>
+        <p
+          class="font-medium text-sm leading-normal text-muted-foreground"
+          data-testid="typography"
+        >
+          Advanced features
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RadioGroup - Snapshots > matches snapshot for default group with labels 1`] = `
+<div
+  aria-required="false"
+  class="grid gap-3"
+  dir="ltr"
+  role="radiogroup"
+  style="outline: none;"
+  tabindex="0"
+>
+  <div
+    class="flex items-start gap-2"
+    data-testid="container"
+  >
+    <button
+      aria-checked="true"
+      class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+      data-radix-collection-item=""
+      data-state="checked"
+      id="radix-normalized"
+      role="radio"
+      tabindex="-1"
+      type="button"
+      value="one"
+    >
+      <span
+        class="flex items-center justify-center"
+        data-state="checked"
+      >
+        <span
+          class="block size-2 rounded-full bg-background"
+        />
+      </span>
+    </button>
+    <div
+      class="flex flex-col gap-1.5"
+      data-testid="container"
+    >
+      <label
+        class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+        data-slot="label"
+        for="radix-normalized"
+      >
+        One
+      </label>
+    </div>
+  </div>
+  <div
+    class="flex items-start gap-2"
+    data-testid="container"
+  >
+    <button
+      aria-checked="false"
+      class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+      data-radix-collection-item=""
+      data-state="unchecked"
+      id="radix-normalized"
+      role="radio"
+      tabindex="-1"
+      type="button"
+      value="two"
+    />
+    <div
+      class="flex flex-col gap-1.5"
+      data-testid="container"
+    >
+      <label
+        class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+        data-slot="label"
+        for="radix-normalized"
+      >
+        Two
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RadioGroup - Snapshots > matches snapshot for disabled item 1`] = `
+<div
+  aria-required="false"
+  class="grid gap-3"
+  dir="ltr"
+  role="radiogroup"
+  style="outline: none;"
+  tabindex="-1"
+>
+  <div
+    class="flex items-start gap-2"
+    data-testid="container"
+  >
+    <button
+      aria-checked="false"
+      class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+      data-disabled=""
+      data-radix-collection-item=""
+      data-state="unchecked"
+      disabled=""
+      id="radix-normalized"
+      role="radio"
+      tabindex="-1"
+      type="button"
+      value="one"
+    />
+    <div
+      class="flex flex-col gap-1.5"
+      data-testid="container"
+    >
+      <label
+        class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+        data-slot="label"
+        for="radix-normalized"
+      >
+        One
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RadioGroup - Snapshots > matches snapshot for item with label and description 1`] = `
+<div
+  aria-required="false"
+  class="grid gap-3"
+  dir="ltr"
+  role="radiogroup"
+  style="outline: none;"
+  tabindex="0"
+>
+  <div
+    class="flex items-start gap-2"
+    data-testid="container"
+  >
+    <button
+      aria-checked="true"
+      class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+      data-radix-collection-item=""
+      data-state="checked"
+      id="radix-normalized"
+      role="radio"
+      tabindex="-1"
+      type="button"
+      value="one"
+    >
+      <span
+        class="flex items-center justify-center"
+        data-state="checked"
+      >
+        <span
+          class="block size-2 rounded-full bg-background"
+        />
+      </span>
+    </button>
+    <div
+      class="flex flex-col gap-1.5"
+      data-testid="container"
+    >
+      <label
+        class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+        data-slot="label"
+        for="radix-normalized"
+      >
+        One
+      </label>
+      <p
+        class="font-medium text-sm leading-normal text-muted-foreground"
+        data-testid="typography"
+      >
+        The first option
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/atoms/RadioGroup/RadioGroup.tsx
+++ b/src/components/atoms/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import * as React from 'react';
+import { RadioGroup as RadioGroupPrimitive } from 'radix-ui';
+import * as Libs from '@/libs';
+import * as Atoms from '@/atoms';
+
+type RadioGroupProps = React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>;
+
+interface RadioGroupItemProps extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {
+  /** Optional label text displayed next to the radio */
+  label?: string;
+  /** Optional description text displayed below the label */
+  description?: string;
+  /** Visual variant: 'default' is a plain radio + label; 'box' wraps the item in a bordered card */
+  variant?: 'default' | 'box';
+}
+
+const RadioGroup = React.forwardRef<React.ComponentRef<typeof RadioGroupPrimitive.Root>, RadioGroupProps>(
+  ({ className, ...props }, ref) => {
+    return <RadioGroupPrimitive.Root ref={ref} className={Libs.cn('grid gap-3', className)} {...props} />;
+  },
+);
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<React.ComponentRef<typeof RadioGroupPrimitive.Item>, RadioGroupItemProps>(
+  ({ className, label, description, id, variant = 'default', ...props }, ref) => {
+    const generatedId = React.useId();
+    const itemId = id || generatedId;
+
+    const radioElement = (
+      <RadioGroupPrimitive.Item
+        ref={ref}
+        id={itemId}
+        className={Libs.cn(
+          'peer size-4 shrink-0 rounded-full',
+          'border border-input bg-white/5 shadow-sm',
+          'transition-colors',
+          'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          'data-[state=checked]:border-brand data-[state=checked]:bg-brand',
+          className,
+        )}
+        {...props}
+      >
+        <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+          <span className="block size-2 rounded-full bg-background" />
+        </RadioGroupPrimitive.Indicator>
+      </RadioGroupPrimitive.Item>
+    );
+
+    if (!label && !description) {
+      return radioElement;
+    }
+
+    const content = (
+      <Atoms.Container overrideDefaults className="flex items-start gap-2">
+        {radioElement}
+        <Atoms.Container overrideDefaults className="flex flex-col gap-1.5">
+          {label && (
+            <Atoms.Label
+              htmlFor={itemId}
+              className="cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+            >
+              {label}
+            </Atoms.Label>
+          )}
+          {description && (
+            <Atoms.Typography className="text-sm leading-normal text-muted-foreground">{description}</Atoms.Typography>
+          )}
+        </Atoms.Container>
+      </Atoms.Container>
+    );
+
+    if (variant === 'box') {
+      return (
+        <Atoms.Container
+          overrideDefaults
+          className={Libs.cn(
+            'rounded-lg border border-border p-4 transition-colors',
+            'has-[[data-state=checked]]:border-brand',
+            'has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-50',
+          )}
+        >
+          {content}
+        </Atoms.Container>
+      );
+    }
+
+    return content;
+  },
+);
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/src/components/atoms/RadioGroup/index.ts
+++ b/src/components/atoms/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioGroup';

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -23,6 +23,7 @@ export * from './PageHeader';
 export * from './PageSubtitle';
 export * from './Popover';
 export * from './PostThreadConnector';
+export * from './RadioGroup';
 export * from './PostThreadSpacer';
 export * from './ReplyLine';
 export * from './Select';

--- a/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx
@@ -71,11 +71,17 @@ describe('CopyrightForm', () => {
     expect(screen.getByLabelText(/Full Name as Signature/i)).toBeInTheDocument();
   });
 
-  it('renders checkboxes for rights owner selection', () => {
+  it('renders radio buttons for rights owner selection', () => {
     render(<CopyrightForm />);
 
-    expect(screen.getByLabelText('I am the rights owner')).toBeInTheDocument();
-    expect(screen.getByLabelText('I am reporting on behalf of my organization or client')).toBeInTheDocument();
+    const rightsOwnerRadio = screen.getByLabelText('I am the rights owner');
+    const reportingRadio = screen.getByLabelText('I am reporting on behalf of my organization or client');
+
+    expect(rightsOwnerRadio).toHaveAttribute('role', 'radio');
+    expect(reportingRadio).toHaveAttribute('role', 'radio');
+    // Rights owner is selected by default
+    expect(rightsOwnerRadio).toHaveAttribute('aria-checked', 'true');
+    expect(reportingRadio).toHaveAttribute('aria-checked', 'false');
   });
 
   it('validates required fields on submit', async () => {
@@ -110,11 +116,10 @@ describe('CopyrightForm', () => {
     });
   });
 
-  it('validates role selection', async () => {
+  it('submits successfully when default role is selected (no role error shown)', async () => {
     const user = userEvent.setup();
     render(<CopyrightForm />);
 
-    // Fill all required fields first
     await user.type(screen.getByLabelText(/Name of the rights owner/i), 'John Doe');
     await user.type(screen.getByLabelText(/Original Content URLs/i), 'https://example.com/original');
     await user.type(screen.getByLabelText(/Brief description/i), 'Description');
@@ -130,17 +135,15 @@ describe('CopyrightForm', () => {
     await user.type(screen.getByLabelText(/Zip code/i), '10001');
     await user.type(screen.getByLabelText(/Full Name as Signature/i), 'John Doe');
 
-    // Switch to reporting on behalf, then uncheck it (both will be unchecked)
-    const reportingOnBehalfCheckbox = screen.getByLabelText('I am reporting on behalf of my organization or client');
-    await user.click(reportingOnBehalfCheckbox);
-    await user.click(reportingOnBehalfCheckbox);
-
     const submitButton = screen.getByRole('button', { name: 'Submit Form' });
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Please select if you are the rights owner or reporting on behalf')).toBeInTheDocument();
+      expect(global.fetch).toHaveBeenCalled();
     });
+    expect(
+      screen.queryByText('Please select if you are the rights owner or reporting on behalf'),
+    ).not.toBeInTheDocument();
   });
 
   it('submits form with valid data', async () => {
@@ -282,26 +285,26 @@ describe('CopyrightForm', () => {
     });
   });
 
-  it('handles checkbox interactions correctly', async () => {
+  it('handles radio selection correctly with mutual exclusivity', async () => {
     const user = userEvent.setup();
     render(<CopyrightForm />);
 
-    const rightsOwnerCheckbox = screen.getByLabelText('I am the rights owner');
-    const reportingOnBehalfCheckbox = screen.getByLabelText('I am reporting on behalf of my organization or client');
+    const rightsOwnerRadio = screen.getByLabelText('I am the rights owner');
+    const reportingOnBehalfRadio = screen.getByLabelText('I am reporting on behalf of my organization or client');
 
-    // Initially, rights owner is checked
-    expect(rightsOwnerCheckbox).toBeChecked();
-    expect(reportingOnBehalfCheckbox).not.toBeChecked();
+    // Initially, rights owner is selected
+    expect(rightsOwnerRadio).toHaveAttribute('aria-checked', 'true');
+    expect(reportingOnBehalfRadio).toHaveAttribute('aria-checked', 'false');
 
-    // Click reporting on behalf - should uncheck rights owner
-    await user.click(reportingOnBehalfCheckbox);
-    expect(reportingOnBehalfCheckbox).toBeChecked();
-    expect(rightsOwnerCheckbox).not.toBeChecked();
+    // Click reporting on behalf - rights owner deselects automatically
+    await user.click(reportingOnBehalfRadio);
+    expect(reportingOnBehalfRadio).toHaveAttribute('aria-checked', 'true');
+    expect(rightsOwnerRadio).toHaveAttribute('aria-checked', 'false');
 
-    // Click rights owner - should uncheck reporting on behalf
-    await user.click(rightsOwnerCheckbox);
-    expect(rightsOwnerCheckbox).toBeChecked();
-    expect(reportingOnBehalfCheckbox).not.toBeChecked();
+    // Click rights owner - reporting deselects automatically
+    await user.click(rightsOwnerRadio);
+    expect(rightsOwnerRadio).toHaveAttribute('aria-checked', 'true');
+    expect(reportingOnBehalfRadio).toHaveAttribute('aria-checked', 'false');
   });
 
   it('resets form after successful submission', async () => {

--- a/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
 <div
-  class="mx-auto w-full flex-col flex"
+  class="mx-auto w-full flex-col flex container max-w-(--container-max-width) px-6 pb-12 xl:px-0"
   data-testid="container"
 >
   <form>
@@ -61,8 +61,12 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
           Rights Owner Information
         </p>
         <div
-          class="mx-auto w-full flex-col flex gap-4 xl:flex-row xl:justify-between"
-          data-testid="container"
+          aria-required="false"
+          class="grid gap-3 gap-4 xl:grid-flow-col xl:auto-cols-fr"
+          dir="ltr"
+          role="radiogroup"
+          style="outline: none;"
+          tabindex="0"
         >
           <div
             class="flex items-start gap-2"
@@ -70,45 +74,32 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
           >
             <button
               aria-checked="true"
-              class="peer h-4 w-4 shrink-0 rounded border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+              class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+              data-radix-collection-item=""
               data-state="checked"
-              id="isRightsOwner"
-              role="checkbox"
+              id="radix-normalized"
+              role="radio"
+              tabindex="-1"
               type="button"
-              value="on"
+              value="rights_owner"
             >
               <span
                 class="flex items-center justify-center"
                 data-state="checked"
-                style="pointer-events: none;"
               >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-check h-3.5 w-3.5 text-background"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="3"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M20 6 9 17l-5-5"
-                  />
-                </svg>
+                <span
+                  class="block size-2 rounded-full bg-background"
+                />
               </span>
             </button>
             <input
               aria-hidden="true"
               checked=""
-              name="isRightsOwner"
-              style="position: absolute; pointer-events: none; opacity: 0; margin: 0px; transform: translateX(-100%); width: 0px; height: 0px;"
+              name="role"
+              style="transform: translateX(-100%); position: absolute; pointer-events: none; opacity: 0; margin: 0px; width: 0px; height: 0px;"
               tabindex="-1"
-              type="checkbox"
-              value="on"
+              type="radio"
+              value="rights_owner"
             />
             <div
               class="flex flex-col gap-1.5"
@@ -117,7 +108,7 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
               <label
                 class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
                 data-slot="label"
-                for="isRightsOwner"
+                for="radix-normalized"
               >
                 I am the rights owner
               </label>
@@ -129,20 +120,22 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
           >
             <button
               aria-checked="false"
-              class="peer h-4 w-4 shrink-0 rounded border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+              class="peer size-4 shrink-0 rounded-full border border-input bg-white/5 shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-brand data-[state=checked]:bg-brand"
+              data-radix-collection-item=""
               data-state="unchecked"
-              id="isReportingOnBehalf"
-              role="checkbox"
+              id="radix-normalized"
+              role="radio"
+              tabindex="-1"
               type="button"
-              value="on"
+              value="reporting_on_behalf"
             />
             <input
               aria-hidden="true"
-              name="isReportingOnBehalf"
-              style="position: absolute; pointer-events: none; opacity: 0; margin: 0px; transform: translateX(-100%); width: 0px; height: 0px;"
+              name="role"
+              style="transform: translateX(-100%); position: absolute; pointer-events: none; opacity: 0; margin: 0px; width: 0px; height: 0px;"
               tabindex="-1"
-              type="checkbox"
-              value="on"
+              type="radio"
+              value="reporting_on_behalf"
             />
             <div
               class="flex flex-col gap-1.5"
@@ -151,7 +144,7 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
               <label
                 class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 cursor-pointer text-base leading-none font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
                 data-slot="label"
-                for="isReportingOnBehalf"
+                for="radix-normalized"
               >
                 I am reporting on behalf of my organization or client
               </label>

--- a/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
           Rights Owner Information
         </p>
         <div
-          aria-required="false"
+          aria-required="true"
           class="grid gap-3 gap-4 xl:auto-cols-fr xl:grid-flow-col"
           dir="ltr"
           role="radiogroup"

--- a/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`CopyrightForm - Snapshots > matches snapshot for default state 1`] = `
         </p>
         <div
           aria-required="false"
-          class="grid gap-3 gap-4 xl:grid-flow-col xl:auto-cols-fr"
+          class="grid gap-3 gap-4 xl:auto-cols-fr xl:grid-flow-col"
           dir="ltr"
           role="radiogroup"
           style="outline: none;"

--- a/src/components/organisms/CopyrightForm/CopyrightForm.tsx
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.tsx
@@ -1,21 +1,22 @@
 'use client';
 
+import { Controller } from 'react-hook-form';
 import * as Atoms from '@/atoms';
 import * as Hooks from '@/hooks';
 import * as Libs from '@/libs';
 import * as Molecules from '@/molecules';
-import { COPYRIGHT_FORM_FIELDS, type CopyrightFormData } from '@/hooks';
+import { COPYRIGHT_FORM_FIELDS, COPYRIGHT_ROLES, type CopyrightFormData } from '@/hooks';
 import { useTranslations } from 'next-intl';
 
 export function CopyrightForm() {
   const t = useTranslations('forms.copyright');
-  const { form, onSubmit, handleRoleChange } = Hooks.useCopyrightForm();
+  const { form, onSubmit } = Hooks.useCopyrightForm();
   const { isSubmitting, errors } = form.formState;
-  const roleError = errors.isRightsOwner?.message;
+  const roleError = errors.role?.message;
   const currentDate = Libs.formatUSDate();
 
   return (
-    <Atoms.Container>
+    <Atoms.Container size="container" className="px-6 pb-12 xl:px-0">
       <form onSubmit={onSubmit}>
         <Atoms.Card className="rounded-t-lg rounded-b-none border border-border p-8 md:p-12">
           <Atoms.Container className="gap-6">
@@ -47,29 +48,34 @@ export function CopyrightForm() {
 
             <Atoms.Typography size="md">{t('rightsOwner')}</Atoms.Typography>
 
-            <Atoms.Container className="gap-4 xl:flex-row xl:justify-between">
-              <Atoms.Checkbox
-                id={COPYRIGHT_FORM_FIELDS.IS_RIGHTS_OWNER}
-                name={COPYRIGHT_FORM_FIELDS.IS_RIGHTS_OWNER}
-                checked={form.watch(COPYRIGHT_FORM_FIELDS.IS_RIGHTS_OWNER)}
-                onCheckedChange={(checked) => handleRoleChange(COPYRIGHT_FORM_FIELDS.IS_RIGHTS_OWNER, Boolean(checked))}
-                label={t('iAmOwner')}
-                disabled={isSubmitting}
-              />
-              <Atoms.Checkbox
-                id={COPYRIGHT_FORM_FIELDS.IS_REPORTING_ON_BEHALF}
-                name={COPYRIGHT_FORM_FIELDS.IS_REPORTING_ON_BEHALF}
-                checked={form.watch(COPYRIGHT_FORM_FIELDS.IS_REPORTING_ON_BEHALF)}
-                onCheckedChange={(checked) =>
-                  handleRoleChange(COPYRIGHT_FORM_FIELDS.IS_REPORTING_ON_BEHALF, Boolean(checked))
-                }
-                label={t('iAmReporting')}
-                disabled={isSubmitting}
-              />
-            </Atoms.Container>
+            <Controller
+              control={form.control}
+              name={COPYRIGHT_FORM_FIELDS.ROLE}
+              render={({ field }) => (
+                <Atoms.RadioGroup
+                  name={field.name}
+                  value={field.value ?? ''}
+                  onValueChange={field.onChange}
+                  onBlur={field.onBlur}
+                  disabled={isSubmitting}
+                  className="gap-4 xl:auto-cols-fr xl:grid-flow-col"
+                  aria-invalid={Boolean(roleError) || undefined}
+                  aria-errormessage={roleError ? 'copyright-role-error' : undefined}
+                  aria-describedby={roleError ? 'copyright-role-error' : undefined}
+                >
+                  <Atoms.RadioGroupItem value={COPYRIGHT_ROLES.RIGHTS_OWNER} label={t('iAmOwner')} />
+                  <Atoms.RadioGroupItem value={COPYRIGHT_ROLES.REPORTING_ON_BEHALF} label={t('iAmReporting')} />
+                </Atoms.RadioGroup>
+              )}
+            />
 
             {roleError && (
-              <Atoms.Typography size="sm" className="font-normal text-destructive" role="alert">
+              <Atoms.Typography
+                id="copyright-role-error"
+                size="sm"
+                className="font-normal text-destructive"
+                role="alert"
+              >
                 {roleError}
               </Atoms.Typography>
             )}

--- a/src/components/organisms/CopyrightForm/CopyrightForm.tsx
+++ b/src/components/organisms/CopyrightForm/CopyrightForm.tsx
@@ -59,6 +59,7 @@ export function CopyrightForm() {
                   onBlur={field.onBlur}
                   disabled={isSubmitting}
                   className="gap-4 xl:auto-cols-fr xl:grid-flow-col"
+                  aria-required
                   aria-invalid={Boolean(roleError) || undefined}
                   aria-errormessage={roleError ? 'copyright-role-error' : undefined}
                   aria-describedby={roleError ? 'copyright-role-error' : undefined}

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -50,10 +50,12 @@ export function Header() {
     return <Molecules.HeaderHome />;
   };
 
-  // Copyright page shows only logo (minimal header)
+  // Copyright page shows only logo (minimal header).
+  // Pass the same classNameNav as other routes so the logo doesn't shift
+  // horizontally when navigating between the app and /copyright.
   if (isCopyrightPage) {
     return (
-      <Molecules.HeaderContainer>
+      <Molecules.HeaderContainer classNameNav={classNameNav}>
         <Molecules.Logo />
       </Molecules.HeaderContainer>
     );

--- a/src/hooks/useCopyrightForm/useCopyrightForm.constants.ts
+++ b/src/hooks/useCopyrightForm/useCopyrightForm.constants.ts
@@ -1,15 +1,19 @@
 import type { CopyrightFormData } from './useCopyrightForm.types';
 
-/** Field names for role selection checkboxes */
+/** Allowed values for the copyright role field */
+export const COPYRIGHT_ROLES = {
+  RIGHTS_OWNER: 'rights_owner',
+  REPORTING_ON_BEHALF: 'reporting_on_behalf',
+} as const;
+
+/** Field names for the copyright form */
 export const COPYRIGHT_FORM_FIELDS = {
-  IS_RIGHTS_OWNER: 'isRightsOwner',
-  IS_REPORTING_ON_BEHALF: 'isReportingOnBehalf',
+  ROLE: 'role',
 } as const;
 
 /** Default values for the copyright form */
 export const copyrightFormDefaultValues: CopyrightFormData = {
-  isRightsOwner: true,
-  isReportingOnBehalf: false,
+  role: COPYRIGHT_ROLES.RIGHTS_OWNER,
   nameOwner: '',
   originalContentUrls: '',
   briefDescription: '',

--- a/src/hooks/useCopyrightForm/useCopyrightForm.test.tsx
+++ b/src/hooks/useCopyrightForm/useCopyrightForm.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCopyrightForm } from './useCopyrightForm';
+import { COPYRIGHT_ROLES } from './useCopyrightForm.constants';
 
 const mockToast = vi.fn();
 const mockShowErrorToast = vi.fn();
@@ -42,38 +43,14 @@ describe('useCopyrightForm', () => {
   });
 
   describe('initial state', () => {
-    it('should initialize with correct default values', () => {
+    it('should initialize with rights_owner role selected by default', () => {
       const { result } = renderHook(() => useCopyrightForm());
       const values = result.current.form.getValues();
 
-      expect(values.isRightsOwner).toBe(true);
-      expect(values.isReportingOnBehalf).toBe(false);
+      expect(values.role).toBe(COPYRIGHT_ROLES.RIGHTS_OWNER);
       expect(values.nameOwner).toBe('');
       expect(values.email).toBe('');
       expect(result.current.form.formState.isSubmitting).toBe(false);
-    });
-  });
-
-  describe('handleRoleChange', () => {
-    it('should handle mutual exclusion for role checkboxes', () => {
-      const { result } = renderHook(() => useCopyrightForm());
-
-      expect(result.current.form.getValues('isRightsOwner')).toBe(true);
-      expect(result.current.form.getValues('isReportingOnBehalf')).toBe(false);
-
-      act(() => {
-        result.current.handleRoleChange('isReportingOnBehalf', true);
-      });
-
-      expect(result.current.form.getValues('isRightsOwner')).toBe(false);
-      expect(result.current.form.getValues('isReportingOnBehalf')).toBe(true);
-
-      act(() => {
-        result.current.handleRoleChange('isRightsOwner', true);
-      });
-
-      expect(result.current.form.getValues('isRightsOwner')).toBe(true);
-      expect(result.current.form.getValues('isReportingOnBehalf')).toBe(false);
     });
   });
 
@@ -88,22 +65,25 @@ describe('useCopyrightForm', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('should not submit when role validation fails', async () => {
+    it('should not submit when role is unset', async () => {
       const { result } = renderHook(() => useCopyrightForm());
 
-      // Fill all required fields but uncheck both role checkboxes
+      // Fill all required fields, then clear the role to trigger role validation failure
       act(() => {
         Object.entries(validFormData).forEach(([key, value]) => {
           result.current.form.setValue(key as keyof typeof validFormData, value);
         });
-        result.current.handleRoleChange('isRightsOwner', false);
+        // Cast undefined to bypass enum-typing — we're explicitly testing the unset case
+        result.current.form.setValue(
+          'role',
+          undefined as unknown as (typeof COPYRIGHT_ROLES)[keyof typeof COPYRIGHT_ROLES],
+        );
       });
 
       await act(async () => {
         await result.current.onSubmit();
       });
 
-      // Should not call fetch because role validation fails
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -126,24 +106,47 @@ describe('useCopyrightForm', () => {
   });
 
   describe('form submission', () => {
-    it('should submit form with valid data', async () => {
+    it('should derive isRightsOwner=true / isReportingOnBehalf=false in payload when role=rights_owner', async () => {
       const { result } = renderHook(() => useCopyrightForm());
 
       act(() => {
         Object.entries(validFormData).forEach(([key, value]) => {
           result.current.form.setValue(key as keyof typeof validFormData, value);
         });
+        result.current.form.setValue('role', COPYRIGHT_ROLES.RIGHTS_OWNER);
       });
 
       await act(async () => {
         await result.current.onSubmit();
       });
 
-      expect(global.fetch).toHaveBeenCalledWith('/api/copyright', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: expect.stringContaining('"nameOwner":"John Doe"'),
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [, init] = vi.mocked(global.fetch).mock.calls[0]!;
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.isRightsOwner).toBe(true);
+      expect(body.isReportingOnBehalf).toBe(false);
+      expect(body.role).toBeUndefined();
+      expect(body.nameOwner).toBe('John Doe');
+    });
+
+    it('should derive isRightsOwner=false / isReportingOnBehalf=true in payload when role=reporting_on_behalf', async () => {
+      const { result } = renderHook(() => useCopyrightForm());
+
+      act(() => {
+        Object.entries(validFormData).forEach(([key, value]) => {
+          result.current.form.setValue(key as keyof typeof validFormData, value);
+        });
+        result.current.form.setValue('role', COPYRIGHT_ROLES.REPORTING_ON_BEHALF);
       });
+
+      await act(async () => {
+        await result.current.onSubmit();
+      });
+
+      const [, init] = vi.mocked(global.fetch).mock.calls[0]!;
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.isRightsOwner).toBe(false);
+      expect(body.isReportingOnBehalf).toBe(true);
     });
 
     it('should show success toast on successful submission', async () => {
@@ -188,13 +191,14 @@ describe('useCopyrightForm', () => {
       });
     });
 
-    it('should reset form after successful submission', async () => {
+    it('should reset form (and restore default role) after successful submission', async () => {
       const { result } = renderHook(() => useCopyrightForm());
 
       act(() => {
         Object.entries(validFormData).forEach(([key, value]) => {
           result.current.form.setValue(key as keyof typeof validFormData, value);
         });
+        result.current.form.setValue('role', COPYRIGHT_ROLES.REPORTING_ON_BEHALF);
       });
 
       expect(result.current.form.getValues('nameOwner')).toBe('John Doe');
@@ -204,7 +208,7 @@ describe('useCopyrightForm', () => {
       });
 
       expect(result.current.form.getValues('nameOwner')).toBe('');
-      expect(result.current.form.getValues('isRightsOwner')).toBe(true);
+      expect(result.current.form.getValues('role')).toBe(COPYRIGHT_ROLES.RIGHTS_OWNER);
     });
 
     it('should handle network errors gracefully', async () => {

--- a/src/hooks/useCopyrightForm/useCopyrightForm.ts
+++ b/src/hooks/useCopyrightForm/useCopyrightForm.ts
@@ -5,8 +5,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
 import * as Molecules from '@/molecules';
 import { postJson } from '@/libs';
-import { copyrightFormSchema, type CopyrightFormData, type RoleField } from './useCopyrightForm.types';
-import { copyrightFormDefaultValues, COPYRIGHT_FORM_FIELDS } from './useCopyrightForm.constants';
+import { copyrightFormSchema, type CopyrightFormData } from './useCopyrightForm.types';
+import { copyrightFormDefaultValues, COPYRIGHT_ROLES } from './useCopyrightForm.constants';
 
 export function useCopyrightForm() {
   const tToast = useTranslations('toast');
@@ -19,7 +19,12 @@ export function useCopyrightForm() {
 
   const submitForm = async (data: CopyrightFormData) => {
     try {
-      await postJson('/api/copyright', data);
+      const { role, ...rest } = data;
+      await postJson('/api/copyright', {
+        ...rest,
+        isRightsOwner: role === COPYRIGHT_ROLES.RIGHTS_OWNER,
+        isReportingOnBehalf: role === COPYRIGHT_ROLES.REPORTING_ON_BEHALF,
+      });
 
       form.reset();
       Molecules.toast({ title: tToast('success'), description: tCopyright('success') });
@@ -46,31 +51,8 @@ export function useCopyrightForm() {
 
   const onSubmit = form.handleSubmit(submitForm, handleInvalidSubmit);
 
-  const handleRoleChange = (field: RoleField, checked: boolean) => {
-    const { IS_RIGHTS_OWNER, IS_REPORTING_ON_BEHALF } = COPYRIGHT_FORM_FIELDS;
-
-    if (field === IS_RIGHTS_OWNER) {
-      form.setValue(IS_RIGHTS_OWNER, checked);
-      if (checked) form.setValue(IS_REPORTING_ON_BEHALF, false);
-    } else {
-      form.setValue(IS_REPORTING_ON_BEHALF, checked);
-      if (checked) form.setValue(IS_RIGHTS_OWNER, false);
-    }
-    const nextIsRightsOwner = form.getValues(IS_RIGHTS_OWNER);
-    const nextIsReportingOnBehalf = form.getValues(IS_REPORTING_ON_BEHALF);
-
-    if (nextIsRightsOwner || nextIsReportingOnBehalf) {
-      // Clear the role error when a valid selection is made
-      form.clearErrors(IS_RIGHTS_OWNER);
-    } else {
-      // Re-validate to surface the role error immediately
-      void form.trigger(IS_RIGHTS_OWNER);
-    }
-  };
-
   return {
     form,
     onSubmit,
-    handleRoleChange,
   };
 }

--- a/src/hooks/useCopyrightForm/useCopyrightForm.types.ts
+++ b/src/hooks/useCopyrightForm/useCopyrightForm.types.ts
@@ -1,41 +1,35 @@
 import { z } from 'zod';
 import { VALIDATION_PATTERNS, VALIDATION_MESSAGES } from '@/config';
-import { COPYRIGHT_FORM_FIELDS } from './useCopyrightForm.constants';
-
-/** Type for role field names */
-export type RoleField = (typeof COPYRIGHT_FORM_FIELDS)[keyof typeof COPYRIGHT_FORM_FIELDS];
+import { COPYRIGHT_ROLES } from './useCopyrightForm.constants';
 
 /**
  * Schema for the copyright removal request form.
- * Validates all required fields and ensures at least one role is selected.
+ * Uses a single `role` enum (UI-only); the API still receives two booleans
+ * derived from this value at submit time, preserving the wire contract.
  */
-export const copyrightFormSchema = z
-  .object({
-    isRightsOwner: z.boolean(),
-    isReportingOnBehalf: z.boolean(),
-    nameOwner: z.string().min(1, 'Name of rights owner is required'),
-    originalContentUrls: z.string().min(1, 'Original content URLs are required'),
-    briefDescription: z.string().min(1, 'Brief description is required'),
-    infringingContentUrl: z.string().min(1, 'Infringing content URL is required'),
-    firstName: z.string().min(1, 'First name is required'),
-    lastName: z.string().min(1, 'Last name is required'),
-    email: z.string().min(1, 'Email is required').email(VALIDATION_MESSAGES.INVALID_EMAIL),
-    phoneNumber: z
-      .string()
-      .min(1, 'Phone number is required')
-      .refine((val) => VALIDATION_PATTERNS.PHONE.test(val), {
-        message: VALIDATION_MESSAGES.INVALID_PHONE,
-      }),
-    streetAddress: z.string().min(1, 'Street address is required'),
-    country: z.string().min(1, 'Country is required'),
-    city: z.string().min(1, 'City is required'),
-    stateProvince: z.string().min(1, 'State/Province is required'),
-    zipCode: z.string().min(1, 'Zip code is required'),
-    signature: z.string().min(1, 'Signature is required'),
-  })
-  .refine((data) => data.isRightsOwner || data.isReportingOnBehalf, {
+export const copyrightFormSchema = z.object({
+  role: z.enum([COPYRIGHT_ROLES.RIGHTS_OWNER, COPYRIGHT_ROLES.REPORTING_ON_BEHALF], {
     message: VALIDATION_MESSAGES.ROLE_REQUIRED,
-    path: ['isRightsOwner'],
-  });
+  }),
+  nameOwner: z.string().min(1, 'Name of rights owner is required'),
+  originalContentUrls: z.string().min(1, 'Original content URLs are required'),
+  briefDescription: z.string().min(1, 'Brief description is required'),
+  infringingContentUrl: z.string().min(1, 'Infringing content URL is required'),
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  email: z.string().min(1, 'Email is required').email(VALIDATION_MESSAGES.INVALID_EMAIL),
+  phoneNumber: z
+    .string()
+    .min(1, 'Phone number is required')
+    .refine((val) => VALIDATION_PATTERNS.PHONE.test(val), {
+      message: VALIDATION_MESSAGES.INVALID_PHONE,
+    }),
+  streetAddress: z.string().min(1, 'Street address is required'),
+  country: z.string().min(1, 'Country is required'),
+  city: z.string().min(1, 'City is required'),
+  stateProvince: z.string().min(1, 'State/Province is required'),
+  zipCode: z.string().min(1, 'Zip code is required'),
+  signature: z.string().min(1, 'Signature is required'),
+});
 
 export type CopyrightFormData = z.infer<typeof copyrightFormSchema>;


### PR DESCRIPTION
Mutually-exclusive role selection in the Copyright form now uses a single radio group instead of two coupled checkboxes. Form state holds a `role` enum; the API payload still carries `isRightsOwner` / `isReportingOnBehalf` booleans (derived at submit) so the server-side controller, validators, and application layer remain unchanged.

Also aligns the Copyright page content width with the rest of the app (`/hot`, `/profile`) and fixes a horizontal logo shift in the header when navigating between app routes and `/copyright`.

- Add shadcn-style RadioGroup atom backed by radix-ui (default + box variants), matching the existing Checkbox tokens
- Replace handleRoleChange with a Controller-driven RadioGroup; derive booleans in submitForm
- Wrap the form in size="container" with px-6 pb-12 xl:px-0 to match ContentLayout used elsewhere
- Pass classNameNav through to the copyright header branch so the logo position no longer jumps between pages
- Add aria-errormessage / aria-describedby + value={field.value ?? ''} fallback for safer Radix controlled state and clearer a11y wiring
- Update hook + component tests, regenerate snapshots

<img width="1724" height="959" alt="image" src="https://github.com/user-attachments/assets/126d6c81-421b-4d2e-8951-0c36db0bd0ec" />


Resolves: #877