### PR TITLE
refactor: unify mobile tab menus into shared component

### DIFF
--- a/src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx
+++ b/src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx
@@ -17,25 +17,39 @@ describe('HotMobileMenu', () => {
     });
   });
 
-  it('has correct structure with sticky positioning', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
-    const rootElement = container.firstChild as HTMLElement;
-    expect(rootElement).toHaveClass(
-      'sticky',
-      'top-(--header-height-mobile)',
-      'z-(--z-mobile-menu)',
-      '-mx-6',
-      '-mt-6',
-      'mb-6',
-      'bg-background',
-      'lg:hidden',
-    );
-  });
-
   it('renders correct number of menu items', () => {
     const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
     const buttons = container.querySelectorAll('button');
     expect(buttons).toHaveLength(HOT_MOBILE_MENU_ITEMS.length);
+  });
+
+  it('renders text labels alongside icons (showLabels mode)', () => {
+    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
+
+    HOT_MOBILE_MENU_ITEMS.forEach((item) => {
+      expect(screen.getByText(item.section)).toBeInTheDocument();
+    });
+
+    const icons = container.querySelectorAll('svg');
+    expect(icons).toHaveLength(HOT_MOBILE_MENU_ITEMS.length);
+  });
+
+  it('applies Hot-specific margin overrides via className passthrough', () => {
+    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
+    const rootElement = container.firstChild as HTMLElement;
+    expect(rootElement).toHaveClass('-mx-6', '-mt-6', 'mb-6');
+  });
+
+  it('renders with sticky positioning', () => {
+    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
+    const rootElement = container.firstChild as HTMLElement;
+    expect(rootElement).toHaveClass('sticky', 'top-(--header-height-mobile)');
+  });
+
+  it('exposes the hot-mobile-menu data-testid on the root', () => {
+    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
+    const rootElement = container.firstChild as HTMLElement;
+    expect(rootElement).toHaveAttribute('data-testid', 'hot-mobile-menu');
   });
 
   it('marks the active item with aria-current="page"', () => {
@@ -43,52 +57,6 @@ describe('HotMobileMenu', () => {
     const activeButton = container.querySelector('button[aria-current="page"]');
     expect(activeButton).toBeInTheDocument();
     expect(activeButton).toHaveAttribute('aria-label', 'users');
-  });
-
-  it('applies correct border classes to active and inactive items', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.USERS} onSectionChange={() => {}} />);
-    const items = container.querySelectorAll('div[class*="border-b"]');
-
-    const usersIndex = HOT_MOBILE_MENU_ITEMS.findIndex((item) => item.section === HotSection.USERS);
-    const activeItem = items[usersIndex];
-    expect(activeItem).toHaveClass('border-foreground');
-
-    items.forEach((item, index) => {
-      if (index !== usersIndex) {
-        expect(item).toHaveClass('border-border');
-      }
-    });
-  });
-
-  it('applies correct text color classes to icons', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.USERS} onSectionChange={() => {}} />);
-    const icons = container.querySelectorAll('svg');
-
-    const usersIndex = HOT_MOBILE_MENU_ITEMS.findIndex((item) => item.section === HotSection.USERS);
-    const activeIcon = icons[usersIndex];
-    expect(activeIcon).toHaveClass('text-foreground');
-
-    icons.forEach((icon, index) => {
-      if (index !== usersIndex) {
-        expect(icon).toHaveClass('text-muted-foreground');
-      }
-    });
-  });
-
-  it('has correct button structure with padding', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
-    const buttons = container.querySelectorAll('button');
-    buttons.forEach((button) => {
-      expect(button).toHaveClass('px-2.5', 'py-2');
-    });
-  });
-
-  it('has correct container structure with flex and border', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
-    const items = container.querySelectorAll('div[class*="border-b"]');
-    items.forEach((item) => {
-      expect(item).toHaveClass('flex', 'flex-1', 'justify-center', 'border-b', 'px-0', 'py-1.5');
-    });
   });
 
   it('calls onSectionChange with correct section when clicked', async () => {
@@ -107,17 +75,6 @@ describe('HotMobileMenu', () => {
     expect(onSectionChange).toHaveBeenCalledWith(HotSection.TAGS);
 
     expect(onSectionChange).toHaveBeenCalledTimes(3);
-  });
-
-  it('renders text labels alongside icons', () => {
-    const { container } = render(<HotMobileMenu activeSection={HotSection.TAGS} onSectionChange={() => {}} />);
-
-    HOT_MOBILE_MENU_ITEMS.forEach((item) => {
-      expect(screen.getByText(item.section)).toBeInTheDocument();
-    });
-
-    const icons = container.querySelectorAll('svg');
-    expect(icons).toHaveLength(HOT_MOBILE_MENU_ITEMS.length);
   });
 });
 

--- a/src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx.snap
+++ b/src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HotMobileMenu - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="mobile-menu-gradient-fade sticky top-(--header-height-mobile) z-(--z-mobile-menu) -mx-6 -mt-6 mb-6 bg-background lg:hidden"
+  class="mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden sticky top-(--header-height-mobile) -mx-6 -mt-6 mb-6"
   data-testid="hot-mobile-menu"
 >
   <div
@@ -16,7 +16,7 @@ exports[`HotMobileMenu - Snapshots > matches snapshot with default props 1`] = `
       <button
         aria-current="page"
         aria-label="tags"
-        class="flex items-center gap-2 px-2.5 py-2"
+        class="px-2.5 py-2 flex items-center gap-2"
         data-slot="button"
       >
         <svg
@@ -56,7 +56,7 @@ exports[`HotMobileMenu - Snapshots > matches snapshot with default props 1`] = `
     >
       <button
         aria-label="users"
-        class="flex items-center gap-2 px-2.5 py-2"
+        class="px-2.5 py-2 flex items-center gap-2"
         data-slot="button"
       >
         <svg
@@ -98,7 +98,7 @@ exports[`HotMobileMenu - Snapshots > matches snapshot with default props 1`] = `
     >
       <button
         aria-label="posts"
-        class="flex items-center gap-2 px-2.5 py-2"
+        class="px-2.5 py-2 flex items-center gap-2"
         data-slot="button"
       >
         <svg

--- a/src/components/molecules/HotMobileMenu/HotMobileMenu.tsx
+++ b/src/components/molecules/HotMobileMenu/HotMobileMenu.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import * as Atoms from '@/atoms';
-import * as Libs from '@/libs';
 import { useTranslations } from 'next-intl';
+import * as Libs from '@/libs';
+import { MobileTabBar, type MobileTabBarItem } from '../MobileTabBar';
 import { HotSection, type HotMobileMenuItem, type HotMobileMenuProps } from './HotMobileMenu.types';
 
 export const HOT_MOBILE_MENU_ITEMS: HotMobileMenuItem[] = [
@@ -15,9 +15,9 @@ export const HOT_MOBILE_MENU_ITEMS: HotMobileMenuItem[] = [
  * Mobile navigation menu for the Hot page.
  * Shows 3 tabs with icon + text: Tags, Users, Posts.
  * Only visible on mobile (< lg breakpoint).
- * Follows same positioning pattern as ProfilePageMobileMenu.
+ * Delegates rendering to the shared `MobileTabBar` molecule.
  *
- * Negative margin overrides:
+ * Negative margin overrides (passed via className):
  * - `-mx-6` cancels the parent ContentLayout container's `px-6` padding
  *   so the menu stretches full-width edge-to-edge.
  * - `-mt-6` cancels the parent flex container's `gap-6` above so the menu sits
@@ -26,45 +26,21 @@ export const HOT_MOBILE_MENU_ITEMS: HotMobileMenuItem[] = [
 export function HotMobileMenu({ activeSection, onSectionChange }: HotMobileMenuProps) {
   const t = useTranslations('hot');
 
-  return (
-    <Atoms.Container
-      overrideDefaults
-      data-testid="hot-mobile-menu"
-      className="mobile-menu-gradient-fade sticky top-(--header-height-mobile) z-(--z-mobile-menu) -mx-6 -mt-6 mb-6 bg-background lg:hidden"
-    >
-      <Atoms.Container overrideDefaults className="flex w-full">
-        {HOT_MOBILE_MENU_ITEMS.map((item) => {
-          const Icon = item.icon;
-          const isSelected = item.section === activeSection;
+  const items: MobileTabBarItem[] = HOT_MOBILE_MENU_ITEMS.map((item) => ({
+    key: item.section,
+    icon: item.icon,
+    label: t(item.section),
+    isActive: item.section === activeSection,
+    onSelect: () => onSectionChange(item.section),
+  }));
 
-          return (
-            <Atoms.Container
-              key={item.section}
-              overrideDefaults
-              className={Libs.cn(
-                'flex flex-1 justify-center border-b px-0 py-1.5',
-                isSelected ? 'border-foreground' : 'border-border',
-              )}
-            >
-              <Atoms.Button
-                overrideDefaults
-                onClick={() => onSectionChange(item.section)}
-                className="flex items-center gap-2 px-2.5 py-2"
-                aria-label={t(item.section)}
-                aria-current={isSelected ? 'page' : undefined}
-              >
-                <Icon size={20} className={isSelected ? 'text-foreground' : 'text-muted-foreground'} />
-                <Atoms.Typography
-                  as="span"
-                  className={Libs.cn('text-sm font-medium', isSelected ? 'text-foreground' : 'text-muted-foreground')}
-                >
-                  {t(item.section)}
-                </Atoms.Typography>
-              </Atoms.Button>
-            </Atoms.Container>
-          );
-        })}
-      </Atoms.Container>
-    </Atoms.Container>
+  return (
+    <MobileTabBar
+      items={items}
+      showLabels
+      position="sticky"
+      className="-mx-6 -mt-6 mb-6"
+      data-testid="hot-mobile-menu"
+    />
   );
 }

--- a/src/components/molecules/MobileTabBar/MobileTabBar.test.tsx
+++ b/src/components/molecules/MobileTabBar/MobileTabBar.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as Libs from '@/libs';
+import { MobileTabBar } from './MobileTabBar';
+import type { MobileTabBarItem } from './MobileTabBar.types';
+
+const makeItems = (overrides: Partial<Record<string, Partial<MobileTabBarItem>>> = {}): MobileTabBarItem[] => {
+  const base: MobileTabBarItem[] = [
+    {
+      key: 'tags',
+      icon: Libs.Tag,
+      label: 'Tags',
+      isActive: true,
+      onSelect: vi.fn(),
+    },
+    {
+      key: 'users',
+      icon: Libs.UsersRound,
+      label: 'Users',
+      isActive: false,
+      onSelect: vi.fn(),
+    },
+    {
+      key: 'posts',
+      icon: Libs.StickyNote,
+      label: 'Posts',
+      isActive: false,
+      onSelect: vi.fn(),
+    },
+  ];
+  return base.map((item) => ({ ...item, ...(overrides[item.key] ?? {}) }));
+};
+
+describe('MobileTabBar', () => {
+  it('renders all items', () => {
+    render(<MobileTabBar items={makeItems()} />);
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument();
+    expect(screen.getByLabelText('Users')).toBeInTheDocument();
+    expect(screen.getByLabelText('Posts')).toBeInTheDocument();
+  });
+
+  it('renders correct number of buttons', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} />);
+    expect(container.querySelectorAll('button')).toHaveLength(3);
+  });
+
+  it('does not render label text in icon-only mode', () => {
+    render(<MobileTabBar items={makeItems()} />);
+    expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+  });
+
+  it('renders label text when showLabels is true', () => {
+    render(<MobileTabBar items={makeItems()} showLabels />);
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('Posts')).toBeInTheDocument();
+  });
+
+  it('applies active color to both icon and label when showLabels is true', () => {
+    render(<MobileTabBar items={makeItems()} showLabels />);
+    const activeLabel = screen.getByText('Tags');
+    expect(activeLabel).toHaveClass('text-foreground');
+    const inactiveLabel = screen.getByText('Users');
+    expect(inactiveLabel).toHaveClass('text-muted-foreground');
+  });
+
+  it('applies sticky positioning by default', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('sticky', 'top-(--header-height-mobile)');
+    expect(root).not.toHaveClass('fixed');
+  });
+
+  it('applies fixed positioning when requested', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} position="fixed" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('fixed', 'top-(--header-height-mobile)', 'right-0', 'left-0');
+    expect(root).not.toHaveClass('sticky');
+  });
+
+  it('always applies shared root classes', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('mobile-menu-gradient-fade', 'bg-background', 'lg:hidden', 'z-(--z-mobile-menu)');
+  });
+
+  it('marks active item with border-foreground, icon text-foreground, and aria-current', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} />);
+    const activeButton = container.querySelector('button[aria-current="page"]');
+    expect(activeButton).toBeInTheDocument();
+    expect(activeButton).toHaveAttribute('aria-label', 'Tags');
+
+    const cells = container.querySelectorAll('div[class*="border-b"]');
+    expect(cells[0]).toHaveClass('border-foreground');
+    expect(cells[1]).toHaveClass('border-border');
+    expect(cells[2]).toHaveClass('border-border');
+
+    const icons = container.querySelectorAll('svg');
+    expect(icons[0]).toHaveClass('text-foreground');
+    expect(icons[1]).toHaveClass('text-muted-foreground');
+    expect(icons[2]).toHaveClass('text-muted-foreground');
+  });
+
+  it('does not set aria-current on inactive items', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} />);
+    const inactiveButtons = container.querySelectorAll('button:not([aria-current])');
+    expect(inactiveButtons).toHaveLength(2);
+  });
+
+  it('calls onSelect when clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const items = makeItems({ users: { onSelect } });
+
+    render(<MobileTabBar items={items} />);
+    await user.click(screen.getByLabelText('Users'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults aria-label to label', () => {
+    render(<MobileTabBar items={makeItems()} />);
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument();
+  });
+
+  it('uses ariaLabel override when provided', () => {
+    const items = makeItems({ tags: { ariaLabel: 'Custom Tags Label' } });
+    render(<MobileTabBar items={items} />);
+    expect(screen.getByLabelText('Custom Tags Label')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Tags')).not.toBeInTheDocument();
+  });
+
+  it('merges className onto the root', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} className="-mx-6 -mt-6 mb-6" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('-mx-6', '-mt-6', 'mb-6');
+  });
+
+  it('passes through data-testid', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} data-testid="my-tab-bar" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-testid', 'my-tab-bar');
+  });
+
+  it('applies flex items-center gap-2 to button only when showLabels is true', () => {
+    const { container: iconOnly } = render(<MobileTabBar items={makeItems()} />);
+    iconOnly.querySelectorAll('button').forEach((btn) => {
+      expect(btn).toHaveClass('px-2.5', 'py-2');
+      expect(btn).not.toHaveClass('flex', 'items-center', 'gap-2');
+    });
+
+    const { container: withLabels } = render(<MobileTabBar items={makeItems()} showLabels />);
+    withLabels.querySelectorAll('button').forEach((btn) => {
+      expect(btn).toHaveClass('px-2.5', 'py-2', 'flex', 'items-center', 'gap-2');
+    });
+  });
+});
+
+describe('MobileTabBar - Snapshots', () => {
+  it('matches snapshot for icon-only sticky (default)', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} data-testid="mobile-tab-bar" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for showLabels + sticky', () => {
+    const { container } = render(<MobileTabBar items={makeItems()} showLabels data-testid="mobile-tab-bar" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/MobileTabBar/MobileTabBar.test.tsx.snap
+++ b/src/components/molecules/MobileTabBar/MobileTabBar.test.tsx.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
+exports[`MobileTabBar - Snapshots > matches snapshot for icon-only sticky (default) 1`] = `
 <div
-  class="mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden fixed top-(--header-height-mobile) right-0 left-0"
-  data-testid="settings-mobile-menu"
+  class="mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden sticky top-(--header-height-mobile)"
+  data-testid="mobile-tab-bar"
 >
   <div
     class="flex w-full"
@@ -15,13 +15,13 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
     >
       <button
         aria-current="page"
-        aria-label="Account"
+        aria-label="Tags"
         class="px-2.5 py-2"
         data-slot="button"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-user-round text-foreground"
+          class="lucide lucide-tag text-foreground"
           fill="none"
           height="20"
           stroke="currentColor"
@@ -32,13 +32,50 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
           width="20"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <path
+            d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
+          />
           <circle
-            cx="12"
+            cx="7.5"
+            cy="7.5"
+            fill="currentColor"
+            r=".5"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
+      data-testid="container"
+    >
+      <button
+        aria-label="Users"
+        class="px-2.5 py-2"
+        data-slot="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-users-round text-muted-foreground"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 21a8 8 0 0 0-16 0"
+          />
+          <circle
+            cx="10"
             cy="8"
             r="5"
           />
           <path
-            d="M20 21a8 8 0 0 0-16 0"
+            d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
           />
         </svg>
       </button>
@@ -48,13 +85,13 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
       data-testid="container"
     >
       <button
-        aria-label="Notifications"
+        aria-label="Posts"
         class="px-2.5 py-2"
         data-slot="button"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-bell text-muted-foreground"
+          class="lucide lucide-sticky-note text-muted-foreground"
           fill="none"
           height="20"
           stroke="currentColor"
@@ -66,26 +103,40 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M10.268 21a2 2 0 0 0 3.464 0"
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
           />
           <path
-            d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
+            d="M15 3v5a1 1 0 0 0 1 1h5"
           />
         </svg>
       </button>
     </div>
+  </div>
+</div>
+`;
+
+exports[`MobileTabBar - Snapshots > matches snapshot for showLabels + sticky 1`] = `
+<div
+  class="mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden sticky top-(--header-height-mobile)"
+  data-testid="mobile-tab-bar"
+>
+  <div
+    class="flex w-full"
+    data-testid="container"
+  >
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-foreground"
       data-testid="container"
     >
       <button
-        aria-label="Privacy & Safety"
-        class="px-2.5 py-2"
+        aria-current="page"
+        aria-label="Tags"
+        class="px-2.5 py-2 flex items-center gap-2"
         data-slot="button"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-shield text-muted-foreground"
+          class="lucide lucide-tag text-foreground"
           fill="none"
           height="20"
           stroke="currentColor"
@@ -97,85 +148,21 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+            d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
           />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
-      data-testid="container"
-    >
-      <button
-        aria-label="Muted Users"
-        class="px-2.5 py-2"
-        data-slot="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-megaphone-off text-muted-foreground"
-          fill="none"
-          height="20"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M11.636 6A13 13 0 0 0 19.4 3.2 1 1 0 0 1 21 4v11.344"
-          />
-          <path
-            d="M14.378 14.357A13 13 0 0 0 11 14H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h1"
-          />
-          <path
-            d="m2 2 20 20"
-          />
-          <path
-            d="M6 14a12 12 0 0 0 2.4 7.2 2 2 0 0 0 3.2-2.4A8 8 0 0 1 10 14"
-          />
-          <path
-            d="M8 8v6"
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
-      data-testid="container"
-    >
-      <button
-        aria-label="Language"
-        class="px-2.5 py-2"
-        data-slot="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-globe text-muted-foreground"
-          fill="none"
-          height="20"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
           <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-          <path
-            d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"
-          />
-          <path
-            d="M2 12h20"
+            cx="7.5"
+            cy="7.5"
+            fill="currentColor"
+            r=".5"
           />
         </svg>
+        <span
+          class="text-sm font-medium text-foreground"
+          data-testid="typography"
+        >
+          Tags
+        </span>
       </button>
     </div>
     <div
@@ -183,13 +170,13 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
       data-testid="container"
     >
       <button
-        aria-label="Help"
-        class="px-2.5 py-2"
+        aria-label="Users"
+        class="px-2.5 py-2 flex items-center gap-2"
         data-slot="button"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-circle-question-mark text-muted-foreground"
+          class="lucide lucide-users-round text-muted-foreground"
           fill="none"
           height="20"
           stroke="currentColor"
@@ -200,18 +187,61 @@ exports[`SettingsMobileMenu - Snapshots > matches snapshot 1`] = `
           width="20"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <path
+            d="M18 21a8 8 0 0 0-16 0"
+          />
           <circle
-            cx="12"
-            cy="12"
-            r="10"
+            cx="10"
+            cy="8"
+            r="5"
           />
           <path
-            d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
-          />
-          <path
-            d="M12 17h.01"
+            d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"
           />
         </svg>
+        <span
+          class="text-sm font-medium text-muted-foreground"
+          data-testid="typography"
+        >
+          Users
+        </span>
+      </button>
+    </div>
+    <div
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
+      data-testid="container"
+    >
+      <button
+        aria-label="Posts"
+        class="px-2.5 py-2 flex items-center gap-2"
+        data-slot="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sticky-note text-muted-foreground"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+          />
+          <path
+            d="M15 3v5a1 1 0 0 0 1 1h5"
+          />
+        </svg>
+        <span
+          class="text-sm font-medium text-muted-foreground"
+          data-testid="typography"
+        >
+          Posts
+        </span>
       </button>
     </div>
   </div>

--- a/src/components/molecules/MobileTabBar/MobileTabBar.tsx
+++ b/src/components/molecules/MobileTabBar/MobileTabBar.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import * as Atoms from '@/atoms';
+import * as Libs from '@/libs';
+import type { MobileTabBarProps } from './MobileTabBar.types';
+
+/**
+ * Shared mobile tab bar molecule used by Hot, Profile, and Settings pages.
+ * Owns the visual + a11y contract for mobile tab navigation:
+ * - Gradient fade background, `lg:hidden`, `--z-mobile-menu` z-index.
+ * - Flex row of tab cells with active/inactive border + text color states.
+ * - Icon-only or icon + label modes via `showLabels`.
+ * - Positioning via `position` ('sticky' default, or 'fixed').
+ *
+ * Consumers own identity semantics (active detection, click handlers, i18n,
+ * filtering) and pass already-resolved `MobileTabBarItem`s.
+ */
+export function MobileTabBar({
+  items,
+  showLabels = false,
+  position = 'sticky',
+  className,
+  'data-testid': dataTestId,
+}: MobileTabBarProps) {
+  return (
+    <Atoms.Container
+      overrideDefaults
+      data-testid={dataTestId}
+      className={Libs.cn(
+        'mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden',
+        position === 'sticky' && 'sticky top-(--header-height-mobile)',
+        position === 'fixed' && 'fixed top-(--header-height-mobile) right-0 left-0',
+        className,
+      )}
+    >
+      <Atoms.Container overrideDefaults className="flex w-full">
+        {items.map((item) => {
+          const Icon = item.icon;
+          const { isActive } = item;
+
+          return (
+            <Atoms.Container
+              key={item.key}
+              overrideDefaults
+              className={Libs.cn(
+                'flex flex-1 justify-center border-b px-0 py-1.5',
+                isActive ? 'border-foreground' : 'border-border',
+              )}
+            >
+              <Atoms.Button
+                overrideDefaults
+                onClick={item.onSelect}
+                className={Libs.cn('px-2.5 py-2', showLabels && 'flex items-center gap-2')}
+                aria-label={item.ariaLabel ?? item.label}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <Icon size={20} className={isActive ? 'text-foreground' : 'text-muted-foreground'} />
+                {showLabels && (
+                  <Atoms.Typography
+                    as="span"
+                    className={Libs.cn('text-sm font-medium', isActive ? 'text-foreground' : 'text-muted-foreground')}
+                  >
+                    {item.label}
+                  </Atoms.Typography>
+                )}
+              </Atoms.Button>
+            </Atoms.Container>
+          );
+        })}
+      </Atoms.Container>
+    </Atoms.Container>
+  );
+}

--- a/src/components/molecules/MobileTabBar/MobileTabBar.types.ts
+++ b/src/components/molecules/MobileTabBar/MobileTabBar.types.ts
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+export interface MobileTabBarItem {
+  /** Stable key for React + optional data-testid derivation */
+  key: string;
+  /** Icon component; rendered at size 20 */
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  /** Already-translated/resolved label; also used as default aria-label */
+  label: string;
+  /** Whether this tab is currently selected */
+  isActive: boolean;
+  /** Called when the user activates this tab */
+  onSelect: () => void;
+  /** Optional override for aria-label (defaults to `label`) */
+  ariaLabel?: string;
+}
+
+export type MobileTabBarPosition = 'sticky' | 'fixed';
+
+export interface MobileTabBarProps {
+  items: MobileTabBarItem[];
+  /** When true, renders the label next to the icon. Defaults to false (icon-only). */
+  showLabels?: boolean;
+  /** Positioning strategy. Defaults to 'sticky'. */
+  position?: MobileTabBarPosition;
+  /** Extra classes merged onto the root (e.g. negative margin overrides). */
+  className?: string;
+  /** Optional data-testid for the root element. */
+  'data-testid'?: string;
+}

--- a/src/components/molecules/MobileTabBar/index.ts
+++ b/src/components/molecules/MobileTabBar/index.ts
@@ -1,0 +1,2 @@
+export * from './MobileTabBar';
+export * from './MobileTabBar.types';

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx
@@ -1,29 +1,43 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ProfilePageMobileMenu, PROFILE_MENU_ITEMS } from './ProfilePageMobileMenu';
 import { PROFILE_PAGE_TYPES } from '@/app/profile/types';
 
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    useRequireAuth: () => ({
+      requireAuth: (cb: () => void) => cb(),
+    }),
+  };
+});
+
 describe('ProfilePageMobileMenu', () => {
-  it('renders all menu items', () => {
+  it('renders all menu items for own profile', () => {
     render(<ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.NOTIFICATIONS} onPageChangeAction={() => {}} />);
     PROFILE_MENU_ITEMS.forEach((item) => {
       expect(screen.getByLabelText(item.label)).toBeInTheDocument();
     });
   });
 
-  it('has correct structure with sticky positioning', () => {
+  it('hides ownProfileOnly items when viewing another user profile', () => {
     const { container } = render(
-      <ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.NOTIFICATIONS} onPageChangeAction={() => {}} />,
+      <ProfilePageMobileMenu
+        activePage={PROFILE_PAGE_TYPES.PROFILE}
+        onPageChangeAction={() => {}}
+        isOwnProfile={false}
+      />,
     );
-    const rootElement = container.firstChild as HTMLElement;
-    expect(rootElement).toHaveClass(
-      'sticky',
-      'top-(--header-height-mobile)',
-      'z-(--z-mobile-menu)',
-      'bg-background',
-      'lg:hidden',
-    );
+
+    const visibleCount = PROFILE_MENU_ITEMS.filter((item) => !item.ownProfileOnly).length;
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(visibleCount);
+
+    // Notifications is ownProfileOnly — must not render
+    expect(screen.queryByLabelText('Notifications')).not.toBeInTheDocument();
   });
 
   it('renders correct number of menu items', () => {
@@ -43,62 +57,30 @@ describe('ProfilePageMobileMenu', () => {
     expect(activeButton).toHaveAttribute('aria-label', 'Following');
   });
 
-  it('applies correct border classes to active and inactive items', () => {
-    const { container } = render(
-      <ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.FOLLOWING} onPageChangeAction={() => {}} />,
-    );
-    const items = container.querySelectorAll('div[class*="border-b"]');
-
-    // Active item (Following) should have border-foreground
-    const followingIndex = PROFILE_MENU_ITEMS.findIndex((item) => item.pageType === PROFILE_PAGE_TYPES.FOLLOWING);
-    const activeItem = items[followingIndex];
-    expect(activeItem).toHaveClass('border-foreground');
-
-    // Inactive items should have border-border
-    items.forEach((item, index) => {
-      if (index !== followingIndex) {
-        expect(item).toHaveClass('border-border');
-      }
-    });
-  });
-
-  it('applies correct text color classes to icons', () => {
-    const { container } = render(
-      <ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.FOLLOWING} onPageChangeAction={() => {}} />,
-    );
-    const icons = container.querySelectorAll('svg');
-
-    // Active icon (Following) should have text-foreground
-    const followingIndex = PROFILE_MENU_ITEMS.findIndex((item) => item.pageType === PROFILE_PAGE_TYPES.FOLLOWING);
-    const activeIcon = icons[followingIndex];
-    expect(activeIcon).toHaveClass('text-foreground');
-
-    // Inactive icons should have text-muted-foreground
-    icons.forEach((icon, index) => {
-      if (index !== followingIndex) {
-        expect(icon).toHaveClass('text-muted-foreground');
-      }
-    });
-  });
-
-  it('has correct button structure with padding', () => {
+  it('exposes the profile-page-mobile-menu data-testid on the root', () => {
     const { container } = render(
       <ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.NOTIFICATIONS} onPageChangeAction={() => {}} />,
     );
-    const buttons = container.querySelectorAll('button');
-    buttons.forEach((button) => {
-      expect(button).toHaveClass('px-2.5', 'py-2');
-    });
+    const rootElement = container.firstChild as HTMLElement;
+    expect(rootElement).toHaveAttribute('data-testid', 'profile-page-mobile-menu');
   });
 
-  it('has correct container structure with flex and border', () => {
+  it('renders with sticky positioning', () => {
     const { container } = render(
       <ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.NOTIFICATIONS} onPageChangeAction={() => {}} />,
     );
-    const items = container.querySelectorAll('div[class*="border-b"]');
-    items.forEach((item) => {
-      expect(item).toHaveClass('flex', 'flex-1', 'justify-center', 'border-b', 'px-0', 'py-1.5');
-    });
+    const rootElement = container.firstChild as HTMLElement;
+    expect(rootElement).toHaveClass('sticky', 'top-(--header-height-mobile)');
+  });
+
+  it('calls onPageChangeAction (via requireAuth) with correct pageType when clicked', async () => {
+    const user = userEvent.setup();
+    const onPageChangeAction = vi.fn();
+
+    render(<ProfilePageMobileMenu activePage={PROFILE_PAGE_TYPES.PROFILE} onPageChangeAction={onPageChangeAction} />);
+
+    await user.click(screen.getByLabelText('Following'));
+    expect(onPageChangeAction).toHaveBeenCalledWith(PROFILE_PAGE_TYPES.FOLLOWING);
   });
 });
 

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx.snap
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx.snap
@@ -2,15 +2,15 @@
 
 exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="mobile-menu-gradient-fade sticky top-(--header-height-mobile) z-(--z-mobile-menu) bg-background lg:hidden"
+  class="mobile-menu-gradient-fade z-(--z-mobile-menu) bg-background lg:hidden sticky top-(--header-height-mobile)"
   data-testid="profile-page-mobile-menu"
 >
   <div
     class="flex w-full"
-    data-testid="profile-page-mobile-menu-items"
+    data-testid="container"
   >
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -48,7 +48,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-foreground"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-foreground"
       data-testid="container"
     >
       <button
@@ -80,7 +80,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -108,7 +108,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -139,7 +139,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -175,7 +175,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -202,7 +202,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button
@@ -230,7 +230,7 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
       </button>
     </div>
     <div
-      class="flex flex-1 justify-center border-b px-0 py-1.5 data-testid=\\"profile-page-mobile-menu-item\\" border-border"
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
       data-testid="container"
     >
       <button

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.tsx
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import * as Atoms from '@/atoms';
 import * as Libs from '@/libs';
 import * as Hooks from '@/hooks';
 import * as Types from '@/app/profile/types';
+import { MobileTabBar, type MobileTabBarItem } from '../MobileTabBar';
 
 export interface ProfileMenuItem {
   icon: React.ComponentType<{ size?: number; className?: string }>;
@@ -41,6 +41,15 @@ export interface ProfilePageMobileMenuProps {
   isOwnProfile?: boolean;
 }
 
+/**
+ * Mobile navigation menu for profile pages.
+ * Delegates rendering to the shared `MobileTabBar` molecule.
+ *
+ * Owns profile-specific semantics:
+ * - Filters items via `isOwnProfile` (e.g. hides Notifications on other users).
+ * - Wraps click handlers with `requireAuth` for unauthenticated users.
+ * - Uses raw English labels (no i18n sweep yet).
+ */
 export function ProfilePageMobileMenu({
   activePage,
   onPageChangeAction,
@@ -58,45 +67,13 @@ export function ProfilePageMobileMenu({
     });
   }, [isOwnProfile]);
 
-  // Handle item click - require auth for unauthenticated users
-  const handleItemClick = (pageType: Types.ProfilePageType) => {
-    requireAuth(() => onPageChangeAction(pageType));
-  };
+  const items: MobileTabBarItem[] = visibleItems.map((item) => ({
+    key: item.pageType,
+    icon: item.icon,
+    label: item.label,
+    isActive: item.pageType === activePage,
+    onSelect: () => requireAuth(() => onPageChangeAction(item.pageType)),
+  }));
 
-  return (
-    <Atoms.Container
-      overrideDefaults={true}
-      className="mobile-menu-gradient-fade sticky top-(--header-height-mobile) z-(--z-mobile-menu) bg-background lg:hidden"
-      data-testid="profile-page-mobile-menu"
-    >
-      <Atoms.Container overrideDefaults={true} className="flex w-full" data-testid="profile-page-mobile-menu-items">
-        {visibleItems.map((item, index) => {
-          const Icon = item.icon;
-          const isSelected = item.pageType === activePage;
-
-          return (
-            <Atoms.Container
-              key={index}
-              overrideDefaults={true}
-              className={Libs.cn(
-                'flex flex-1 justify-center border-b px-0 py-1.5',
-                'data-testid="profile-page-mobile-menu-item"',
-                isSelected ? 'border-foreground' : 'border-border',
-              )}
-            >
-              <Atoms.Button
-                overrideDefaults
-                onClick={() => handleItemClick(item.pageType)}
-                className="px-2.5 py-2"
-                aria-label={item.label}
-                aria-current={isSelected ? 'page' : undefined}
-              >
-                <Icon size={20} className={isSelected ? 'text-foreground' : 'text-muted-foreground'} />
-              </Atoms.Button>
-            </Atoms.Container>
-          );
-        })}
-      </Atoms.Container>
-    </Atoms.Container>
-  );
+  return <MobileTabBar items={items} position="sticky" data-testid="profile-page-mobile-menu" />;
 }

--- a/src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.test.tsx
+++ b/src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.test.tsx
@@ -28,6 +28,20 @@ describe('SettingsMobileMenu', () => {
     const { container } = render(<SettingsMobileMenu />);
     expect(container.firstChild).toHaveClass('lg:hidden');
   });
+
+  it('uses the mobile-menu z-index (consolidated from --z-sticky-header)', () => {
+    const { container } = render(<SettingsMobileMenu />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('z-(--z-mobile-menu)');
+    expect(root).not.toHaveClass('z-(--z-sticky-header)');
+  });
+
+  it('preserves fixed positioning', () => {
+    const { container } = render(<SettingsMobileMenu />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('fixed', 'top-(--header-height-mobile)', 'right-0', 'left-0');
+    expect(root).not.toHaveClass('sticky');
+  });
 });
 
 describe('SettingsMobileMenu - Snapshots', () => {

--- a/src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.tsx
+++ b/src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.tsx
@@ -2,54 +2,36 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import * as Libs from '@/libs';
-import * as Atoms from '@/atoms';
+import { MobileTabBar, type MobileTabBarItem } from '../../MobileTabBar';
 import { SETTINGS_MOBILE_ITEMS } from './SettingsMobileMenu.constants';
 
 /**
  * Mobile settings navigation menu.
- * Follows same pattern as ProfilePageMobileMenu.
- * Uses --header-height-mobile CSS var for consistent positioning.
- * Only visible on mobile (< lg breakpoint).
+ * Delegates rendering to the shared `MobileTabBar` molecule.
+ *
+ * Owns settings-specific semantics:
+ * - Selection derived from `usePathname`.
+ * - Click handler uses `router.push` to navigate between settings subpages.
+ * - Labels come from the `settings.menu.*` i18n namespace.
+ * - Uses `position='fixed'` so the bar sits outside the settings layout's
+ *   flow (existing behavior preserved).
+ *
+ * Z-index is `--z-mobile-menu` (via `MobileTabBar`'s default), consolidating
+ * all three mobile tab bars onto the same variable. Previously used
+ * `--z-sticky-header` — see unify-mobile-tab-bar plan for rationale.
  */
 export function SettingsMobileMenu() {
   const pathname = usePathname();
   const router = useRouter();
   const t = useTranslations('settings.menu');
 
-  return (
-    <Atoms.Container
-      overrideDefaults
-      data-testid="settings-mobile-menu"
-      className="mobile-menu-gradient-fade fixed top-(--header-height-mobile) right-0 left-0 z-(--z-sticky-header) bg-background lg:hidden"
-    >
-      <Atoms.Container overrideDefaults className="flex w-full">
-        {SETTINGS_MOBILE_ITEMS.map((item) => {
-          const Icon = item.icon;
-          const isSelected = pathname === item.path;
+  const items: MobileTabBarItem[] = SETTINGS_MOBILE_ITEMS.map((item) => ({
+    key: item.path,
+    icon: item.icon,
+    label: t(item.labelKey),
+    isActive: pathname === item.path,
+    onSelect: () => router.push(item.path),
+  }));
 
-          return (
-            <Atoms.Container
-              key={item.path}
-              overrideDefaults
-              className={Libs.cn(
-                'flex flex-1 justify-center border-b px-0 py-1.5',
-                isSelected ? 'border-foreground' : 'border-border',
-              )}
-            >
-              <Atoms.Button
-                overrideDefaults
-                onClick={() => router.push(item.path)}
-                className="px-2.5 py-2"
-                aria-label={t(item.labelKey)}
-                aria-current={isSelected ? 'page' : undefined}
-              >
-                <Icon size={20} className={isSelected ? 'text-foreground' : 'text-muted-foreground'} />
-              </Atoms.Button>
-            </Atoms.Container>
-          );
-        })}
-      </Atoms.Container>
-    </Atoms.Container>
-  );
+  return <MobileTabBar items={items} position="fixed" data-testid="settings-mobile-menu" />;
 }

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -24,6 +24,7 @@ export * from './HeaderSignIn';
 export * from './Settings/HelpContent';
 export * from './Home';
 export * from './HotMobileMenu';
+export * from './MobileTabBar';
 export * from './HotTagCard';
 export * from './InputField';
 export * from './Install';


### PR DESCRIPTION
# Unify Mobile Tab Bars into a Shared `MobileTabBar` Molecule

## 🎯 Summary

Three structurally identical mobile tab-bar components (`ProfilePageMobileMenu`, `SettingsMobileMenu`, and the newly added `HotMobileMenu`) existed because this repeated pattern was not initially made into a reusable component. This PR extracts a single shared **`MobileTabBar`** molecule that owns the visual + a11y contract, and migrates all three call sites onto it.

Delivered as a **follow-up PR targeting the original `HotMobileMenu` PR branch** so reviewers can evaluate the unification in isolation from the Hot-page feature work.

## 🧱 What changed

### New shared component
- `src/components/molecules/MobileTabBar/MobileTabBar.tsx`
- `src/components/molecules/MobileTabBar/MobileTabBar.types.ts`
- `src/components/molecules/MobileTabBar/MobileTabBar.test.tsx` (+ snapshot)
- `src/components/molecules/MobileTabBar/index.ts`
- Registered in `src/components/molecules/index.ts`

**API highlights:**
- Per-item `isActive` + `onSelect` (not a global `activeKey`) — keeps `requireAuth` wrapping, `pathname` comparisons, and `setState` setters natural in consumers.
- `showLabels` toggles icon-only vs icon + label.
- `position` toggles between `sticky top-(--header-height-mobile)` and `fixed top-(--header-height-mobile) right-0 left-0`.
- `className` is merged last via `cn(...)` so consumers can append margin overrides without fighting defaults.
- `data-testid` passthrough + `aria-label` default (with optional override) + `aria-current="page"` on active.

### Migrated consumers (thin adapters)
- **`HotMobileMenu`** → `<MobileTabBar showLabels position="sticky" className="-mx-6 -mt-6 mb-6" ... />`. Keeps `HOT_MOBILE_MENU_ITEMS`, `HotSection`, and `hot.*` i18n.
- **`ProfilePageMobileMenu`** → `<MobileTabBar position="sticky" ... />`. Preserves `PROFILE_MENU_ITEMS` export, `isOwnProfile` filtering, `requireAuth`-wrapped clicks, and raw English labels.
- **`SettingsMobileMenu`** → `<MobileTabBar position="fixed" ... />`. Keeps `useTranslations('settings.menu')`, `SETTINGS_MOBILE_ITEMS`, and `usePathname`/`useRouter` selection.

## ⚠️ Behavioral change (intentional, scoped)

**Settings z-index consolidation:** `z-(--z-sticky-header)` (20) → `z-(--z-mobile-menu)` (30), which is the variable documented for mobile navigation and the value already used by Profile + Hot. This was a silent drift that this refactor corrects.

No other behavior changes:
- Settings remains `fixed`; Profile + Hot remain `sticky`.
- Hot keeps its `-mx-6 -mt-6 mb-6` layout overrides via `className` passthrough.
- Profile `requireAuth` and `isOwnProfile` filtering are preserved.
- i18n namespaces are unchanged.
- `lg:hidden` still hides all three on desktop.

## 🧹 Drive-by fix

Removed a stale literal string (`'data-testid="profile-page-mobile-menu-item"'`) that was being passed into `cn(...)` as a className in the old `ProfilePageMobileMenu` render block. It had no effect but was technically invalid class input.

## 🧪 Tests

- **`MobileTabBar`** — 18 tests: item rendering, icon-only vs `showLabels`, sticky + fixed positioning, always-applied root classes, active vs inactive states (border, icon color, `aria-current`), click dispatch, `aria-label` default + override, `className` merge, `data-testid` passthrough, button class toggling.
- **`HotMobileMenu`** — 9 tests, trimmed to behavior-level assertions (label rendering, `-mx-6 -mt-6 mb-6` passthrough, sticky, `data-testid`, `aria-current`, click wiring). Snapshot regenerated.
- **`ProfilePageMobileMenu`** — 8 tests. Added explicit coverage for `isOwnProfile={false}` filtering and `requireAuth`-gated click dispatch via `vi.mock('@/hooks', ...)`. Snapshot regenerated.
- **`SettingsMobileMenu`** — 5 tests. Added explicit `z-(--z-mobile-menu)` assertion + negative assertion against the old `z-(--z-sticky-header)`, plus a `fixed` positioning assertion. Snapshot regenerated.
- **Consumer suites** — `templates/Feed/Hot` (17) and `templates/Settings` (40) all pass with zero prop changes.

**Totals:** 97 targeted tests ✅ · `yarn tsc --noEmit` ✅ · `yarn lint` ✅

## 📦 File inventory

**New**
- `src/components/molecules/MobileTabBar/MobileTabBar.tsx`
- `src/components/molecules/MobileTabBar/MobileTabBar.types.ts`
- `src/components/molecules/MobileTabBar/MobileTabBar.test.tsx`
- `src/components/molecules/MobileTabBar/MobileTabBar.test.tsx.snap`
- `src/components/molecules/MobileTabBar/index.ts`

**Modified**
- `src/components/molecules/index.ts`
- `src/components/molecules/HotMobileMenu/HotMobileMenu.tsx`
- `src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx`
- `src/components/molecules/HotMobileMenu/HotMobileMenu.test.tsx.snap`
- `src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.tsx`
- `src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx`
- `src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx.snap`
- `src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.tsx`
- `src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.test.tsx`
- `src/components/molecules/Settings/SettingsMobileMenu/SettingsMobileMenu.test.tsx.snap`

## 🚧 Deferred / follow-ups

- **Phase 5 (optional):** investigate whether Settings can move from `fixed` to `sticky` (would eliminate the last positioning fork). Deferred to keep this PR's behavior change surface minimal.
- **Future i18n sweep:** `PROFILE_MENU_ITEMS` still uses raw English labels while Hot and Settings use translation keys. Out of scope here.

## Related

This PR was created to directly address this review comment https://github.com/pubky/pubky-app/pull/1632#pullrequestreview-4075361705.

---

_This pull request summary was generated, for full implementation details please reference the file changes._
