### PR TITLE
feat(notification): move preference filtering into Application pagination loop

### DIFF
--- a/src/core/application/bootstrap/bootstrap.ts
+++ b/src/core/application/bootstrap/bootstrap.ts
@@ -1,6 +1,6 @@
 import * as Core from '@/core';
-import { NotificationType } from '@/core/models/notification/notification.types';
-import { NotificationState } from '@/core/stores/notification/notification.types';
+import type { NotificationType } from '@/core/models/notification/notification.types';
+import type { NotificationState } from '@/core/stores/notification/notification.types';
 import { Env } from '@/libs/env/env';
 import { AppError } from '@/libs/error/error';
 import { HttpMethod, HttpStatusCode } from '@/libs/http/http.types';

--- a/src/core/application/notification/notification.test.ts
+++ b/src/core/application/notification/notification.test.ts
@@ -389,7 +389,7 @@ describe('NotificationApplication.getOrFetchNotifications (filtered pagination)'
   });
 
   it('should stop when no more pages exist even if filtered result is empty', async () => {
-    vi.spyOn(LocalNotificationService, 'getOlderThan').mockResolvedValue([createFlat(1000)]); // cache miss: nothing in local DB for this page
+    vi.spyOn(LocalNotificationService, 'getOlderThan').mockResolvedValue([createFlat(1000)]); // cache hit: returns a Follow from local DB
     vi.spyOn(NexusUserService, 'notifications').mockResolvedValue([]); // meaning no more notifications to fetch
     mockNormalizer();
     mockFetchMissingEntities();
@@ -422,6 +422,43 @@ describe('NotificationApplication.getOrFetchNotifications (filtered pagination)'
     });
 
     expect(result.flatNotifications).toHaveLength(2);
+    expect(result.olderThan).toBe(3999);
+  });
+
+  it('should set cursor from last included item when page has more matches than remaining', async () => {
+    // Scenario: limit = 2, filter = Reply only
+    //
+    // Round 1: Nexus returns [Reply:5000, Reply:4000, Reply:3000]
+    //   (numbers are timestamps, descending = newest first)
+    //   - All 3 pass the filter, but we only need 2 (remaining = 2)
+    //   - collected = [Reply:5000, Reply:4000] (sliced to remaining)
+    //   - raw page olderThan = 2999 (oldest item timestamp - 1)
+    //
+    // BUG (before fix): cursor = 2999 (end of raw page)
+    //   → "load more" starts at 2999 → Reply:3000 is SKIPPED forever
+    //
+    // EXPECTED (after fix): cursor = 3999 (last included item timestamp - 1)
+    //   → "load more" starts at 3999 → Reply:3000 is reachable on the next page
+    vi.spyOn(Core.LocalNotificationService, 'getOlderThan').mockResolvedValue([]);
+    vi.spyOn(Core.NexusUserService, 'notifications').mockResolvedValueOnce([
+      createNexusReply(5000),
+      createNexusReply(4000),
+      createNexusReply(3000),
+    ]);
+    mockNormalizerWithReply();
+    mockFetchMissingEntities();
+    vi.spyOn(Core.LocalNotificationService, 'bulkSave').mockResolvedValue(undefined);
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit: 2,
+      allowedTypes: replyOnly,
+    });
+
+    expect(result.flatNotifications).toHaveLength(2);
+    // Cursor must point after the last INCLUDED item (4000), not the last raw item (3000)
+    // so that Reply:3000 is reachable on the next "load more" call.
     expect(result.olderThan).toBe(3999);
   });
 

--- a/src/core/application/notification/notification.test.ts
+++ b/src/core/application/notification/notification.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as Core from '@/core';
 import { LastReadResult } from 'pubky-app-specs';
 import { NotificationApplication } from './notification';
-import { NotificationType } from '@/core/models/notification/notification.types';
+import { FlatNotification, NotificationType } from '@/core/models/notification/notification.types';
 import { asInvalid, asOpaque } from '@/test-utils';
+import { LocalNotificationService } from '@/core/services/local/notification/notification';
+import { NexusUserService } from '@/core/services/nexus/user/user';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 
@@ -20,13 +22,39 @@ const createFlat = (timestamp: number): Core.FlatNotification => {
   } as Core.FlatNotification;
 };
 
+const createReplyFlat = (timestamp: number): FlatNotification => ({
+  id: `reply:${timestamp}:user-${timestamp}`,
+  type: NotificationType.Reply,
+  timestamp,
+  replied_by: `user-${timestamp}`,
+  parent_post_uri: 'pubky://post/1',
+  reply_uri: 'pubky://post/2',
+});
+
 const createNexus = (timestamp: number): Core.NexusNotification => ({
   timestamp,
   body: { type: Core.NotificationType.Follow, followed_by: `user-${timestamp}` },
 });
 
+const createNexusReply = (timestamp: number): Core.NexusNotification => ({
+  timestamp,
+  body: {
+    type: NotificationType.Reply,
+    replied_by: `user-${timestamp}`,
+    parent_post_uri: 'pubky://post/1',
+    reply_uri: 'pubky://post/2',
+  },
+});
+
 const mockNormalizer = () =>
   vi.spyOn(Core.NotificationNormalizer, 'toFlatNotification').mockImplementation((n) => createFlat(n.timestamp));
+
+const mockNormalizerWithReply = () =>
+  vi
+    .spyOn(Core.NotificationNormalizer, 'toFlatNotification')
+    .mockImplementation((n) =>
+      n.body.type === NotificationType.Reply ? createReplyFlat(n.timestamp) : createFlat(n.timestamp),
+    );
 
 const mockFetchMissingEntities = () => {
   vi.spyOn(Core.LocalNotificationService, 'parseNotifications').mockReturnValue({
@@ -43,7 +71,7 @@ describe('NotificationApplication.persistAndSummarize', () => {
   const lastRead = 1234;
   const allowedTypes = Object.values(NotificationType);
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.restoreAllMocks());
 
   it('should bulkSave, count filtered unread, and return nextPollCursor', async () => {
     const notifications = [createNexus(2000), createNexus(1000)];
@@ -307,6 +335,149 @@ describe('NotificationApplication.getOrFetchNotifications', () => {
 
       expect(result.flatNotifications).toHaveLength(1);
     });
+  });
+});
+
+describe('NotificationApplication.getOrFetchNotifications (filtered pagination)', () => {
+  const limit = 30;
+  const allTypes = Object.values(NotificationType);
+  const replyOnly = [NotificationType.Reply];
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return immediately when filtered results are found on first page', async () => {
+    vi.spyOn(LocalNotificationService, 'getOlderThan').mockResolvedValue([createFlat(3000)]);
+    vi.spyOn(NexusUserService, 'notifications').mockResolvedValue([]);
+    mockNormalizer();
+    mockFetchMissingEntities();
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: allTypes,
+    });
+
+    expect(result.flatNotifications).toHaveLength(1);
+    expect(result.olderThan).toBeUndefined();
+  });
+
+  it('should fetch next pages when filter removes all items from a page', async () => {
+    const getOlderThanSpy = vi.spyOn(LocalNotificationService, 'getOlderThan').mockResolvedValue([]);
+
+    vi.spyOn(NexusUserService, 'notifications')
+      .mockResolvedValueOnce([createNexus(3000)]) // create a Follow notification which will be filtered out
+      .mockResolvedValueOnce([createNexusReply(2000)]) // create a Reply notification which is allowed by filter
+      .mockResolvedValueOnce([]); // no more notifications to fetch
+
+    mockNormalizerWithReply();
+    mockFetchMissingEntities();
+    vi.spyOn(LocalNotificationService, 'bulkSave').mockResolvedValue(undefined);
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: replyOnly,
+    });
+
+    expect(getOlderThanSpy).toHaveBeenCalledTimes(3); // first page filtered out, second page yields reply, third stops
+    expect(getOlderThanSpy).toHaveBeenNthCalledWith(2, { olderThan: 2999, limit });
+    expect(result.flatNotifications).toHaveLength(1);
+    expect(result.flatNotifications[0].type).toBe(NotificationType.Reply);
+    expect(result.olderThan).toBeUndefined(); // no more pages to fetch
+  });
+
+  it('should stop when no more pages exist even if filtered result is empty', async () => {
+    vi.spyOn(LocalNotificationService, 'getOlderThan').mockResolvedValue([createFlat(1000)]); // cache miss: nothing in local DB for this page
+    vi.spyOn(NexusUserService, 'notifications').mockResolvedValue([]); // meaning no more notifications to fetch
+    mockNormalizer();
+    mockFetchMissingEntities();
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: replyOnly,
+    });
+
+    expect(result.flatNotifications).toHaveLength(0);
+    expect(result.olderThan).toBeUndefined(); // no more pages to fetch
+  });
+
+  it('should accumulate filtered results across pages until limit is filled', async () => {
+    vi.spyOn(Core.LocalNotificationService, 'getOlderThan').mockResolvedValue([]); // cache miss: nothing in local DB for this page
+    vi.spyOn(Core.NexusUserService, 'notifications')
+      .mockResolvedValueOnce([createNexusReply(5000)])
+      .mockResolvedValueOnce([createNexusReply(4000)]);
+    mockNormalizerWithReply();
+    mockFetchMissingEntities();
+    vi.spyOn(Core.LocalNotificationService, 'bulkSave').mockResolvedValue(undefined);
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit: 2, // Request exactly two filtered items; collection should stop once two replies are found.
+      allowedTypes: replyOnly,
+    });
+
+    expect(result.flatNotifications).toHaveLength(2);
+    expect(result.olderThan).toBe(3999);
+  });
+
+  it('should stop after MAX_FETCH_ROUNDS even if no results pass the filter', async () => {
+    const getOlderThanSpy = vi.spyOn(Core.LocalNotificationService, 'getOlderThan').mockResolvedValue([]); // cache miss: nothing in local DB for this page
+    vi.spyOn(Core.NexusUserService, 'notifications').mockResolvedValue([createNexus(1000)]);
+    mockNormalizer();
+    mockFetchMissingEntities();
+    vi.spyOn(Core.LocalNotificationService, 'bulkSave').mockResolvedValue(undefined);
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: replyOnly,
+    });
+
+    expect(getOlderThanSpy).toHaveBeenCalledTimes(10); // MAX_FETCH_ROUNDS = 10
+    expect(result.flatNotifications).toHaveLength(0);
+    expect(result.olderThan).toBe(999);
+  });
+
+  it('should return empty when first page returns no notifications', async () => {
+    const getOlderThanSpy = vi.spyOn(Core.LocalNotificationService, 'getOlderThan').mockResolvedValue([]); // No local items for this page.
+    vi.spyOn(Core.NexusUserService, 'notifications').mockResolvedValue([]); // Nexus also has no items to return.
+    mockNormalizer();
+    mockFetchMissingEntities();
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: allTypes,
+    });
+
+    expect(getOlderThanSpy).toHaveBeenCalledTimes(1);
+    expect(result.flatNotifications).toHaveLength(0);
+    expect(result.olderThan).toBeUndefined();
+  });
+
+  it('should return empty when allowedTypes is empty', async () => {
+    const disabledAll: NotificationType[] = [];
+    const getOlderThanSpy = vi.spyOn(Core.LocalNotificationService, 'getOlderThan');
+    const nexusSpy = vi.spyOn(Core.NexusUserService, 'notifications');
+
+    const result = await NotificationApplication.getOrFetchNotifications({
+      userId,
+      olderThan: Infinity,
+      limit,
+      allowedTypes: disabledAll,
+    });
+
+    expect(getOlderThanSpy).not.toHaveBeenCalled();
+    expect(nexusSpy).not.toHaveBeenCalled();
+    expect(result.flatNotifications).toHaveLength(0);
+    expect(result.olderThan).toBeUndefined();
   });
 });
 

--- a/src/core/application/notification/notification.ts
+++ b/src/core/application/notification/notification.ts
@@ -1,7 +1,12 @@
 import * as Core from '@/core';
+import { FlatNotification, NotificationType } from '@/core/models/notification/notification.types';
 import { LastReadResult } from 'pubky-app-specs';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
+import type { Pubky } from '@/core/models/models.types';
+import type { TGetOrFetchNotificationsResponse } from './notification.types';
+
+const MAX_FETCH_ROUNDS = 10;
 
 export class NotificationApplication {
   private constructor() {} // Prevent instantiation
@@ -63,21 +68,99 @@ export class NotificationApplication {
    * Retrieves notifications from cache if available, otherwise fetches from Nexus.
    * Follows a cache-first pattern similar to stream posts.
    *
-   * Flow:
+   * When `allowedTypes` is provided (e.g., preference filtering), continues fetching
+   * successive pages and accumulates matching notifications until reaching `limit`
+   * or until there are no more pages, capped at NEXUS_NOTIFICATIONS_MAX_FETCH_ROUNDS.
+   * This handles the case where filtering removes all items from early pages —
+   * without looping, the UI would show "no notifications" even though later pages
+   * may contain matching items.
+   * Follows the same pattern as PostStreamQueue.collect().
+   *
+   * Flow (per page):
    * 1. Query cache for notifications older than the given timestamp
    * 2. If cache has enough items, return immediately (full cache hit)
    * 3. If cache has partial items, fetch remaining from Nexus (partial cache hit)
    * 4. If cache is empty, fetch all from Nexus (cache miss)
    * 5. Persist fetched notifications and return combined result
    *
-   * @param params - Parameters containing userId, olderThan timestamp, and limit
+   * @param params - Parameters containing userId, olderThan timestamp, limit, and optional allowedTypes
    * @returns Promise resolving to notifications and next olderThan for pagination
    */
   static async getOrFetchNotifications({
     userId,
     olderThan,
     limit,
+    allowedTypes,
   }: Core.TGetOrFetchNotificationsParams): Promise<Core.TGetOrFetchNotificationsResponse> {
+    if (allowedTypes === undefined) {
+      // No preference constraints are applied (e.g., all notification settings are enabled),
+      // so use the normal single-page fetch path.
+      return this.getOrFetchPage({ userId, olderThan, limit });
+    }
+    if (allowedTypes.length === 0) {
+      // All notification types are disabled by user preferences, so skip pagination calls.
+      return { flatNotifications: [], olderThan: undefined };
+    }
+    // Preference filtering - fetch filtered notifications
+    return this.collectPages({ userId, olderThan, limit, allowedTypes });
+  }
+
+  /**
+   * Get or fetch pages until `limit` filtered notifications are collected or no more pages exist.
+   * Capped at NEXUS_NOTIFICATIONS_MAX_FETCH_ROUNDS to prevent runaway requests.
+   */
+  private static async collectPages({
+    userId,
+    olderThan,
+    limit,
+    allowedTypes,
+  }: {
+    userId: Core.Pubky;
+    olderThan: number;
+    limit: number;
+    allowedTypes?: NotificationType[];
+  }): Promise<Core.TGetOrFetchNotificationsResponse> {
+    let cursor: number | undefined = olderThan;
+    const collected: FlatNotification[] = [];
+
+    // TODO(notification): Revisit capped pagination strategy. In extreme distributions
+    // (many consecutive filtered-out pages), MAX_FETCH_ROUNDS can still return an empty
+    // list with a non-undefined cursor, which may require additional UI pagination logic
+    // or a different fetch contract to guarantee reachability of older matching items.
+    for (let attempt = 0; attempt < MAX_FETCH_ROUNDS && collected.length < limit; attempt++) {
+      const remaining = limit - collected.length;
+      const response = await this.getOrFetchPage({
+        userId,
+        olderThan: cursor ?? Infinity,
+        limit: remaining,
+      });
+
+      const filtered = this.filterByAllowedTypes(response.flatNotifications, allowedTypes);
+
+      if (filtered.length > 0) {
+        collected.push(...filtered);
+      }
+
+      cursor = response.olderThan;
+      // cursor === undefined means no more pages to fetch
+      if (cursor === undefined) break;
+    }
+
+    return { flatNotifications: collected, olderThan: cursor };
+  }
+
+  /**
+   * Fetches a single page of notifications using cache-first strategy.
+   */
+  private static async getOrFetchPage({
+    userId,
+    olderThan,
+    limit,
+  }: {
+    userId: Pubky;
+    olderThan: number;
+    limit: number;
+  }): Promise<TGetOrFetchNotificationsResponse> {
     // Try to get notifications from cache
     const flatNotifications = await Core.LocalNotificationService.getOlderThan({ olderThan, limit });
 
@@ -225,9 +308,24 @@ export class NotificationApplication {
    * (e.g., lost_friend from the server).
    */
   static toSupportedFlatNotifications(notifications: Core.NexusNotification[]): Core.TFlatNotificationList {
-    const supportedTypes = Object.values(Core.NotificationType) as string[];
+    const supportedTypes = Object.values(NotificationType) as string[];
     return notifications
       .map((n) => Core.NotificationNormalizer.toFlatNotification(n))
       .filter((n) => supportedTypes.includes(n.type));
+  }
+
+  /**
+   * Applies user preference filtering to a page of notifications.
+   * - `allowedTypes === undefined`: no preference filter, keep all notifications
+   * - `allowedTypes.length === 0`: all types disabled, return nothing
+   */
+  private static filterByAllowedTypes(
+    notifications: FlatNotification[],
+    allowedTypes?: NotificationType[],
+  ): FlatNotification[] {
+    if (allowedTypes === undefined) return notifications;
+    if (allowedTypes.length === 0) return [];
+
+    return notifications.filter((notification) => allowedTypes.includes(notification.type));
   }
 }

--- a/src/core/application/notification/notification.ts
+++ b/src/core/application/notification/notification.ts
@@ -70,7 +70,7 @@ export class NotificationApplication {
    *
    * When `allowedTypes` is provided (e.g., preference filtering), continues fetching
    * successive pages and accumulates matching notifications until reaching `limit`
-   * or until there are no more pages, capped at NEXUS_NOTIFICATIONS_MAX_FETCH_ROUNDS.
+   * or until there are no more pages, capped at MAX_FETCH_ROUNDS.
    * This handles the case where filtering removes all items from early pages —
    * without looping, the UI would show "no notifications" even though later pages
    * may contain matching items.
@@ -107,7 +107,7 @@ export class NotificationApplication {
 
   /**
    * Get or fetch pages until `limit` filtered notifications are collected or no more pages exist.
-   * Capped at NEXUS_NOTIFICATIONS_MAX_FETCH_ROUNDS to prevent runaway requests.
+   * Capped at MAX_FETCH_ROUNDS to prevent runaway requests.
    */
   private static async collectPages({
     userId,
@@ -123,10 +123,10 @@ export class NotificationApplication {
     let cursor: number | undefined = olderThan;
     const collected: FlatNotification[] = [];
 
-    // TODO(notification): Revisit capped pagination strategy. In extreme distributions
-    // (many consecutive filtered-out pages), MAX_FETCH_ROUNDS can still return an empty
-    // list with a non-undefined cursor, which may require additional UI pagination logic
-    // or a different fetch contract to guarantee reachability of older matching items.
+    // TODO(notification): #1746 - Discuss with Product/UI/UX. This can return no visible
+    // notifications while still allowing "load more" when many pages are filtered out.
+    // Example: user only enables "New Friend", but the next 10 pages (300 items) have none.
+    // Decide what users should see in that case.
     for (let attempt = 0; attempt < MAX_FETCH_ROUNDS && collected.length < limit; attempt++) {
       const remaining = limit - collected.length;
       const response = await this.getOrFetchPage({
@@ -138,7 +138,15 @@ export class NotificationApplication {
       const filtered = this.filterByAllowedTypes(response.flatNotifications, allowedTypes);
 
       if (filtered.length > 0) {
-        collected.push(...filtered.slice(0, remaining));
+        const taken = filtered.slice(0, remaining);
+        collected.push(...taken);
+
+        // When we slice (more matches than remaining), set cursor from the last
+        // included item so skipped matches on this page are reachable on "load more".
+        if (filtered.length > remaining) {
+          cursor = taken[taken.length - 1].timestamp - 1;
+          break;
+        }
       }
 
       cursor = response.olderThan;

--- a/src/core/application/notification/notification.ts
+++ b/src/core/application/notification/notification.ts
@@ -118,7 +118,7 @@ export class NotificationApplication {
     userId: Core.Pubky;
     olderThan: number;
     limit: number;
-    allowedTypes?: NotificationType[];
+    allowedTypes: NotificationType[];
   }): Promise<Core.TGetOrFetchNotificationsResponse> {
     let cursor: number | undefined = olderThan;
     const collected: FlatNotification[] = [];
@@ -132,13 +132,13 @@ export class NotificationApplication {
       const response = await this.getOrFetchPage({
         userId,
         olderThan: cursor ?? Infinity,
-        limit: remaining,
+        limit,
       });
 
       const filtered = this.filterByAllowedTypes(response.flatNotifications, allowedTypes);
 
       if (filtered.length > 0) {
-        collected.push(...filtered);
+        collected.push(...filtered.slice(0, remaining));
       }
 
       cursor = response.olderThan;
@@ -316,16 +316,12 @@ export class NotificationApplication {
 
   /**
    * Applies user preference filtering to a page of notifications.
-   * - `allowedTypes === undefined`: no preference filter, keep all notifications
-   * - `allowedTypes.length === 0`: all types disabled, return nothing
+   * Only called from collectPages where allowedTypes is guaranteed non-empty.
    */
   private static filterByAllowedTypes(
     notifications: FlatNotification[],
-    allowedTypes?: NotificationType[],
+    allowedTypes: NotificationType[],
   ): FlatNotification[] {
-    if (allowedTypes === undefined) return notifications;
-    if (allowedTypes.length === 0) return [];
-
     return notifications.filter((notification) => allowedTypes.includes(notification.type));
   }
 }

--- a/src/core/application/notification/notification.types.ts
+++ b/src/core/application/notification/notification.types.ts
@@ -1,10 +1,11 @@
 import * as Core from '@/core';
+import type { NotificationType } from '@/core/models/notification/notification.types';
 
 export type TNotificationApplicationNotificationsParams = {
   userId: Core.Pubky;
   lastPolledTimestamp: number | undefined;
   lastRead: number;
-  allowedTypes: Core.NotificationType[];
+  allowedTypes: NotificationType[];
 };
 
 /**
@@ -35,6 +36,7 @@ export type TNotificationsPartialCacheHitParams = {
  */
 export type TGetOrFetchNotificationsParams = Core.TOlderThanQueryParams & {
   userId: Core.Pubky;
+  allowedTypes?: NotificationType[];
 };
 
 export type TFlatNotificationList = Core.FlatNotification[];

--- a/src/core/controllers/notification/notification.test.ts
+++ b/src/core/controllers/notification/notification.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NotificationApplication } from '@/core/application/notification/notification';
 import { NotificationController } from './notification';
 import * as Core from '@/core';
 import * as Config from '@/config';
+import { NotificationType } from '@/core/models/notification/notification.types';
 import { mockAuthStore, mockNotificationStore, asOpaque } from '@/test-utils';
 
 const mockUserId = 'pubky-user-123' as Core.Pubky;
@@ -61,7 +63,7 @@ describe('NotificationController', () => {
         userId: mockUserId,
         lastPolledTimestamp: 500,
         lastRead: 1234,
-        allowedTypes: expect.arrayContaining(Object.values(Core.NotificationType)),
+        allowedTypes: expect.arrayContaining(Object.values(NotificationType)),
       });
       expect(store.setUnread).toHaveBeenCalledWith(5);
       expect(store.setLastPolledTimestamp).toHaveBeenCalledWith(3000);
@@ -80,7 +82,7 @@ describe('NotificationController', () => {
       expect(appSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           lastRead: 1234,
-          allowedTypes: expect.not.arrayContaining([Core.NotificationType.Follow]),
+          allowedTypes: expect.not.arrayContaining([NotificationType.Follow]),
         }),
       );
     });
@@ -137,7 +139,7 @@ describe('NotificationController', () => {
         userId: mockUserId,
         lastPolledTimestamp: undefined,
         lastRead: 1000,
-        allowedTypes: expect.arrayContaining(Object.values(Core.NotificationType)),
+        allowedTypes: expect.arrayContaining(Object.values(NotificationType)),
       });
       expect(setUnread).toHaveBeenCalledWith(2);
       expect(setLastPolledTimestamp).toHaveBeenCalledWith(3000);
@@ -150,7 +152,7 @@ describe('NotificationController', () => {
         userId: mockUserId,
         lastPolledTimestamp: 3000,
         lastRead: 1000,
-        allowedTypes: expect.arrayContaining(Object.values(Core.NotificationType)),
+        allowedTypes: expect.arrayContaining(Object.values(NotificationType)),
       });
       expect(setUnread).toHaveBeenCalledWith(4);
       expect(setLastPolledTimestamp).toHaveBeenCalledWith(5000);
@@ -203,7 +205,7 @@ describe('NotificationController', () => {
   describe('getOrFetchNotifications', () => {
     const mockResponse: Core.TGetOrFetchNotificationsResponse = {
       flatNotifications: [
-        { id: 'follow:3000:user-1', type: Core.NotificationType.Follow, timestamp: 3000, followed_by: 'user-1' },
+        { id: 'follow:3000:user-1', type: NotificationType.Follow, timestamp: 3000, followed_by: 'user-1' },
       ] as Core.FlatNotification[],
       olderThan: 3000,
     };
@@ -218,86 +220,42 @@ describe('NotificationController', () => {
       { params: { olderThan: 5000 }, expectedOlderThan: 5000, expectedLimit: Config.NEXUS_NOTIFICATIONS_LIMIT },
       { params: { limit: 50 }, expectedOlderThan: Infinity, expectedLimit: 50 },
       { params: { olderThan: 8000, limit: 20 }, expectedOlderThan: 8000, expectedLimit: 20 },
-    ])('should call application with params: $params', async ({ params, expectedOlderThan, expectedLimit }) => {
-      const spy = vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
+    ])(
+      'should delegate to NotificationApplication.getOrFetchNotifications with params: $params',
+      async ({ params, expectedOlderThan, expectedLimit }) => {
+        const spy = vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
 
-      await NotificationController.getOrFetchNotifications(params);
+        await NotificationController.getOrFetchNotifications(params);
 
-      expect(spy).toHaveBeenCalledWith({
-        userId: mockUserId,
-        olderThan: expectedOlderThan,
-        limit: expectedLimit,
-      });
+        expect(spy).toHaveBeenCalledWith({
+          userId: mockUserId,
+          olderThan: expectedOlderThan,
+          limit: expectedLimit,
+          allowedTypes: undefined,
+        });
+      },
+    );
+
+    it('should pass allowedTypes derived from preferences', async () => {
+      mockSettingsStore({ follow: false });
+      const spy = vi.spyOn(NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
+
+      await NotificationController.getOrFetchNotifications({});
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedTypes: expect.not.arrayContaining([NotificationType.Follow]),
+        }),
+      );
     });
 
-    it('should return all notifications when all preferences are enabled (default)', async () => {
-      // mockSettingsStore() defaults to all preferences enabled,
-      // so no notifications should be filtered out
+    it('should return the response from application', async () => {
       vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
 
       const result = await NotificationController.getOrFetchNotifications({});
 
       expect(result.flatNotifications).toHaveLength(1);
       expect(result.olderThan).toBe(3000);
-    });
-
-    it('should filter out disabled notification types', async () => {
-      mockSettingsStore({ follow: false });
-      vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mockResponse);
-
-      const result = await NotificationController.getOrFetchNotifications({});
-
-      expect(result.flatNotifications).toHaveLength(0);
-      expect(result.olderThan).toBe(3000);
-    });
-
-    it('should filter mixed notification types by preferences', async () => {
-      mockSettingsStore({ postDeleted: false });
-      const mixedResponse: Core.TGetOrFetchNotificationsResponse = {
-        flatNotifications: [
-          { id: 'follow:3000:user-1', type: Core.NotificationType.Follow, timestamp: 3000, followed_by: 'user-1' },
-          {
-            id: 'post_deleted:2000:user-2',
-            type: Core.NotificationType.PostDeleted,
-            timestamp: 2000,
-            delete_source: 'reply',
-            deleted_by: 'user-2',
-            deleted_uri: 'pubky://post/1',
-            linked_uri: 'pubky://post/2',
-          },
-          {
-            id: 'reply:1000:user-3',
-            type: Core.NotificationType.Reply,
-            timestamp: 1000,
-            replied_by: 'user-3',
-            parent_post_uri: 'pubky://post/1',
-            reply_uri: 'pubky://post/3',
-          },
-        ] as Core.FlatNotification[],
-        olderThan: 1000,
-      };
-      vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue(mixedResponse);
-
-      const result = await NotificationController.getOrFetchNotifications({});
-
-      expect(result.flatNotifications).toHaveLength(2);
-      expect(result.flatNotifications.map((n) => n.type)).toEqual([
-        Core.NotificationType.Follow,
-        Core.NotificationType.Reply,
-      ]);
-      expect(result.olderThan).toBe(1000);
-    });
-
-    it('should return empty response when no notifications', async () => {
-      vi.spyOn(Core.NotificationApplication, 'getOrFetchNotifications').mockResolvedValue({
-        flatNotifications: [],
-        olderThan: undefined,
-      });
-
-      const result = await NotificationController.getOrFetchNotifications({});
-
-      expect(result.flatNotifications).toHaveLength(0);
-      expect(result.olderThan).toBeUndefined();
     });
 
     it('should bubble errors from application', async () => {

--- a/src/core/controllers/notification/notification.ts
+++ b/src/core/controllers/notification/notification.ts
@@ -1,5 +1,6 @@
 import * as Core from '@/core';
 import * as Config from '@/config';
+import { NotificationType } from '@/core/models/notification/notification.types';
 import { NotificationNormalizer } from '@/core/pipes/notification/notification.normalizer';
 import { useSettingsStore } from '@/core/stores/settings/settings.store';
 
@@ -64,9 +65,10 @@ export class NotificationController {
    * Uses timestamp-based pagination.
    *
    * All notifications are stored unfiltered in IndexedDB.
-   * Filtering by user preferences happens here at read time — the Controller reads
-   * NotificationPreferences from the settings store and removes disabled items before
-   * returning to the UI. This avoids accessing Zustand stores from the Application layer (ADR-0004).
+   * The controller reads NotificationPreferences from the settings store and computes
+   * allowedTypes, then delegates filtering-aware pagination to NotificationApplication.
+   * This keeps store access in the Controller layer (ADR-0004) while keeping fetch
+   * orchestration in the Application layer.
    *
    * @param params.olderThan - Unix timestamp to get notifications older than.
    *                           Defaults to Infinity for initial load (most recent notifications).
@@ -81,17 +83,15 @@ export class NotificationController {
   }: Core.TGetNotificationsParams): Promise<Core.TGetOrFetchNotificationsResponse> {
     const userId = Core.useAuthStore.getState().selectCurrentUserPubky();
     const preferences = useSettingsStore.getState().notifications;
+    const allowedTypes = NotificationNormalizer.toEnabledTypes(preferences);
+    const shouldFilterByPreferences = allowedTypes.length < Object.values(NotificationType).length;
 
-    const response = await Core.NotificationApplication.getOrFetchNotifications({
+    return Core.NotificationApplication.getOrFetchNotifications({
       userId,
       olderThan,
       limit,
+      allowedTypes: shouldFilterByPreferences ? allowedTypes : undefined,
     });
-
-    return {
-      ...response,
-      flatNotifications: NotificationNormalizer.filterByPreferences(response.flatNotifications, preferences),
-    };
   }
 
   /**

--- a/src/core/pipes/notification/notification.normalizer.test.ts
+++ b/src/core/pipes/notification/notification.normalizer.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as Core from '@/core';
 import { LastReadResult } from 'pubky-app-specs';
-import { NotificationType, PostChangedSource } from '@/core/models/notification/notification.types';
-import type { FlatNotification } from '@/core/models/notification/notification.types';
 import type { NotificationPreferences } from '@/core/stores/settings/settings.types';
 import { defaultNotificationPreferences } from '@/core/stores/settings/settings.types';
 import { NotificationNormalizer } from './notification.normalizer';
-import { NOTIFICATION_TYPE_TO_PREFERENCE_KEY } from './notification.constants';
 import { asOpaque } from '@/test-utils';
 import {
   TEST_PUBKY,
@@ -21,49 +18,6 @@ import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 
 describe('NotificationNormalizer', () => {
-  const makeNotification = (type: NotificationType, timestamp: number): FlatNotification => {
-    const base = { id: `${type}:${timestamp}:actor`, timestamp, type };
-
-    switch (type) {
-      case NotificationType.Follow:
-        return { ...base, type, followed_by: 'user-1' };
-      case NotificationType.NewFriend:
-        return { ...base, type, followed_by: 'user-1' };
-      case NotificationType.TagPost:
-        return { ...base, type, tagged_by: 'user-1', tag_label: 'test', post_uri: 'pubky://post/1' };
-      case NotificationType.TagProfile:
-        return { ...base, type, tagged_by: 'user-1', tag_label: 'test' };
-      case NotificationType.Reply:
-        return { ...base, type, replied_by: 'user-1', parent_post_uri: 'pubky://post/1', reply_uri: 'pubky://post/2' };
-      case NotificationType.Repost:
-        return { ...base, type, reposted_by: 'user-1', embed_uri: 'pubky://post/1', repost_uri: 'pubky://post/2' };
-      case NotificationType.Mention:
-        return { ...base, type, mentioned_by: 'user-1', post_uri: 'pubky://post/1' };
-      case NotificationType.PostDeleted:
-        return {
-          ...base,
-          type,
-          delete_source: PostChangedSource.Reply,
-          deleted_by: 'user-1',
-          deleted_uri: 'pubky://post/1',
-          linked_uri: 'pubky://post/2',
-        };
-      case NotificationType.PostEdited:
-        return {
-          ...base,
-          type,
-          edit_source: PostChangedSource.Reply,
-          edited_by: 'user-1',
-          edited_uri: 'pubky://post/1',
-          linked_uri: 'pubky://post/2',
-        };
-      default: {
-        const _exhaustive: never = type;
-        throw new Error(`Unhandled notification type: ${_exhaustive}`);
-      }
-    }
-  };
-
   /**
    * Tests for `to` method - Creates LastRead result (same as LastReadNormalizer)
    */
@@ -271,99 +225,6 @@ describe('NotificationNormalizer', () => {
 
         expect(result).toHaveProperty('extra_field', 'extra_value');
       });
-    });
-  });
-
-  describe('filterByPreferences', () => {
-    it('should return all notifications when all preferences are enabled', () => {
-      const notifications = [
-        makeNotification(Core.NotificationType.Follow, 1000),
-        makeNotification(Core.NotificationType.Reply, 2000),
-        makeNotification(Core.NotificationType.PostDeleted, 3000),
-      ];
-
-      const result = NotificationNormalizer.filterByPreferences(notifications, defaultNotificationPreferences);
-
-      expect(result).toHaveLength(3);
-    });
-
-    it('should filter out disabled notification types', () => {
-      const notifications = [
-        makeNotification(Core.NotificationType.Follow, 1000),
-        makeNotification(Core.NotificationType.Reply, 2000),
-        makeNotification(Core.NotificationType.PostDeleted, 3000),
-      ];
-      const preferences: NotificationPreferences = {
-        ...defaultNotificationPreferences,
-        postDeleted: false,
-      };
-
-      const result = NotificationNormalizer.filterByPreferences(notifications, preferences);
-
-      expect(result).toHaveLength(2);
-      expect(result.map((n) => n.type)).toEqual([Core.NotificationType.Follow, Core.NotificationType.Reply]);
-    });
-
-    it('should filter out multiple disabled types', () => {
-      const notifications = [
-        makeNotification(Core.NotificationType.Follow, 1000),
-        makeNotification(Core.NotificationType.NewFriend, 2000),
-        makeNotification(Core.NotificationType.Reply, 3000),
-        makeNotification(Core.NotificationType.Repost, 4000),
-      ];
-      const preferences: NotificationPreferences = {
-        ...defaultNotificationPreferences,
-        follow: false,
-        repost: false,
-      };
-
-      const result = NotificationNormalizer.filterByPreferences(notifications, preferences);
-
-      expect(result).toHaveLength(2);
-      expect(result.map((n) => n.type)).toEqual([Core.NotificationType.NewFriend, Core.NotificationType.Reply]);
-    });
-
-    it('should return empty array when all preferences are disabled', () => {
-      const notifications = [
-        makeNotification(Core.NotificationType.Follow, 1000),
-        makeNotification(Core.NotificationType.Reply, 2000),
-      ];
-      const preferences: NotificationPreferences = {
-        follow: false,
-        newFriend: false,
-        tagPost: false,
-        tagProfile: false,
-        mention: false,
-        reply: false,
-        repost: false,
-        postDeleted: false,
-        postEdited: false,
-      };
-
-      const result = NotificationNormalizer.filterByPreferences(notifications, preferences);
-
-      expect(result).toHaveLength(0);
-    });
-
-    it('should return empty array when given empty notifications', () => {
-      const result = NotificationNormalizer.filterByPreferences([], defaultNotificationPreferences);
-
-      expect(result).toHaveLength(0);
-    });
-
-    it('should correctly map each notification type to its preference key', () => {
-      const allTypes = Object.values(Core.NotificationType);
-      const notifications = allTypes.map((type, i) => makeNotification(type, (i + 1) * 1000));
-
-      for (const disabledType of allTypes) {
-        const preferences: NotificationPreferences = { ...defaultNotificationPreferences };
-        preferences[NOTIFICATION_TYPE_TO_PREFERENCE_KEY[disabledType]] = false;
-
-        const result = NotificationNormalizer.filterByPreferences(notifications, preferences);
-
-        expect(result).toHaveLength(allTypes.length - 1);
-        expect(result.every((n) => n.type !== disabledType)).toBe(true);
-      }
     });
   });
 

--- a/src/core/pipes/notification/notification.normalizer.ts
+++ b/src/core/pipes/notification/notification.normalizer.ts
@@ -3,7 +3,6 @@ import * as Core from '@/core';
 import { getBusinessKey } from '@/core/models/notification/notification.helpers';
 import type { NotificationPreferences } from '@/core/stores/settings/settings.types';
 import { NotificationType } from '@/core/models/notification/notification.types';
-import type { FlatNotification } from '@/core/models/notification/notification.types';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
@@ -39,20 +38,6 @@ export class NotificationNormalizer {
       ...notificationWithoutId,
       id,
     };
-  }
-
-  /**
-   * Filters notifications by user preferences.
-   * Returns only notifications whose type is enabled in the given preferences.
-   */
-  static filterByPreferences(
-    notifications: FlatNotification[],
-    preferences: NotificationPreferences,
-  ): FlatNotification[] {
-    return notifications.filter((notification) => {
-      const preferenceKey = NOTIFICATION_TYPE_TO_PREFERENCE_KEY[notification.type];
-      return preferences[preferenceKey];
-    });
   }
 
   /**

--- a/src/hooks/useNotifications/useNotifications.test.tsx
+++ b/src/hooks/useNotifications/useNotifications.test.tsx
@@ -2,13 +2,48 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useNotifications } from './useNotifications';
 import { NotificationType } from '@/core';
+import type { FlatNotification } from '@/core/models/notification/notification.types';
+
 import * as Core from '@/core';
 import { useMutedUsers } from '@/hooks/useMutedUsers';
+function createAllEnabledNotificationPreferences() {
+  return {
+    follow: true,
+    newFriend: true,
+    tagPost: true,
+    tagProfile: true,
+    mention: true,
+    reply: true,
+    repost: true,
+    postDeleted: true,
+    postEdited: true,
+  };
+}
 
 // Hoist mock data
-const { mockCurrentUserPubky, setMockCurrentUserPubky, mockUnreadCount, setMockUnreadCount } = vi.hoisted(() => {
+const {
+  mockCurrentUserPubky,
+  setMockCurrentUserPubky,
+  mockUnreadCount,
+  setMockUnreadCount,
+  mockNotificationPreferences,
+  setMockNotificationPreferences,
+  mockNotificationController,
+} = vi.hoisted(() => {
   const pubky = { current: 'test-user-pubky' as string | null };
   const unread = { current: 0 };
+  const notificationPreferences = {
+    current: createAllEnabledNotificationPreferences(),
+  };
+  const notificationController = {
+    getOrFetchNotifications: vi.fn(() =>
+      Promise.resolve({
+        flatNotifications: [],
+        olderThan: undefined,
+      }),
+    ),
+    markAllAsRead: vi.fn(),
+  };
   return {
     mockCurrentUserPubky: pubky,
     setMockCurrentUserPubky: (value: string | null) => {
@@ -18,23 +53,32 @@ const { mockCurrentUserPubky, setMockCurrentUserPubky, mockUnreadCount, setMockU
     setMockUnreadCount: (value: number) => {
       unread.current = value;
     },
+    mockNotificationPreferences: notificationPreferences,
+    setMockNotificationPreferences: (value: typeof notificationPreferences.current) => {
+      notificationPreferences.current = value;
+    },
+    mockNotificationController: notificationController,
   };
 });
 
+vi.mock('@/core/controllers/notification/notification', () => ({
+  NotificationController: mockNotificationController,
+}));
+
+vi.mock('@/core/stores/settings/settings.store', () => ({
+  useSettingsStore: vi.fn((selector) => {
+    const state = { notifications: mockNotificationPreferences.current };
+    return selector ? selector(state) : state;
+  }),
+}));
+
 // Mock Core
+// TODO(refactor): Remove Core.* test access once direct-path imports replace the core barrel. #1722
 vi.mock('@/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/core')>();
   return {
     ...actual,
-    NotificationController: {
-      getOrFetchNotifications: vi.fn(() =>
-        Promise.resolve({
-          flatNotifications: [],
-          olderThan: undefined,
-        }),
-      ),
-      markAllAsRead: vi.fn(),
-    },
+    NotificationController: mockNotificationController,
     useAuthStore: vi.fn(() => ({
       currentUserPubky: mockCurrentUserPubky.current,
     })),
@@ -68,6 +112,7 @@ describe('useNotifications', () => {
     vi.clearAllMocks();
     setMockCurrentUserPubky('test-user-pubky');
     setMockUnreadCount(0);
+    setMockNotificationPreferences(createAllEnabledNotificationPreferences());
     vi.mocked(useMutedUsers).mockReturnValue({
       mutedUserIds: [],
       mutedUserIdSet: new Set(),
@@ -299,5 +344,57 @@ describe('useNotifications', () => {
     expect(result.current.count).toBe(2);
     // Should have called getOrFetchNotifications twice: once on mount, once on unread count change
     expect(Core.NotificationController.getOrFetchNotifications).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reset pagination and refetch first page when notification filter changes', async () => {
+    // Regression intent:
+    // - User may already be paginated into older items (cursor has advanced).
+    // - When notification preferences change, list query context changes.
+    // - Hook should restart from first page, not continue from stale olderThan cursor.
+    const olderPageNotifications = [
+      { id: 'older-1', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user1' },
+    ] as FlatNotification[];
+    const latestPageNotifications = [
+      { id: 'latest-1', type: NotificationType.Reply, timestamp: 3000, replied_by: 'user2' },
+    ] as FlatNotification[];
+
+    vi.mocked(Core.NotificationController.getOrFetchNotifications)
+      .mockResolvedValueOnce({
+        flatNotifications: olderPageNotifications,
+        olderThan: 999,
+      })
+      .mockResolvedValueOnce({
+        flatNotifications: latestPageNotifications,
+        olderThan: 2999,
+      });
+
+    const { result, rerender } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Initial render reflects current paginated snapshot.
+    expect(result.current.notifications).toEqual(olderPageNotifications);
+    expect(Core.NotificationController.getOrFetchNotifications).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      // Simulate user toggling one notification type in Settings.
+      setMockNotificationPreferences({
+        ...createAllEnabledNotificationPreferences(),
+        follow: false,
+      });
+      rerender();
+    });
+
+    // filter change should trigger a fresh first-page request ({})
+    // so newest matching items are shown again.
+    await waitFor(() => {
+      // Includes the initial mount call + one refetch after filter change.
+      expect(Core.NotificationController.getOrFetchNotifications).toHaveBeenCalledTimes(2);
+    });
+
+    expect(Core.NotificationController.getOrFetchNotifications).toHaveBeenNthCalledWith(2, {});
+    expect(result.current.notifications).toEqual(latestPageNotifications);
   });
 });

--- a/src/hooks/useNotifications/useNotifications.tsx
+++ b/src/hooks/useNotifications/useNotifications.tsx
@@ -232,7 +232,6 @@ export function useNotifications(): UseNotificationsResult {
 
     if (!hasPreferencesChanged) return;
 
-    setHasMore(true);
     refresh();
   }, [currentUserPubky, notificationPreferences, refresh]);
 

--- a/src/hooks/useNotifications/useNotifications.tsx
+++ b/src/hooks/useNotifications/useNotifications.tsx
@@ -5,6 +5,7 @@ import * as Core from '@/core';
 import { NotificationType, type FlatNotification } from '@/core';
 // Direct import to avoid circular dependency (this hook is exported from @/hooks)
 import { useMutedUsers } from '@/hooks/useMutedUsers';
+import { useSettingsStore } from '@/core/stores/settings/settings.store';
 import type { UseNotificationsResult } from './useNotifications.types';
 import { Logger } from '@/libs/logger/logger';
 
@@ -23,6 +24,8 @@ export function useNotifications(): UseNotificationsResult {
   const loadingRef = useRef(false);
 
   const { currentUserPubky } = Core.useAuthStore();
+  const notificationPreferences = useSettingsStore((s) => s.notifications);
+  const previousPreferencesRef = useRef(notificationPreferences);
 
   /**
    * Mute filtering for notifications.
@@ -215,6 +218,23 @@ export function useNotifications(): UseNotificationsResult {
     if (!currentUserPubky) return;
     performInitialLoad();
   }, [currentUserPubky, performInitialLoad]);
+
+  /**
+   * Reset pagination when notification filter preferences change.
+   * Preference changes create a new query context, so we must restart from
+   * the first page instead of continuing with the previous olderThan cursor.
+   */
+  useEffect(() => {
+    if (!currentUserPubky) return;
+
+    const hasPreferencesChanged = previousPreferencesRef.current !== notificationPreferences;
+    previousPreferencesRef.current = notificationPreferences;
+
+    if (!hasPreferencesChanged) return;
+
+    setHasMore(true);
+    refresh();
+  }, [currentUserPubky, notificationPreferences, refresh]);
 
   /**
    * Reactively filter notifications when mute state changes.


### PR DESCRIPTION
## Summary

  - Fix empty notification list when user has only some notification types enabled and matching items are beyond the
   first page
  - Move preference filtering from Controller (post-fetch) into Application layer's pagination loop, so it fetches
  successive pages until enough matching items are collected (capped at MAX_FETCH_ROUNDS)
  - Reset pagination cursor in `useNotifications` when preferences change

## Test plan

  - Enable only one notification type (e.g., New Friend) that doesn't appear in the first 30 items (`NEXUS_NOTIFICATIONS_LIMIT`)
  - Verify matching notifications are displayed on the notifications page
  - Toggle preferences and verify the list refreshes from page 1
  - Verify all notification types enabled still works as before (no pagination loop)
  - Run `vitest` for notification Application, Controller, Pipe, and hook tests

## Test
### Before

https://github.com/user-attachments/assets/990f1c0b-2999-4dd3-9ff4-cd874976137b

### After

https://github.com/user-attachments/assets/eea04ea9-0747-4150-99b5-9cd7c2dfae56

