### PR TITLE
fix(ui): header avatar shows blank after avatar removal (#526)

### DIFF
--- a/src/components/organisms/AvatarWithFallback/AvatarWithFallback.test.tsx
+++ b/src/components/organisms/AvatarWithFallback/AvatarWithFallback.test.tsx
@@ -328,6 +328,35 @@ describe('AvatarWithFallback', () => {
     });
   });
 
+  describe('Avatar root key', () => {
+    // Verifies the consumer passes `key={resolvedAvatarUrl ?? 'fallback'}` to
+    // <Atoms.Avatar>. React doesn't expose `key` to the rendered component, so we
+    // assert the observable effect: the avatar DOM node is replaced when the key
+    // changes, and preserved when it doesn't. See issue #526 for the underlying
+    // Radix state issue this workaround addresses.
+    it('replaces the avatar root node when avatarUrl changes', () => {
+      const { rerender } = render(<AvatarWithFallback {...mockProps} avatarUrl={validAvatarUrl} />);
+      const firstRoot = screen.getByTestId('avatar');
+
+      // Note: undefined avatarUrl triggers the fallback (image not shown)
+      rerender(<AvatarWithFallback {...mockProps} avatarUrl={undefined} />);
+      const secondRoot = screen.getByTestId('avatar');
+
+      expect(secondRoot).not.toBe(firstRoot);
+    });
+
+    it('preserves the avatar root node when avatarUrl is unchanged', () => {
+      const { rerender } = render(<AvatarWithFallback {...mockProps} avatarUrl={validAvatarUrl} />);
+      const firstRoot = screen.getByTestId('avatar');
+
+      // Note: name change doesn't trigger a remount, so the avatar root node is preserved.
+      rerender(<AvatarWithFallback {...mockProps} avatarUrl={validAvatarUrl} name="Updated Name" />);
+      const secondRoot = screen.getByTestId('avatar');
+
+      expect(secondRoot).toBe(firstRoot);
+    });
+  });
+
   describe('Local Avatar Resolution', () => {
     const localBlobUrl = 'blob:http://localhost/local-avatar-123';
 

--- a/src/components/organisms/AvatarWithFallback/AvatarWithFallback.tsx
+++ b/src/components/organisms/AvatarWithFallback/AvatarWithFallback.tsx
@@ -74,7 +74,9 @@ export function AvatarWithFallback({
     setImageError(false);
   }, [resolvedAvatarUrl]);
   return (
-    <Atoms.Avatar size={size} className={className} data-testid={dataTestId}>
+    // `key` forces remount so Radix Avatar resets its 'loaded' state and shows the fallback (#526).
+    // TODO: cover with E2E/VRT — jsdom can't reproduce real image loading.
+    <Atoms.Avatar key={resolvedAvatarUrl ?? 'fallback'} size={size} className={className} data-testid={dataTestId}>
       {resolvedAvatarUrl && !imageError && (
         <>
           <Atoms.AvatarImage


### PR DESCRIPTION
## Summary

  Closes #526.

  When a user removed their profile avatar, the header thumbnail went blank instead of falling back to the default
  placeholder. The avatar on the profile page itself updated correctly — only the header was stuck.

  ## Why it happened

  The header is a persistent layout element: it doesn't remount when you navigate or save the profile. The
  underlying Radix Avatar component caches the load state of the image internally, so once an avatar had
  successfully loaded, removing the URL didn't cause the placeholder to appear — the cached "image is loaded" state
  suppressed the fallback.

  The profile page didn't have this problem because saving navigates back to the profile route, which mounts a fresh
   Avatar tree.

  ## The fix

  Tie the Avatar's React `key` to the resolved avatar URL, so the Avatar tree remounts whenever the URL changes
  (including when it goes away). A fresh mount means a fresh internal state — and the placeholder shows up as
  expected.

  One-line change in `AvatarWithFallback.tsx`.

  ## Tests

  - Added a unit test that asserts the Avatar root is replaced when the URL changes (catches regressions of the
  `key` wiring).
  - Added a TODO in the component pointing to E2E/VRT for the user-visible flow — the actual visual bug requires
  real image loading, which jsdom can't reproduce, so unit tests can only verify the wiring.

  ## Test plan

  - [ ] Sign in with a custom avatar set
  - [ ] Go to your profile page, edit profile, remove the avatar, save
  - [ ] Confirm the header thumbnail shows the FacehashAvatar placeholder (not blank, not black)
  - [ ] Upload a new avatar and confirm the header updates immediately
  - [ ] Navigate around the app and confirm avatars on posts/lists still render correctly
  
  ## Result
  

https://github.com/user-attachments/assets/fb85d20c-f1c9-49fa-8705-ff4237a0ff3c

