### PR TITLE
refactor: remove miscellaneous barrel imports

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "sourceMap": false,
     "outDir": "../dist/out-tsc",

--- a/docs/component-testing.md
+++ b/docs/component-testing.md
@@ -139,7 +139,8 @@ const authStore = {
 const event = { key: 'Enter', preventDefault: vi.fn() } as any;
 
 // After — the helpers type-check the partials and add sensible defaults
-import { mockAuthStore, mockKeyboardEvent } from '@/test-utils';
+import { mockKeyboardEvent } from '@/test-utils/react-events';
+import { mockAuthStore } from '@/test-utils/stores';
 
 const authStore = mockAuthStore({
   currentUserPubky: 'abc',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,11 @@ import { getLocale, getMessages } from 'next-intl/server';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { IntlProvider } from '@/providers/IntlProvider/IntlProvider';
+import { GlobalErrorHandlerProvider } from '@/providers/GlobalErrorHandlerProvider/GlobalErrorHandlerProvider';
+import { ErrorBoundaryProvider } from '@/providers/ErrorBoundaryProvider/ErrorBoundaryProvider';
+import { DatabaseProvider } from '@/providers/DatabaseProvider/DatabaseProvider';
+import { RouteGuardProvider } from '@/providers/RouteGuardProvider/RouteGuardProvider';
 import { TOOLTIP_DELAY_MS } from '@/config';
 
 export const viewport: Viewport = {
@@ -32,24 +36,24 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   return (
     <Molecules.RootContainer locale={locale}>
-      <Providers.IntlProvider locale={locale} messages={messages}>
+      <IntlProvider locale={locale} messages={messages}>
         <Atoms.TooltipProvider delayDuration={TOOLTIP_DELAY_MS}>
-          <Providers.GlobalErrorHandlerProvider>
-            <Providers.ErrorBoundaryProvider>
-              <Providers.DatabaseProvider>
-                <Providers.RouteGuardProvider>
+          <GlobalErrorHandlerProvider>
+            <ErrorBoundaryProvider>
+              <DatabaseProvider>
+                <RouteGuardProvider>
                   <Organisms.CoordinatorsManager />
                   <Organisms.Header />
                   {children}
                   <Molecules.NewPostCTA />
                   <Molecules.Toaster />
                   <Organisms.DialogSignIn />
-                </Providers.RouteGuardProvider>
-              </Providers.DatabaseProvider>
-            </Providers.ErrorBoundaryProvider>
-          </Providers.GlobalErrorHandlerProvider>
+                </RouteGuardProvider>
+              </DatabaseProvider>
+            </ErrorBoundaryProvider>
+          </GlobalErrorHandlerProvider>
         </Atoms.TooltipProvider>
-      </Providers.IntlProvider>
+      </IntlProvider>
     </Molecules.RootContainer>
   );
 }

--- a/src/app/profile/(own)/layout.tsx
+++ b/src/app/profile/(own)/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { ProfileProvider } from '@/providers/ProfileProvider/ProfileProvider';
 
 /**
  * ProfileLayout - Next.js layout for profile pages (own profile)
@@ -15,8 +15,8 @@ import * as Providers from '@/providers';
  */
 export default function ProfileLayout({ children }: { children: React.ReactNode }) {
   return (
-    <Providers.ProfileProvider>
+    <ProfileProvider>
       <Organisms.ProfilePageContainer>{children}</Organisms.ProfilePageContainer>
-    </Providers.ProfileProvider>
+    </ProfileProvider>
   );
 }

--- a/src/app/profile/[pubky]/layout.tsx
+++ b/src/app/profile/[pubky]/layout.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useParams } from 'next/navigation';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { ProfileProvider } from '@/providers/ProfileProvider/ProfileProvider';
 import { stripPubkyPrefix } from '@/libs/utils/utils';
 import type { Pubky } from '@/models/models.types';
 /**
@@ -23,8 +23,8 @@ export default function DynamicProfileLayout({ children }: { children: React.Rea
   const pubky = stripPubkyPrefix(decodedParam) as Pubky;
 
   return (
-    <Providers.ProfileProvider pubky={pubky}>
+    <ProfileProvider pubky={pubky}>
       <Organisms.ProfilePageContainer>{children}</Organisms.ProfilePageContainer>
-    </Providers.ProfileProvider>
+    </ProfileProvider>
   );
 }

--- a/src/components/molecules/ContainerRoot/ContainerRoot.tsx
+++ b/src/components/molecules/ContainerRoot/ContainerRoot.tsx
@@ -3,7 +3,7 @@ import Script from 'next/script';
 
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
-import { isRtlLocale } from '@/i18n';
+import { isRtlLocale } from '@/i18n/constants';
 import { Env } from '@/libs/env/env';
 
 const interTight = Inter_Tight({

--- a/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx
+++ b/src/components/molecules/MarkdownEditor/InitializedMDXEditor.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React, { createRef } from 'react';
 import type { MDXEditorMethods } from '@mdxeditor/editor';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import InitializedMDXEditor from './InitializedMDXEditor';
 
 // Mock config - use a smaller value for easier testing

--- a/src/components/molecules/PostLinkEmbeds/PostLinkEmbeds.tsx
+++ b/src/components/molecules/PostLinkEmbeds/PostLinkEmbeds.tsx
@@ -4,17 +4,21 @@ import { useMemo } from 'react';
 import LinkifyIt from 'linkify-it';
 
 import * as Atoms from '@/atoms';
-import * as Providers from './Providers';
-import * as Types from './PostLinkEmbeds.types';
+import { Generic } from '@/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric';
+import type { EmbedProvider } from '@/molecules/PostLinkEmbeds/Providers/Provider.types';
+import { Twitter } from '@/molecules/PostLinkEmbeds/Providers/Twitter/ProviderTwitter';
+import { Vimeo } from '@/molecules/PostLinkEmbeds/Providers/Vimeo/ProviderVimeo';
+import { Youtube } from '@/molecules/PostLinkEmbeds/Providers/Youtube/ProviderYoutube';
+import type { ParseUrlForLinkEmbedResult, PostLinkEmbedsProps } from './PostLinkEmbeds.types';
 
 // Register all embed providers here
-const EMBED_PROVIDERS: Providers.EmbedProvider[] = [
-  Providers.Youtube,
-  Providers.Vimeo,
-  Providers.Twitter,
-  Providers.Generic,
+const EMBED_PROVIDERS: EmbedProvider[] = [
+  Youtube,
+  Vimeo,
+  Twitter,
+  Generic,
   // Add more providers here:
-  // Providers.Twitch,
+  // Twitch,
 ];
 
 // Protocol types to ignore when parsing links
@@ -24,11 +28,11 @@ const IGNORED_PROTOCOLS = ['ftp:', 'mailto:'];
  * Create a hostname-to-provider lookup map for O(1) performance
  * Lazily initialized on first use to avoid module circular dependency issues
  */
-let PROVIDER_MAP: Map<string, Providers.EmbedProvider> | null = null;
+let PROVIDER_MAP: Map<string, EmbedProvider> | null = null;
 
-const getProviderMap = (): Map<string, Providers.EmbedProvider> => {
+const getProviderMap = (): Map<string, EmbedProvider> => {
   if (!PROVIDER_MAP) {
-    PROVIDER_MAP = new Map<string, Providers.EmbedProvider>(
+    PROVIDER_MAP = new Map<string, EmbedProvider>(
       EMBED_PROVIDERS.flatMap((provider) => provider.domains.map((domain) => [domain, provider] as const)),
     );
   }
@@ -68,7 +72,7 @@ const parseContentForUrl = (content: string) => {
  * Parse content for embeddable links
  * Returns the first embeddable link and its provider
  */
-const parseContentForLinkEmbed = (content: string): Types.ParseUrlForLinkEmbedResult => {
+const parseContentForLinkEmbed = (content: string): ParseUrlForLinkEmbedResult => {
   try {
     const url = parseContentForUrl(content);
     if (!url) return { embed: null, provider: null };
@@ -81,15 +85,15 @@ const parseContentForLinkEmbed = (content: string): Types.ParseUrlForLinkEmbedRe
     const provider = providerMap.get(hostname);
 
     if (!provider) {
-      const embed = Providers.Generic.parseEmbed(url);
-      return { embed, provider: Providers.Generic };
+      const embed = Generic.parseEmbed(url);
+      return { embed, provider: Generic };
     }
 
     const embed = provider.parseEmbed(url);
 
     if (!embed) {
-      const embed = Providers.Generic.parseEmbed(url);
-      return { embed, provider: Providers.Generic };
+      const embed = Generic.parseEmbed(url);
+      return { embed, provider: Generic };
     }
 
     return { embed, provider };
@@ -98,7 +102,7 @@ const parseContentForLinkEmbed = (content: string): Types.ParseUrlForLinkEmbedRe
   }
 };
 
-export const PostLinkEmbeds = ({ content }: Types.PostLinkEmbedsProps) => {
+export const PostLinkEmbeds = ({ content }: PostLinkEmbedsProps) => {
   const { embed, provider } = useMemo(() => parseContentForLinkEmbed(content), [content]);
 
   if (!embed || !provider) return null;

--- a/src/components/molecules/PostLinkEmbeds/PostLinkEmbeds.types.ts
+++ b/src/components/molecules/PostLinkEmbeds/PostLinkEmbeds.types.ts
@@ -1,10 +1,10 @@
-import * as Providers from './Providers';
+import type { EmbedData, EmbedProvider } from '@/molecules/PostLinkEmbeds/Providers/Provider.types';
 
 export type PostLinkEmbedsProps = {
   content: string;
 };
 
 export type ParseUrlForLinkEmbedResult = {
-  embed: Providers.EmbedData | null;
-  provider: Providers.EmbedProvider | null;
+  embed: EmbedData | null;
+  provider: EmbedProvider | null;
 };

--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import type { EmbedData } from '../../Providers/Provider.types';
 import { Generic } from './ProviderGeneric';
 import { GenericPreview } from './GenericPreview';

--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/index.ts
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/index.ts
@@ -1,1 +1,0 @@
-export * from './ProviderGeneric';

--- a/src/components/molecules/PostLinkEmbeds/Providers/Twitter/index.ts
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Twitter/index.ts
@@ -1,1 +1,0 @@
-export * from './ProviderTwitter';

--- a/src/components/molecules/PostLinkEmbeds/Providers/Vimeo/index.ts
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Vimeo/index.ts
@@ -1,1 +1,0 @@
-export * from './ProviderVimeo';

--- a/src/components/molecules/PostLinkEmbeds/Providers/Youtube/index.ts
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Youtube/index.ts
@@ -1,1 +1,0 @@
-export * from './ProviderYoutube';

--- a/src/components/molecules/PostLinkEmbeds/Providers/index.ts
+++ b/src/components/molecules/PostLinkEmbeds/Providers/index.ts
@@ -1,5 +1,0 @@
-export * from './Youtube';
-export * from './Vimeo';
-export * from './Twitter';
-export * from './Generic';
-export * from './Provider.types';

--- a/src/components/molecules/PostText/PostText.utils.test.ts
+++ b/src/components/molecules/PostText/PostText.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Root, Paragraph, Text, Code, Link, Emphasis } from 'mdast';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import {
   remarkPlaintextCodeblock,
   remarkDisallowMarkdownLinks,

--- a/src/components/organisms/HumanLightningPayment/HumanLightningPayment.test.tsx
+++ b/src/components/organisms/HumanLightningPayment/HumanLightningPayment.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor, fireEvent, screen } from '@testing-library/react';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HumanLightningPayment } from './HumanLightningPayment';
 import { VerificationHandler } from './HumanLightningPayment.utils';
 import { HomegateController } from '@/controllers/homegate/homegate';

--- a/src/components/organisms/HumanLightningPayment/HumanLightningPayment.utils.test.ts
+++ b/src/components/organisms/HumanLightningPayment/HumanLightningPayment.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VerificationHandler } from './HumanLightningPayment.utils';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HomegateController } from '@/controllers/homegate/homegate';
 type VerificationHandlerInternals = { checkPaymentStatus: () => Promise<void> };
 

--- a/src/components/organisms/PostAttachments/PostAttachments.test.tsx
+++ b/src/components/organisms/PostAttachments/PostAttachments.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PostAttachments } from './PostAttachments';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { FileController } from '@/controllers/file/file';
 import { FileVariant } from '@/services/nexus/file/file.types';
 import type { NexusFileDetails } from '@/services/nexus/nexus.types';

--- a/src/components/organisms/PostContentBase/PostContentBase.test.tsx
+++ b/src/components/organisms/PostContentBase/PostContentBase.test.tsx
@@ -5,7 +5,7 @@ import { PostContentBase } from './PostContentBase';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 // Mock next/navigation for usePathname used by PostText

--- a/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx
+++ b/src/components/organisms/ProfileFollowers/ProfileFollowers.test.tsx
@@ -4,10 +4,10 @@ import { ProfileFollowers } from './ProfileFollowers';
 import { useFollowUser } from '@/hooks/useFollowUser/useFollowUser';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { useProfileConnections } from '@/hooks/useProfileConnections/useProfileConnections';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 // Mock Providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: vi.fn(() => ({
     pubky: 'user123',
     isOwnProfile: true,

--- a/src/components/organisms/ProfileFollowers/ProfileFollowers.tsx
+++ b/src/components/organisms/ProfileFollowers/ProfileFollowers.tsx
@@ -7,7 +7,7 @@ import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { NEXUS_USERS_PER_PAGE } from '@/config';
 import type { Pubky } from '@/models/models.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -22,7 +22,7 @@ const LOAD_MORE_SKELETON_COUNT = 2;
  */
 export function ProfileFollowers() {
   // Get the profile pubky from context
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
   // Get the current logged-in user's pubky
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
 

--- a/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx
+++ b/src/components/organisms/ProfileFollowing/ProfileFollowing.test.tsx
@@ -4,10 +4,10 @@ import { ProfileFollowing } from './ProfileFollowing';
 import { useFollowUser } from '@/hooks/useFollowUser/useFollowUser';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { useProfileConnections } from '@/hooks/useProfileConnections/useProfileConnections';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 // Mock Providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: vi.fn(() => ({
     pubky: 'user123',
     isOwnProfile: true,

--- a/src/components/organisms/ProfileFollowing/ProfileFollowing.tsx
+++ b/src/components/organisms/ProfileFollowing/ProfileFollowing.tsx
@@ -7,7 +7,7 @@ import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { NEXUS_USERS_PER_PAGE } from '@/config';
 import type { Pubky } from '@/models/models.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -22,7 +22,7 @@ const LOAD_MORE_SKELETON_COUNT = 2;
  */
 export function ProfileFollowing() {
   // Get the profile pubky from context
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
   // Get the current logged-in user's pubky
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
 

--- a/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx
+++ b/src/components/organisms/ProfileFriends/ProfileFriends.test.tsx
@@ -4,10 +4,10 @@ import { ProfileFriends } from './ProfileFriends';
 import { useFollowUser } from '@/hooks/useFollowUser/useFollowUser';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { useProfileConnections } from '@/hooks/useProfileConnections/useProfileConnections';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 // Mock Providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: vi.fn(() => ({
     pubky: 'user123',
     isOwnProfile: true,

--- a/src/components/organisms/ProfileFriends/ProfileFriends.tsx
+++ b/src/components/organisms/ProfileFriends/ProfileFriends.tsx
@@ -7,7 +7,7 @@ import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { NEXUS_USERS_PER_PAGE } from '@/config';
 import type { Pubky } from '@/models/models.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -24,7 +24,7 @@ const LOAD_MORE_SKELETON_COUNT = 2;
  */
 export function ProfileFriends() {
   // Get the profile pubky from context
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
   // Get the current logged-in user's pubky
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
 

--- a/src/components/organisms/ProfilePageContainer/ProfilePageContainer.test.tsx
+++ b/src/components/organisms/ProfilePageContainer/ProfilePageContainer.test.tsx
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ProfilePageContainer } from './ProfilePageContainer';
 import { PROFILE_PAGE_TYPES } from '@/app/profile/types';
-import { asOpaque, mockAuthStore } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockAuthStore } from '@/test-utils/stores';
 import { useProfileHeader } from '@/hooks/useProfileHeader/useProfileHeader';
 import { useAuthStore } from '@/stores/auth/auth.store';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import type { AuthStore } from '@/stores/auth/auth.types';
 // Mock dependencies
 const mockCurrentUserPubky = 'user123';
@@ -17,7 +19,7 @@ vi.mock('@/stores/auth/auth.store', () => ({
 }));
 
 // Mock Providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: vi.fn(() => ({
     pubky: mockCurrentUserPubky,
     isOwnProfile: true,
@@ -276,8 +278,7 @@ describe('ProfilePageContainer - User not found', () => {
 
   it('shows UserNotFound when user is not found and not own profile', async () => {
     // Mock useProfileContext to return isOwnProfile: false
-    const providers = await import('@/providers');
-    vi.mocked(providers.useProfileContext).mockReturnValue({
+    vi.mocked(useProfileContext).mockReturnValue({
       pubky: 'nonexistent-user',
       isOwnProfile: false,
       isLoading: false,
@@ -312,8 +313,7 @@ describe('ProfilePageContainer - User not found', () => {
 
   it('shows ProfilePageLayout when user is found', async () => {
     // Reset to default mocks
-    const providers = await import('@/providers');
-    vi.mocked(providers.useProfileContext).mockReturnValue({
+    vi.mocked(useProfileContext).mockReturnValue({
       pubky: mockCurrentUserPubky,
       isOwnProfile: true,
       isLoading: false,
@@ -338,8 +338,7 @@ describe('ProfilePageContainer - User not found', () => {
 
   it('does not show UserNotFound for own profile even if userNotFound is true', async () => {
     // Mock useProfileContext to return isOwnProfile: true
-    const providers = await import('@/providers');
-    vi.mocked(providers.useProfileContext).mockReturnValue({
+    vi.mocked(useProfileContext).mockReturnValue({
       pubky: mockCurrentUserPubky,
       isOwnProfile: true,
       isLoading: false,
@@ -375,8 +374,7 @@ describe('ProfilePageContainer - User not found', () => {
 
   it('does not show UserNotFound during logout even if userNotFound is true', async () => {
     // Mock useProfileContext to return isOwnProfile: false (simulating state after logout clears auth)
-    const providers = await import('@/providers');
-    vi.mocked(providers.useProfileContext).mockReturnValue({
+    vi.mocked(useProfileContext).mockReturnValue({
       pubky: '',
       isOwnProfile: false,
       isLoading: false,

--- a/src/components/organisms/ProfilePageContainer/ProfilePageContainer.tsx
+++ b/src/components/organisms/ProfilePageContainer/ProfilePageContainer.tsx
@@ -7,7 +7,7 @@ import { useProfileNavigation } from '@/hooks/useProfileNavigation/useProfileNav
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { useAuthStore } from '@/stores/auth/auth.store';
 export interface ProfilePageContainerProps {
   /** Child pages to render in the main content area */
@@ -47,7 +47,7 @@ export interface ProfilePageContainerProps {
  */
 export function ProfilePageContainer({ children }: ProfilePageContainerProps) {
   // Business logic: Get profile context (pubky and isOwnProfile)
-  const { pubky, isOwnProfile } = Providers.useProfileContext();
+  const { pubky, isOwnProfile } = useProfileContext();
 
   // Check if logout is in progress (global state to prevent flash of weird states)
   const isLoggingOut = useAuthStore((state) => state.isLoggingOut);

--- a/src/components/organisms/ProfilePageSidebar/ProfilePageSidebar.test.tsx
+++ b/src/components/organisms/ProfilePageSidebar/ProfilePageSidebar.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@/controllers/profile/profile', () => ({
 }));
 
 // Mock @/providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: vi.fn(() => ({
     pubky: 'test-pubky-123',
     isOwnProfile: true,

--- a/src/components/organisms/ProfilePageSidebar/ProfilePageSidebar.tsx
+++ b/src/components/organisms/ProfilePageSidebar/ProfilePageSidebar.tsx
@@ -9,7 +9,7 @@ import { usePathname } from 'next/navigation';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
 import * as Organisms from '@/organisms';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import * as Config from '@/config';
 import { MAX_SIDEBAR_TAGS } from './ProfilePageSidebar.constants';
 import { cn } from '@/libs/utils/utils';
@@ -19,7 +19,7 @@ export function ProfilePageSidebar() {
   const { isAuthenticated, requireAuth } = useRequireAuth();
 
   // Get the profile pubky and isOwnProfile from context
-  const { pubky, isOwnProfile } = Providers.useProfileContext();
+  const { pubky, isOwnProfile } = useProfileContext();
 
   // Get user profile data for the target user
   const { profile } = useUserProfile(pubky ?? '');

--- a/src/components/organisms/ProfileProfile/ProfileProfile.tsx
+++ b/src/components/organisms/ProfileProfile/ProfileProfile.tsx
@@ -8,7 +8,7 @@ import { useTagged } from '@/hooks/useTagged/useTagged';
 import * as React from 'react';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { ProfilePageHeader } from '@/organisms';
 import { MAX_SIDEBAR_TAGS } from '../ProfilePageSidebar/ProfilePageSidebar.constants';
 
@@ -21,7 +21,7 @@ import { MAX_SIDEBAR_TAGS } from '../ProfilePageSidebar/ProfilePageSidebar.const
  */
 export function ProfileProfile() {
   // Get the profile pubky and isOwnProfile from context
-  const { pubky, isOwnProfile } = Providers.useProfileContext();
+  const { pubky, isOwnProfile } = useProfileContext();
 
   // Note: useProfileHeader guarantees a non-null profile with default values during loading
   const { profile, actions, isLoading } = useProfileHeader(pubky ?? '');

--- a/src/components/organisms/ProfileReplies/ProfileReplies.tsx
+++ b/src/components/organisms/ProfileReplies/ProfileReplies.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { RepliesWithParent } from './RepliesWithParent';
 import type { AuthorRepliesStreamCompositeId } from '@/models/stream/post/postStream.types';
 import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
@@ -12,7 +12,7 @@ import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
  * Uses ProfileContext to get the target user's pubky.
  */
 export function ProfileReplies() {
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
 
   const streamId = pubky ? (`${StreamSource.AUTHOR_REPLIES}:${pubky}` as AuthorRepliesStreamCompositeId) : undefined;
 

--- a/src/components/organisms/ProfileTagged/ProfileTagged.test.tsx
+++ b/src/components/organisms/ProfileTagged/ProfileTagged.test.tsx
@@ -6,7 +6,7 @@ import { useTagged } from '@/hooks/useTagged/useTagged';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 
 // Mock providers
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: () => ({
     pubky: 'test-user-pubky',
     isOwnProfile: true,

--- a/src/components/organisms/ProfileTagged/ProfileTagged.tsx
+++ b/src/components/organisms/ProfileTagged/ProfileTagged.tsx
@@ -4,7 +4,7 @@ import { useTagged } from '@/hooks/useTagged/useTagged';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import * as Atoms from '@/atoms';
 import * as Molecules from '@/molecules';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { ProfileTaggedSkeleton } from './ProfileTagged.skeleton';
 
 /**
@@ -20,7 +20,7 @@ import { ProfileTaggedSkeleton } from './ProfileTagged.skeleton';
  */
 export function ProfileTagged() {
   // Get the profile pubky from context
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
 
   // Get user profile data for the target user
   const { profile } = useUserProfile(pubky ?? '');

--- a/src/components/organisms/Scan/Scan.test.tsx
+++ b/src/components/organisms/Scan/Scan.test.tsx
@@ -5,7 +5,7 @@ import { ScanContent, ScanFooter, ScanHeader, ScanNavigation } from './Scan';
 import * as Config from '@/config';
 import * as App from '@/app';
 import { useMobileAuth } from '@/hooks/useMobileAuth/useMobileAuth';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 
 // Mock Next.js router
 const mockPush = vi.fn();

--- a/src/components/organisms/Settings/LanguageSelector/LanguageSelector.constants.ts
+++ b/src/components/organisms/Settings/LanguageSelector/LanguageSelector.constants.ts
@@ -1,7 +1,7 @@
 import type { LanguageOption } from './LanguageSelector.types';
 
 // Re-export RTL locales from shared i18n constants
-export { RTL_LOCALES, isRtlLocale } from '@/i18n';
+export { RTL_LOCALES, isRtlLocale } from '@/i18n/constants';
 
 /** Available languages for the application */
 export const LANGUAGES: LanguageOption[] = [

--- a/src/components/organisms/Settings/LanguageSelector/LanguageSelector.constants.ts
+++ b/src/components/organisms/Settings/LanguageSelector/LanguageSelector.constants.ts
@@ -1,8 +1,5 @@
 import type { LanguageOption } from './LanguageSelector.types';
 
-// Re-export RTL locales from shared i18n constants
-export { RTL_LOCALES, isRtlLocale } from '@/i18n/constants';
-
 /** Available languages for the application */
 export const LANGUAGES: LanguageOption[] = [
   { code: 'en', name: 'US English', flag: '🇺🇸' },

--- a/src/components/organisms/SignIn/SignIn.test.tsx
+++ b/src/components/organisms/SignIn/SignIn.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vites
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import messages from '../../../../messages/en.json';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { SignInContent, SignInFooter } from './SignIn';
 import { useMobileAuth } from '@/hooks/useMobileAuth/useMobileAuth';
 

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
@@ -9,8 +9,8 @@ import { useCustomStreamId } from '@/hooks/useCustomStreamId/useCustomStreamId';
 import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
 import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStreamIdFromFilters';
 import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
-import * as Providers from '@/providers';
-import { asInvalid } from '@/test-utils';
+import { ProfileProvider } from '@/providers/ProfileProvider/ProfileProvider';
+import { asInvalid } from '@/test-utils/type-assertions';
 import type { UsePullToRefreshResult } from '@/hooks/usePullToRefresh/usePullToRefresh.types';
 import { PostStreamTypes, type PostStreamId } from '@/models/stream/post/postStream.types';
 import { useHomeStore } from '@/stores/home/home.store';
@@ -95,14 +95,6 @@ vi.mock('@/hooks/useIsScrolledFromTop/useIsScrolledFromTop', () => ({
 vi.mock('@/hooks/usePullToRefresh/usePullToRefresh', () => ({
   usePullToRefresh: mockUsePullToRefresh,
 }));
-
-vi.mock('@/providers', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/providers')>();
-  return {
-    ...actual,
-    ProfileContext: actual.ProfileContext,
-  };
-});
 
 // Mock components
 vi.mock('@/molecules', () => ({
@@ -520,9 +512,9 @@ describe('TimelineFeed', () => {
   describe('Profile Variant', () => {
     it('should show loading when profile context has no pubky', () => {
       render(
-        <Providers.ProfileProvider>
+        <ProfileProvider>
           <TimelineFeed variant={TIMELINE_FEED_VARIANT.PROFILE} />
-        </Providers.ProfileProvider>,
+        </ProfileProvider>,
       );
 
       // When pubky is not available, streamId is undefined

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -9,7 +9,7 @@ import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStream
 import { useSyncInteractiveVisualContent } from '@/hooks/useSyncInteractiveVisualContent/useSyncInteractiveVisualContent';
 import { TIMELINE_FEED_VARIANT } from '@/config';
 import * as Molecules from '@/molecules';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { getTagsLayoutForSurfaceLayout } from '@/organisms/PostMain/PostMainLayout';
 import type { TimelineFeedProps } from './TimelineFeed.types';
 import { resolveVisualFeedContent } from './TimelineFeedVisual.helpers';
@@ -110,7 +110,7 @@ function BookmarksTimelineFeed({ children }: { children?: TimelineFeedProps['chi
 }
 
 function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['children'] }) {
-  const { pubky } = Providers.useProfileContext();
+  const { pubky } = useProfileContext();
   const streamId = pubky ? (`${StreamSource.AUTHOR}:${pubky}` as AuthorStreamCompositeId) : undefined;
   const layoutResolution = useFeedLayoutResolution(TIMELINE_FEED_VARIANT.PROFILE);
   const tagsLayout = getTagsLayoutForSurfaceLayout(layoutResolution.effectiveLayout);

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeedVisualMedia.utils.test.ts
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeedVisualMedia.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { probeImageDimensions, probeVideoDimensions } from './TimelineFeedVisualMedia.utils';
 
 describe('TimelineFeedVisualMedia.utils', () => {

--- a/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx
+++ b/src/components/organisms/WhoToFollowPage/WhoToFollowPageMain.test.tsx
@@ -5,7 +5,7 @@ import { WhoToFollowPageMain } from './WhoToFollowPageMain';
 import { useFollowUser } from '@/hooks/useFollowUser/useFollowUser';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
 import { useUserStream } from '@/hooks/useUserStream/useUserStream';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 // Mock dependencies
 vi.mock('@/stores/auth/auth.store', () => ({

--- a/src/core/application/auth/auth.test.ts
+++ b/src/core/application/auth/auth.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Session, Keypair } from '@synonymdev/pubky';
-import { asOpaque, mockAuthStore, mockSession } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockAuthStore } from '@/test-utils/stores';
+import { mockSession } from '@/test-utils/pubky';
 import { AppError } from '@/libs/error/error';
 import { AuthErrorCode, ClientErrorCode, NetworkErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';

--- a/src/core/application/bookmark/bookmark.test.ts
+++ b/src/core/application/bookmark/bookmark.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BookmarkApplication } from './bookmark';
 import type { TCreateBookmarkInput, TDeleteBookmarkInput } from './bookmark.types';
-import { mockAuthStore } from '@/test-utils';
+import { mockAuthStore } from '@/test-utils/stores';
 import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';
 import { HomeserverService } from '@/services/homeserver/homeserver';

--- a/src/core/application/bootstrap/bootstrap.test.ts
+++ b/src/core/application/bootstrap/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LastReadResult } from 'pubky-app-specs';
 import { BootstrapApplication } from './bootstrap';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { Env } from '@/libs/env/env';
 import { ClientErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';

--- a/src/core/application/copyright/copyright.ts
+++ b/src/core/application/copyright/copyright.ts
@@ -1,4 +1,4 @@
-import * as Types from './copyright.types';
+import type { TCopyrightSubmitInput } from './copyright.types';
 import { ChatwootService } from '@/services/chatwoot/chatwoot';
 import { CHATWOOT_INBOX_IDS } from '@/services/chatwoot/chatwoot.constants';
 import { extractSourceId } from '@/services/chatwoot/chatwoot.utils';
@@ -25,7 +25,7 @@ export class CopyrightApplication {
   /**
    * Format form data as JSON string for message body
    */
-  private static formatFormData(formData: Types.TCopyrightSubmitInput): string {
+  private static formatFormData(formData: TCopyrightSubmitInput): string {
     return JSON.stringify(formData, null, 2);
   }
 
@@ -42,7 +42,7 @@ export class CopyrightApplication {
    * @param params - Parameters object with all copyright form fields
    * @throws AppError if submission fails
    */
-  static async submit(params: Types.TCopyrightSubmitInput): Promise<void> {
+  static async submit(params: TCopyrightSubmitInput): Promise<void> {
     const email = params.email;
     const inboxId = CHATWOOT_INBOX_IDS.COPYRIGHT;
     const name = `${params.firstName} ${params.lastName}`.trim();

--- a/src/core/application/feed/feed.test.ts
+++ b/src/core/application/feed/feed.test.ts
@@ -7,7 +7,7 @@ import {
   PubkySpecsBuilder,
 } from 'pubky-app-specs';
 import { FeedApplication } from './feed';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import type { TFeedPersistCreateParams, TFeedPersistDeleteParams } from '@/application/feed/feed.types';

--- a/src/core/application/feedback/feedback.test.ts
+++ b/src/core/application/feedback/feedback.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TFeedbackSubmitInput } from './feedback.types';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { NetworkErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';

--- a/src/core/application/feedback/feedback.ts
+++ b/src/core/application/feedback/feedback.ts
@@ -1,4 +1,4 @@
-import * as Types from './feedback.types';
+import type { TFeedbackSubmitInput } from './feedback.types';
 import { Logger } from '@/libs/logger/logger';
 import { AppError } from '@/libs/error/error';
 import { ServerErrorCode } from '@/libs/error/error.codes';
@@ -46,7 +46,7 @@ export class FeedbackApplication {
    * @param params.name - User's display name
    * @throws AppError if submission fails
    */
-  static async submit({ pubky, comment, name }: Types.TFeedbackSubmitInput): Promise<void> {
+  static async submit({ pubky, comment, name }: TFeedbackSubmitInput): Promise<void> {
     try {
       // Build email from pubky
       const email = buildChatwootEmail(pubky);

--- a/src/core/application/file/file.test.ts
+++ b/src/core/application/file/file.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BlobResult, FileResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
-import type { Pubky } from '@/models/models.types';
 import { FileVariant } from '@/services/nexus/file/file.types';
 import type { NexusFileDetails } from '@/services/nexus/nexus.types';
 import * as buildCompositeIdFromPubkyUriModule from '@/models/models.utils';
 import * as parseCompositeIdModule from '@/models/models.utils';
 import { FileDetailsModel } from '@/models/file/fileDetails';
-import { CompositeIdDomain } from '@/models/models.types';
+import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeId, buildCompositeIdFromPubkyUri } from '@/models/models.utils';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 import { LocalFileService } from '@/services/local/file/file';

--- a/src/core/application/file/file.test.ts
+++ b/src/core/application/file/file.test.ts
@@ -4,8 +4,6 @@ import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { FileVariant } from '@/services/nexus/file/file.types';
 import type { NexusFileDetails } from '@/services/nexus/nexus.types';
-import * as buildCompositeIdFromPubkyUriModule from '@/models/models.utils';
-import * as parseCompositeIdModule from '@/models/models.utils';
 import { FileDetailsModel } from '@/models/file/fileDetails';
 import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeId, buildCompositeIdFromPubkyUri } from '@/models/models.utils';
@@ -59,6 +57,10 @@ vi.mock('@/models/file/fileDetails', () => ({
 }));
 
 let FileApplication: typeof import('./file').FileApplication;
+
+const spyOnBuildCompositeIdFromPubkyUri = async () =>
+  vi.spyOn(await import('@/models/models.utils'), 'buildCompositeIdFromPubkyUri');
+const spyOnParseCompositeId = async () => vi.spyOn(await import('@/models/models.utils'), 'parseCompositeId');
 
 const TEST_PUBKY = 'operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rd0' as Pubky;
 const TEST_TIMESTAMP = 1234567890;
@@ -341,11 +343,11 @@ describe('FileApplication', () => {
       expect(result).toBe(expectedUrl);
     });
 
-    it('propagates errors from parseCompositeId', () => {
+    it('propagates errors from parseCompositeId', async () => {
       const invalidCompositeId = 'invalid-id';
       const variant = FileVariant.FEED;
 
-      vi.spyOn(parseCompositeIdModule, 'parseCompositeId').mockImplementation(() => {
+      (await spyOnParseCompositeId()).mockImplementation(() => {
         throw new Error(`Invalid composite id: ${invalidCompositeId}`);
       });
 
@@ -551,7 +553,7 @@ describe('FileApplication', () => {
     it('skips deletion gracefully when composite ID cannot be built from invalid URI', async () => {
       const invalidUri = 'not-a-valid-uri';
 
-      vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(null);
+      (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(null);
       const deleteMetadataSpy = vi.spyOn(HomeserverService, 'delete').mockResolvedValue(undefined);
       const findByIdSpy = vi.spyOn(FileDetailsModel, 'findById');
       const deleteLocalSpy = vi.spyOn(LocalFileService, 'deleteById');
@@ -590,7 +592,7 @@ describe('FileApplication', () => {
       const mockFile = createMockFile(compositeId, 'file1.jpg', fileUri, { src: blobUrl });
 
       const error = new Error('Blob deletion failed');
-      vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(compositeId);
+      (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(compositeId);
       const deleteMetadataSpy = vi.spyOn(HomeserverService, 'delete').mockImplementation((uri: string) => {
         if (uri === fileUri) {
           return Promise.resolve(undefined); // Metadata deletion succeeds
@@ -620,7 +622,7 @@ describe('FileApplication', () => {
       const mockFile = createMockFile(compositeId, 'file1.jpg', fileUri, { src: blobUrl });
 
       const error = new Error('Local deletion failed');
-      vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(compositeId);
+      (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(compositeId);
       vi.spyOn(HomeserverService, 'delete').mockResolvedValue(undefined);
       vi.spyOn(LocalFileService, 'read').mockResolvedValue(mockFile);
       const deleteLocalSpy = vi.spyOn(LocalFileService, 'deleteById').mockRejectedValue(error);
@@ -639,7 +641,7 @@ describe('FileApplication', () => {
       const compositeId = buildCompositeId({ pubky: TEST_PUBKY, id: fileId });
 
       const error = new Error('Homeserver fetch failed');
-      vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(compositeId);
+      (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(compositeId);
       vi.spyOn(HomeserverService, 'delete').mockResolvedValue(undefined);
       vi.spyOn(LocalFileService, 'read').mockResolvedValue(null);
       const requestSpy = vi.spyOn(HomeserverService, 'request').mockRejectedValue(error);

--- a/src/core/application/homegate/homegate.ts
+++ b/src/core/application/homegate/homegate.ts
@@ -1,4 +1,12 @@
-import type * as Types from './homegate.types';
+import type {
+  THomegateAwaitLnVerificationResult,
+  THomegateCreateLnVerificationResult,
+  THomegateLnInfoResult,
+  THomegateSendSmsCodeResult,
+  THomegateSmsInfoResult,
+  THomegateVerifySmsCodeParams,
+  THomegateVerifySmsCodeResult,
+} from './homegate.types';
 import { ExchangerateService } from '@/services/exchangerate/exchangerate';
 import type { BtcRate } from '@/services/exchangerate/exchangerate.types';
 import { HomegateService } from '@/services/homegate/homegate';
@@ -21,7 +29,7 @@ export class HomegateApplication {
    * @returns The availability status
    * @throws AppError if retrieval fails
    */
-  static async getSmsVerificationInfo(): Promise<Types.THomegateSmsInfoResult> {
+  static async getSmsVerificationInfo(): Promise<THomegateSmsInfoResult> {
     return await HomegateService.getSmsVerificationInfo();
   }
 
@@ -31,7 +39,7 @@ export class HomegateApplication {
    * @returns The availability status and price if available
    * @throws AppError if retrieval fails
    */
-  static async getLnVerificationInfo(): Promise<Types.THomegateLnInfoResult> {
+  static async getLnVerificationInfo(): Promise<THomegateLnInfoResult> {
     return await HomegateService.getLnVerificationInfo();
   }
 
@@ -41,7 +49,7 @@ export class HomegateApplication {
    * @returns The verification details including the BOLT11 invoice
    * @throws AppError if creation fails
    */
-  static async createLnVerification(): Promise<Types.THomegateCreateLnVerificationResult> {
+  static async createLnVerification(): Promise<THomegateCreateLnVerificationResult> {
     return HomegateService.createLnVerification();
   }
 
@@ -57,7 +65,7 @@ export class HomegateApplication {
   static async awaitLnVerification(
     verificationId: string,
     signal?: AbortSignal,
-  ): Promise<Types.THomegateAwaitLnVerificationResult> {
+  ): Promise<THomegateAwaitLnVerificationResult> {
     if (signal) {
       return HomegateService.awaitLnVerification(verificationId, signal);
     }
@@ -75,7 +83,7 @@ export class HomegateApplication {
   static async verifySmsCode({
     phoneNumber,
     code,
-  }: Types.THomegateVerifySmsCodeParams): Promise<Types.THomegateVerifySmsCodeResult> {
+  }: THomegateVerifySmsCodeParams): Promise<THomegateVerifySmsCodeResult> {
     return HomegateService.verifySmsCode({ phoneNumber, code });
   }
 
@@ -86,7 +94,7 @@ export class HomegateApplication {
    * @returns The result of the SMS send request
    * @throws AppError if sending fails
    */
-  static async sendSmsCode(phoneNumber: string): Promise<Types.THomegateSendSmsCodeResult> {
+  static async sendSmsCode(phoneNumber: string): Promise<THomegateSendSmsCodeResult> {
     return HomegateService.sendSmsCode(phoneNumber);
   }
 

--- a/src/core/application/moderation/moderation.utils.test.ts
+++ b/src/core/application/moderation/moderation.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { detectModerationFromTags, shouldBlur } from './moderation.utils';
-import * as Config from '@/config';
+import { MODERATED_TAGS, MODERATION_ID } from '@/config/moderation';
 
 describe('moderation.utils', () => {
   describe('detectModerationFromTags', () => {
@@ -22,8 +22,8 @@ describe('moderation.utils', () => {
     it('should return true when tag has moderation label and moderation tagger', () => {
       const tags = [
         {
-          label: Config.MODERATED_TAGS[0],
-          taggers: [Config.MODERATION_ID],
+          label: MODERATED_TAGS[0],
+          taggers: [MODERATION_ID],
         },
       ];
 
@@ -34,7 +34,7 @@ describe('moderation.utils', () => {
     it('should return false when tag has moderation label but wrong tagger', () => {
       const tags = [
         {
-          label: Config.MODERATED_TAGS[0],
+          label: MODERATED_TAGS[0],
           taggers: ['other-tagger'],
         },
       ];
@@ -47,7 +47,7 @@ describe('moderation.utils', () => {
       const tags = [
         {
           label: 'other-label',
-          taggers: [Config.MODERATION_ID],
+          taggers: [MODERATION_ID],
         },
       ];
 
@@ -62,8 +62,8 @@ describe('moderation.utils', () => {
           taggers: ['other-tagger'],
         },
         {
-          label: Config.MODERATED_TAGS[0],
-          taggers: [Config.MODERATION_ID],
+          label: MODERATED_TAGS[0],
+          taggers: [MODERATION_ID],
         },
         {
           label: 'another-label',

--- a/src/core/application/moderation/moderation.utils.ts
+++ b/src/core/application/moderation/moderation.utils.ts
@@ -1,6 +1,6 @@
-import * as Config from '@/config';
+import { MODERATED_TAGS, MODERATION_ID } from '@/config/moderation';
 
-const MODERATED_TAG_SET = new Set(Config.MODERATED_TAGS);
+const MODERATED_TAG_SET = new Set(MODERATED_TAGS);
 
 /**
  * Detects if a post is moderated based on its tags.
@@ -8,7 +8,7 @@ const MODERATED_TAG_SET = new Set(Config.MODERATED_TAGS);
  */
 export const detectModerationFromTags = (tags: { label: string; taggers: string[] }[] | null | undefined): boolean => {
   if (!tags) return false;
-  return tags.some((tag) => MODERATED_TAG_SET.has(tag.label) && tag.taggers.includes(Config.MODERATION_ID));
+  return tags.some((tag) => MODERATED_TAG_SET.has(tag.label) && tag.taggers.includes(MODERATION_ID));
 };
 
 /**

--- a/src/core/application/mute/mute.test.ts
+++ b/src/core/application/mute/mute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { asInvalid, asOpaque } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
 import { MuteApplication } from './mute';
 import { AppError } from '@/libs/error/error';
 import { ClientErrorCode, ServerErrorCode } from '@/libs/error/error.codes';

--- a/src/core/application/notification/notification.test.ts
+++ b/src/core/application/notification/notification.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LastReadResult } from 'pubky-app-specs';
 import { NotificationApplication } from './notification';
-import { asInvalid, asOpaque } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import { PostStreamApplication } from '@/application/stream/posts/post';

--- a/src/core/application/post/post.test.ts
+++ b/src/core/application/post/post.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PubkyAppPost, PubkyAppPostKind, type BlobResult, type FileResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';

--- a/src/core/application/profile/profile.download.test.ts
+++ b/src/core/application/profile/profile.download.test.ts
@@ -25,13 +25,19 @@ vi.mock('@/config', async (importOriginal) => {
   };
 });
 
-// Mock the Env module (admin credentials are now server-side only)
-vi.mock('@/libs/env/env', () => ({
-  Env: {
-    HOMESERVER_ADMIN_URL: 'http://test-admin.com',
-    HOMESERVER_ADMIN_PASSWORD: 'test-password',
-  },
-}));
+// Mock the Env module (admin credentials are now server-side only).
+// Merge with real Env so @/config/database still gets NEXT_PUBLIC_DB_NAME / NEXT_PUBLIC_DB_VERSION
+// (franky is loaded via the module graph; a partial Env would break Dexie.version()).
+vi.mock('@/libs/env/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/libs/env/env')>();
+  return {
+    Env: {
+      ...actual.Env,
+      HOMESERVER_ADMIN_URL: 'http://test-admin.com',
+      HOMESERVER_ADMIN_PASSWORD: 'test-password',
+    },
+  };
+});
 
 // Mock HomeserverService methods
 vi.mock('@/services/homeserver/homeserver', () => ({

--- a/src/core/application/profile/profile.download.test.ts
+++ b/src/core/application/profile/profile.download.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 const mockFile = vi.fn();

--- a/src/core/application/profile/profile.test.ts
+++ b/src/core/application/profile/profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PubkyAppUser, UserResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/application/profile/profile.ts
+++ b/src/core/application/profile/profile.ts
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
 
-import * as Specs from 'pubky-app-specs';
+import { baseUriBuilder } from 'pubky-app-specs';
 import { HttpMethod } from '@/libs/http/http.types';
 import { ClientErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
@@ -120,7 +120,7 @@ export class ProfileApplication {
     // Clear local IndexedDB data first
     await LocalProfileService.deleteAll();
 
-    const baseDirectory = Specs.baseUriBuilder(pubky);
+    const baseDirectory = baseUriBuilder(pubky);
     // TODO: Using undefined, false, and Infinity here as a temporary workaround since
     // homeserver.list does not yet support pagination. This ensures all files are deleted.
     const dataList = await HomeserverService.list({ baseDirectory, reverse: false, limit: Infinity });
@@ -161,7 +161,7 @@ export class ProfileApplication {
    * @param params - Parameters containing user's public key and optional progress callback
    */
   static async downloadData({ pubky, setProgress }: TDownloadDataParams) {
-    const baseDirectory = Specs.baseUriBuilder(pubky);
+    const baseDirectory = baseUriBuilder(pubky);
 
     // TODO: Using undefined, false, and Infinity here as a temporary workaround since homeserver.list does not yet
     // support pagination. This ensures all files are retrieved.

--- a/src/core/application/report/report.test.ts
+++ b/src/core/application/report/report.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TReportSubmitInput } from './report.types';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { NetworkErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';

--- a/src/core/application/report/report.ts
+++ b/src/core/application/report/report.ts
@@ -1,4 +1,4 @@
-import * as Types from './report.types';
+import type { TReportSubmitInput } from './report.types';
 import { Logger } from '@/libs/logger/logger';
 import { AppError } from '@/libs/error/error';
 import { ServerErrorCode } from '@/libs/error/error.codes';
@@ -78,7 +78,7 @@ export class ReportApplication {
    * @param params.name - Reporter's display name
    * @throws AppError if submission fails
    */
-  static async submit({ pubky, postUrl, issueType, reason, name }: Types.TReportSubmitInput): Promise<void> {
+  static async submit({ pubky, postUrl, issueType, reason, name }: TReportSubmitInput): Promise<void> {
     try {
       // Build email from pubky
       const email = buildChatwootEmail(pubky);

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as Config from '@/config';
 import { postStreamQueue } from './muting/post-stream-queue';
 import { MuteFilter } from './muting/mute-filter';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { FileApplication } from '@/application/file/file';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { FORCE_FETCH_NEW_POSTS, SKIP_FETCH_NEW_POSTS } from '@/controllers/stream/posts/post.constants';
@@ -23,13 +23,13 @@ import { UserRelationshipsModel } from '@/models/user/relationships/userRelation
 import { UserTagsModel } from '@/models/user/tags/userTags';
 import { LocalStreamPostsService } from '@/services/local/stream/posts/posts';
 import { LocalStreamUsersService } from '@/services/local/stream/users/users';
-import { StreamSorting } from '@/services/nexus/nexus.types';
-import type {
-  NexusFileDetails,
-  NexusFileUrls,
-  NexusPost,
-  NexusPostsKeyStream,
-  NexusUser,
+import {
+  StreamSorting,
+  type NexusFileDetails,
+  type NexusFileUrls,
+  type NexusPost,
+  type NexusPostsKeyStream,
+  type NexusUser,
 } from '@/services/nexus/nexus.types';
 import { NexusPostStreamService } from '@/services/nexus/stream/posts/postStream';
 import { NexusUserStreamService } from '@/services/nexus/stream/users/userStream';

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as Config from '@/config';
+import { STREAM_CACHE_MAX_AGE_MS } from '@/config/nexus';
 import { postStreamQueue } from './muting/post-stream-queue';
 import { MuteFilter } from './muting/mute-filter';
 import { asInvalid } from '@/test-utils/type-assertions';
@@ -1464,8 +1464,8 @@ describe('PostStreamApplication', () => {
     });
 
     it('should clear both streams when main stream cache is stale', async () => {
-      const now = BASE_TIMESTAMP + Config.STREAM_CACHE_MAX_AGE_MS + 10;
-      const staleTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS - 1;
+      const now = BASE_TIMESTAMP + STREAM_CACHE_MAX_AGE_MS + 10;
+      const staleTimestamp = now - STREAM_CACHE_MAX_AGE_MS - 1;
       vi.spyOn(Date, 'now').mockReturnValue(now);
 
       const mainPostId = `${DEFAULT_AUTHOR}:post-main`;
@@ -1484,9 +1484,9 @@ describe('PostStreamApplication', () => {
     });
 
     it('should clear unread stream when unread cache is stale and main is fresh', async () => {
-      const now = BASE_TIMESTAMP + Config.STREAM_CACHE_MAX_AGE_MS + 10;
-      const freshTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS + 1;
-      const staleTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS - 1;
+      const now = BASE_TIMESTAMP + STREAM_CACHE_MAX_AGE_MS + 10;
+      const freshTimestamp = now - STREAM_CACHE_MAX_AGE_MS + 1;
+      const staleTimestamp = now - STREAM_CACHE_MAX_AGE_MS - 1;
       vi.spyOn(Date, 'now').mockReturnValue(now);
 
       const mainPostId = `${DEFAULT_AUTHOR}:post-main`;
@@ -1506,7 +1506,7 @@ describe('PostStreamApplication', () => {
     });
 
     it('should merge unread into main and clear unread when both streams are fresh', async () => {
-      const now = BASE_TIMESTAMP + Config.STREAM_CACHE_MAX_AGE_MS + 10;
+      const now = BASE_TIMESTAMP + STREAM_CACHE_MAX_AGE_MS + 10;
       vi.spyOn(Date, 'now').mockReturnValue(now);
 
       const mainPostIds = [`${DEFAULT_AUTHOR}:post-1`, `${DEFAULT_AUTHOR}:post-2`];
@@ -1514,10 +1514,10 @@ describe('PostStreamApplication', () => {
       await createStreamWithPosts(mainPostIds);
       await UnreadPostStreamModel.create(streamId, unreadPostIds);
 
-      const mainHeadTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS + 2;
-      const mainOlderTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS + 1;
-      const unreadNewestTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS + 4;
-      const unreadOlderTimestamp = now - Config.STREAM_CACHE_MAX_AGE_MS + 3;
+      const mainHeadTimestamp = now - STREAM_CACHE_MAX_AGE_MS + 2;
+      const mainOlderTimestamp = now - STREAM_CACHE_MAX_AGE_MS + 1;
+      const unreadNewestTimestamp = now - STREAM_CACHE_MAX_AGE_MS + 4;
+      const unreadOlderTimestamp = now - STREAM_CACHE_MAX_AGE_MS + 3;
 
       await createPostDetailWithTimestamp(mainPostIds[0], mainHeadTimestamp);
       await createPostDetailWithTimestamp(mainPostIds[1], mainOlderTimestamp);

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { STREAM_CACHE_MAX_AGE_MS } from '@/config/nexus';
 import { postStreamQueue } from './muting/post-stream-queue';
 import { MuteFilter } from './muting/mute-filter';
 import { Logger } from '@/libs/logger/logger';
@@ -141,7 +141,7 @@ export class PostStreamApplication {
         streamId,
         headTimestamp: mainStreamHead,
         ageMs: now - mainStreamHead,
-        maxAgeMs: Config.STREAM_CACHE_MAX_AGE_MS,
+        maxAgeMs: STREAM_CACHE_MAX_AGE_MS,
       });
       await Promise.all([
         LocalStreamPostsService.deleteById({ streamId }),
@@ -158,7 +158,7 @@ export class PostStreamApplication {
         streamId,
         headTimestamp: unreadStreamHead,
         ageMs: now - unreadStreamHead,
-        maxAgeMs: Config.STREAM_CACHE_MAX_AGE_MS,
+        maxAgeMs: STREAM_CACHE_MAX_AGE_MS,
       });
       await LocalStreamPostsService.clearUnreadStream({ streamId });
       return;
@@ -179,7 +179,7 @@ export class PostStreamApplication {
       return false;
     }
     const ageMs = now - timestamp;
-    return ageMs > Config.STREAM_CACHE_MAX_AGE_MS;
+    return ageMs > STREAM_CACHE_MAX_AGE_MS;
   }
 
   /**

--- a/src/core/application/stream/users/users.ts
+++ b/src/core/application/stream/users/users.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { NEXUS_USERS_PER_PAGE } from '@/config/nexus';
 import { Logger } from '@/libs/logger/logger';
 import type {
   TFetchStreamFromNexusParams,
@@ -87,7 +87,7 @@ export class UserStreamApplication {
   private static async fetchStreamFromNexus({
     streamId,
     skip = 0,
-    limit = Config.NEXUS_USERS_PER_PAGE,
+    limit = NEXUS_USERS_PER_PAGE,
     viewerId,
     cachedStream,
   }: TFetchStreamFromNexusParams): Promise<TUserStreamChunkResponse> {

--- a/src/core/application/stream/users/users.types.ts
+++ b/src/core/application/stream/users/users.types.ts
@@ -6,7 +6,7 @@ import type { UserStreamId } from '@/models/stream/user/userStream.types';
  * - A composite ID (userId:reach) e.g., 'user123:followers', 'user456:following'
  * - A UserStreamType (source:timeframe:reach) e.g., 'influencers:today:all', 'recommended:all:all'
  *
- * Note: limit is not included as it's controlled by Config.NEXUS_USERS_PER_PAGE
+ * Note: limit is not included as it's controlled by NEXUS_USERS_PER_PAGE
  * viewerId is not included as it's extracted from auth store by the controller
  */
 export type TReadUserStreamChunkParams = {
@@ -17,7 +17,7 @@ export type TReadUserStreamChunkParams = {
 
 /**
  * Internal parameters for fetching user stream (extends public params with limit and viewerId)
- * Used internally by application layer - limit comes from Config.NEXUS_USERS_PER_PAGE
+ * Used internally by application layer - limit comes from NEXUS_USERS_PER_PAGE
  */
 export type TFetchUserStreamChunkParams = TReadUserStreamChunkParams & {
   limit: number;

--- a/src/core/application/ttl/ttl.test.ts
+++ b/src/core/application/ttl/ttl.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { asOpaque } from '@/test-utils/type-assertions';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { queryNexus } from '@/services/nexus/nexus.utils';
 import { FileApplication } from '@/application/file/file';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { TtlApplication } from '@/application/ttl/ttl';
@@ -13,6 +13,17 @@ import type { NexusPost, NexusUser } from '@/services/nexus/nexus.types';
 import { postStreamApi } from '@/services/nexus/stream/posts/postStream.api';
 import { NexusUserStreamService } from '@/services/nexus/stream/users/userStream';
 import { userStreamApi } from '@/services/nexus/stream/users/userStream.api';
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
+
 describe('TtlApplication', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -80,7 +91,7 @@ describe('TtlApplication', () => {
         },
       ];
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(nexusPosts);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(nexusPosts);
       const persistPostsSpy = vi
         .spyOn(LocalStreamPostsService, 'persistPosts')
         .mockResolvedValue(
@@ -108,7 +119,7 @@ describe('TtlApplication', () => {
         body: { post_ids: ['alice:1'], viewer_id: viewerId },
       } as ReturnType<typeof postStreamApi.postsByIds>);
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockRejectedValue(new Error('Network down'));
+      mockQueryNexus.mockRejectedValue(new Error('Network down'));
       const persistPostsSpy = vi
         .spyOn(LocalStreamPostsService, 'persistPosts')
         .mockResolvedValue({ attachmentMetadata: [] });
@@ -147,7 +158,7 @@ describe('TtlApplication', () => {
         body: { post_ids: ['reposter:repost-1'], viewer_id: viewerId },
       } as ReturnType<typeof postStreamApi.postsByIds>);
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([repostNexusPost]);
+      mockQueryNexus.mockResolvedValue([repostNexusPost]);
       vi.spyOn(LocalStreamPostsService, 'persistPosts').mockResolvedValue(
         asOpaque<Awaited<ReturnType<typeof LocalStreamPostsService.persistPosts>>>({ attachmentMetadata: [] }),
       );
@@ -192,7 +203,7 @@ describe('TtlApplication', () => {
         body: { post_ids: ['alice:post-1'], viewer_id: viewerId },
       } as ReturnType<typeof postStreamApi.postsByIds>);
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([regularPost]);
+      mockQueryNexus.mockResolvedValue([regularPost]);
       vi.spyOn(LocalStreamPostsService, 'persistPosts').mockResolvedValue(
         asOpaque<Awaited<ReturnType<typeof LocalStreamPostsService.persistPosts>>>({ attachmentMetadata: [] }),
       );

--- a/src/core/application/ttl/ttl.test.ts
+++ b/src/core/application/ttl/ttl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import * as queryNexusModule from '@/services/nexus/nexus.utils';
 import { FileApplication } from '@/application/file/file';
 import { PostStreamApplication } from '@/application/stream/posts/post';

--- a/src/core/application/user/user.test.ts
+++ b/src/core/application/user/user.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { UserApplication } from './user';
 import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/controllers/auth/auth.test.ts
+++ b/src/core/controllers/auth/auth.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LastReadResult } from 'pubky-app-specs';
 import { AuthController } from './auth';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
-  asOpaque,
   mockAuthStore,
   mockHomeStore,
   mockHotStore,
@@ -11,10 +11,10 @@ import {
   mockNotificationStore,
   mockOnboardingStore,
   mockSearchStore,
-  mockSession as buildMockSession,
   mockSettingsStore,
   mockSignInStore,
-} from '@/test-utils';
+} from '@/test-utils/stores';
+import { mockSession as buildMockSession } from '@/test-utils/pubky';
 import { Identity } from '@/libs/identity/identity';
 import { Logger } from '@/libs/logger/logger';
 import * as clearDatabaseModule from '@/database/franky/franky.helpers';

--- a/src/core/controllers/auth/auth.test.ts
+++ b/src/core/controllers/auth/auth.test.ts
@@ -17,7 +17,7 @@ import {
 import { mockSession as buildMockSession } from '@/test-utils/pubky';
 import { Identity } from '@/libs/identity/identity';
 import { Logger } from '@/libs/logger/logger';
-import * as clearDatabaseModule from '@/database/franky/franky.helpers';
+import { clearDatabase } from '@/database/franky/franky.helpers';
 import { AuthApplication } from '@/application/auth/auth';
 import { BootstrapApplication } from '@/application/bootstrap/bootstrap';
 import { postStreamQueue } from '@/application/stream/posts/muting/post-stream-queue';
@@ -101,6 +101,12 @@ const setupAuthAndNotificationStores = () => {
 vi.mock('pubky-app-specs', () => ({
   default: vi.fn(() => Promise.resolve()),
 }));
+
+vi.mock('@/database/franky/franky.helpers', () => ({
+  clearDatabase: vi.fn(),
+}));
+
+const mockClearDatabase = vi.mocked(clearDatabase);
 
 const storeMocks = vi.hoisted(() => {
   const resetAuthStore = vi.fn();
@@ -264,6 +270,7 @@ vi.mock('@/libs/env/env', () => ({
 describe('AuthController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClearDatabase.mockReset();
     // Ensure migration store mock is always available
     vi.spyOn(useMigrationStore, 'getState').mockReturnValue(
       mockMigrationStore({
@@ -339,7 +346,7 @@ describe('AuthController', () => {
       });
       const keypairFromSecretKeySpy = vi.spyOn(Identity, 'keypairFromSecretKey').mockReturnValue(keypair);
       const z32FromSessionSpy = vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearAllQueryClientsSpy = await spyOnClearAllQueryClients();
 
       const authStore = storeMocks.getAuthState();
@@ -371,7 +378,7 @@ describe('AuthController', () => {
 
       const signUpSpy = vi.spyOn(AuthApplication, 'signUp').mockRejectedValue(new Error('Signup failed'));
       const keypairFromSecretKeySpy = vi.spyOn(Identity, 'keypairFromSecretKey').mockReturnValue(keypair);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearAllQueryClientsSpy = await spyOnClearAllQueryClients();
 
       await expect(AuthController.signUp({ secretKey: TEST_SECRET_KEY, signupToken })).rejects.toThrow('Signup failed');
@@ -409,7 +416,7 @@ describe('AuthController', () => {
       const z32FromSessionSpy = vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
       const userIsSignedUpSpy = vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(true);
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize').mockResolvedValue(bootstrapResponse);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearAllQueryClientsSpy = await spyOnClearAllQueryClients();
 
       const _authStore = setupAuthAndNotificationStores();
@@ -455,7 +462,7 @@ describe('AuthController', () => {
       const z32FromSessionSpy = vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
       const userIsSignedUpSpy = vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(false);
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize');
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       const _authStore = setupAuthAndNotificationStores();
@@ -484,7 +491,7 @@ describe('AuthController', () => {
 
       vi.spyOn(Identity, 'keypairFromMnemonic').mockReturnValue(mockKeypair);
       vi.spyOn(AuthApplication, 'signIn').mockResolvedValue(undefined);
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize');
@@ -501,7 +508,7 @@ describe('AuthController', () => {
 
       vi.spyOn(Identity, 'keypairFromMnemonic').mockReturnValue(mockKeypair);
       vi.spyOn(AuthApplication, 'signIn').mockRejectedValue(new Error('Authentication failed'));
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       await expect(AuthController.loginWithMnemonic({ mnemonic })).rejects.toThrow('Authentication failed');
@@ -533,7 +540,7 @@ describe('AuthController', () => {
       const z32FromSessionSpy = vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
       const userIsSignedUpSpy = vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(true);
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize').mockResolvedValue(bootstrapResponse);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearAllQueryClientsSpy = await spyOnClearAllQueryClients();
 
       const _authStore = setupAuthAndNotificationStores();
@@ -578,7 +585,7 @@ describe('AuthController', () => {
       const z32FromSessionSpy = vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
       const userIsSignedUpSpy = vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(false);
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize');
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       const _authStore = setupAuthAndNotificationStores();
@@ -608,7 +615,7 @@ describe('AuthController', () => {
 
       vi.spyOn(Identity, 'decryptRecoveryFile').mockResolvedValue(mockKeypair);
       vi.spyOn(AuthApplication, 'signIn').mockResolvedValue(undefined);
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       const initializeSpy = vi.spyOn(BootstrapApplication, 'initialize');
@@ -637,7 +644,7 @@ describe('AuthController', () => {
 
       vi.spyOn(Identity, 'decryptRecoveryFile').mockResolvedValue(mockKeypair);
       vi.spyOn(AuthApplication, 'signIn').mockRejectedValue(new Error('Authentication failed'));
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearAllQueryClients();
 
       await expect(AuthController.loginWithEncryptedFile({ encryptedFile, password })).rejects.toThrow(
@@ -659,7 +666,7 @@ describe('AuthController', () => {
         cancelAuthFlow,
       };
       const generateAuthUrlSpy = vi.spyOn(AuthApplication, 'generateAuthUrl').mockResolvedValue(mockAuthUrl);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
 
       const result = await AuthController.getAuthUrl();
 
@@ -676,7 +683,7 @@ describe('AuthController', () => {
       const generateAuthUrlSpy = vi
         .spyOn(AuthApplication, 'generateAuthUrl')
         .mockRejectedValue(new Error('Failed to generate auth URL'));
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
 
       await expect(AuthController.getAuthUrl()).rejects.toThrow('Failed to generate auth URL');
       expect(clearDatabaseSpy).toHaveBeenCalled();
@@ -684,7 +691,7 @@ describe('AuthController', () => {
     });
 
     it('should free stale auth flows when multiple requests overlap (StrictMode)', async () => {
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
 
       const cancelAuthFlowA = vi.fn();
       const cancelAuthFlowB = vi.fn();
@@ -737,7 +744,7 @@ describe('AuthController', () => {
       const generateSignupAuthUrlSpy = vi
         .spyOn(AuthApplication, 'generateSignupAuthUrl')
         .mockResolvedValue(mockAuthUrl);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
 
       const result = await AuthController.getSignupAuthUrl('A9KM-7MJP-ERM9');
 
@@ -752,7 +759,7 @@ describe('AuthController', () => {
       const generateSignupAuthUrlSpy = vi
         .spyOn(AuthApplication, 'generateSignupAuthUrl')
         .mockRejectedValue(new Error('Failed to generate signup auth URL'));
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
 
       await expect(AuthController.getSignupAuthUrl('INVITE-CODE')).rejects.toThrow(
         'Failed to generate signup auth URL',
@@ -761,7 +768,7 @@ describe('AuthController', () => {
     });
 
     it('should free stale auth flows when multiple requests overlap (StrictMode)', async () => {
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
 
       const cancelAuthFlowA = vi.fn();
       const cancelAuthFlowB = vi.fn();
@@ -843,7 +850,7 @@ describe('AuthController', () => {
 
       vi.spyOn(useAuthStore, 'getState').mockReturnValue(authStore);
       vi.spyOn(AuthApplication, 'restorePersistedSession').mockResolvedValue(null);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
       const resetSpy = vi.spyOn(PubkySpecsSingleton, 'reset');
@@ -885,7 +892,7 @@ describe('AuthController', () => {
         awaitApproval: new Promise(() => {}),
         cancelAuthFlow,
       });
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
 
       await AuthController.getAuthUrl();
 
@@ -1010,7 +1017,7 @@ describe('AuthController', () => {
 
     it('should successfully logout user, clear stores, cookies and redirect', async () => {
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockResolvedValue(undefined);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       const clearAllQueryClientsSpy = await spyOnClearAllQueryClients();
       const resetSpy = vi.spyOn(PubkySpecsSingleton, 'reset');
@@ -1077,7 +1084,7 @@ describe('AuthController', () => {
 
     it('should log warning and clear local state even when homeserver logout fails', async () => {
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockRejectedValue(new Error('Network error'));
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
       const warnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
@@ -1106,7 +1113,7 @@ describe('AuthController', () => {
         export: vi.fn(() => 'restored-export'),
       });
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockResolvedValue(undefined);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
 
@@ -1148,7 +1155,7 @@ describe('AuthController', () => {
     });
 
     it('should not run local cleanup twice when persisted session restore fails', async () => {
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockResolvedValue(undefined);
@@ -1171,7 +1178,7 @@ describe('AuthController', () => {
 
     it('should reset PubkySpecsSingleton even when homeserver logout fails (issue #538)', async () => {
       vi.spyOn(AuthApplication, 'logout').mockRejectedValue(new Error('Pubky resolution failed'));
-      vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      mockClearDatabase.mockResolvedValue(undefined);
       await spyOnClearCookies();
       await spyOnClearAllQueryClients();
       vi.spyOn(Logger, 'warn').mockImplementation(() => {});
@@ -1189,7 +1196,7 @@ describe('AuthController', () => {
 
     it('should clear all existing cookies', async () => {
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockResolvedValue(undefined);
-      const clearDatabaseSpy = vi.spyOn(clearDatabaseModule, 'clearDatabase').mockResolvedValue(undefined);
+      const clearDatabaseSpy = mockClearDatabase.mockResolvedValue(undefined);
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
 
@@ -1209,9 +1216,7 @@ describe('AuthController', () => {
 
     it('should throw error if clearing the database fails', async () => {
       const logoutSpy = vi.spyOn(AuthApplication, 'logout').mockResolvedValue(undefined);
-      const clearDatabaseSpy = vi
-        .spyOn(clearDatabaseModule, 'clearDatabase')
-        .mockRejectedValue(new Error('clear failed'));
+      const clearDatabaseSpy = mockClearDatabase.mockRejectedValue(new Error('clear failed'));
       const clearCookiesSpy = await spyOnClearCookies();
       await spyOnClearAllQueryClients();
 

--- a/src/core/controllers/copyright/copyright.ts
+++ b/src/core/controllers/copyright/copyright.ts
@@ -1,4 +1,4 @@
-import * as Types from './copyright.types';
+import type { TCopyrightSubmitParams } from './copyright.types';
 import { CopyrightApplication } from '@/application/copyright/copyright';
 import { CopyrightValidators } from '@/pipes/copyright/copyright.validators';
 /**
@@ -16,7 +16,7 @@ export class CopyrightController {
    * @param params - Copyright form data
    * @throws AppError if validation fails or submission fails
    */
-  static async submit(params: Types.TCopyrightSubmitParams): Promise<void> {
+  static async submit(params: TCopyrightSubmitParams): Promise<void> {
     // Validate and normalize inputs using pipes layer
     const nameOwner = CopyrightValidators.validateNameOwner(params.nameOwner);
     const originalContentUrls = CopyrightValidators.validateOriginalContentUrls(params.originalContentUrls);

--- a/src/core/controllers/feed/feed.test.ts
+++ b/src/core/controllers/feed/feed.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PubkyAppFeedLayout, PubkyAppFeedReach, PubkyAppFeedSort } from 'pubky-app-specs';
 import type { TFeedCreateParams, TFeedUpdateParams, TFeedIdParam } from './feed.types';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { FeedApplication } from '@/application/feed/feed';
 import type { FeedModelSchema } from '@/models/feed/feed.schema';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/controllers/feedback/feedback.test.ts
+++ b/src/core/controllers/feedback/feedback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as Config from '@/config';
 import type { TFeedbackSubmitParams } from './feedback.types';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { FeedbackApplication } from '@/application/feedback/feedback';
 import type { Pubky } from '@/models/models.types';
 const testData = {

--- a/src/core/controllers/feedback/feedback.test.ts
+++ b/src/core/controllers/feedback/feedback.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as Config from '@/config';
+import { FEEDBACK_MAX_CHARACTER_LENGTH } from '@/config/posts';
 import type { TFeedbackSubmitParams } from './feedback.types';
 import { asInvalid } from '@/test-utils/type-assertions';
 import { FeedbackApplication } from '@/application/feedback/feedback';
@@ -101,7 +101,7 @@ describe('FeedbackController', () => {
     });
 
     it('should accept comment at max length', async () => {
-      const maxLengthComment = 'a'.repeat(Config.FEEDBACK_MAX_CHARACTER_LENGTH);
+      const maxLengthComment = 'a'.repeat(FEEDBACK_MAX_CHARACTER_LENGTH);
       const params = createFeedbackParams({ comment: maxLengthComment });
       const submitSpy = vi.spyOn(FeedbackApplication, 'submit');
 
@@ -115,11 +115,11 @@ describe('FeedbackController', () => {
     });
 
     it('should throw when comment exceeds max length', async () => {
-      const longComment = 'a'.repeat(Config.FEEDBACK_MAX_CHARACTER_LENGTH + 1);
+      const longComment = 'a'.repeat(FEEDBACK_MAX_CHARACTER_LENGTH + 1);
       const params = createFeedbackParams({ comment: longComment });
 
       await expect(FeedbackController.submit(params)).rejects.toThrow(
-        `Comment must be no more than ${Config.FEEDBACK_MAX_CHARACTER_LENGTH} characters`,
+        `Comment must be no more than ${FEEDBACK_MAX_CHARACTER_LENGTH} characters`,
       );
     });
   });

--- a/src/core/controllers/feedback/feedback.ts
+++ b/src/core/controllers/feedback/feedback.ts
@@ -1,4 +1,4 @@
-import * as Types from './feedback.types';
+import type { TFeedbackSubmitParams } from './feedback.types';
 import { FeedbackApplication } from '@/application/feedback/feedback';
 import { FeedbackValidators } from '@/pipes/feedback/feedback.validators';
 /**
@@ -18,7 +18,7 @@ export class FeedbackController {
    * @param params.name - User's display name
    * @throws AppError if validation fails or submission fails
    */
-  static async submit(params: Types.TFeedbackSubmitParams): Promise<void> {
+  static async submit(params: TFeedbackSubmitParams): Promise<void> {
     // Validate and normalize inputs using pipes layer
     const pubky = FeedbackValidators.validatePubky(params.pubky);
     const comment = FeedbackValidators.validateComment(params.comment);

--- a/src/core/controllers/migration/migration.test.ts
+++ b/src/core/controllers/migration/migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MigrationController } from './migration';
-import { mockSettingsStore } from '@/test-utils';
+import { mockSettingsStore } from '@/test-utils/stores';
 import { MigrationApplication } from '@/application/migration/migration';
 import type { Pubky } from '@/models/models.types';
 import { SettingsNormalizer } from '@/pipes/settings/settings.normalizer';

--- a/src/core/controllers/mute/mute.test.ts
+++ b/src/core/controllers/mute/mute.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MuteResult } from 'pubky-app-specs';
 import { MuteController } from './mute';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { MuteApplication } from '@/application/mute/mute';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/controllers/notification/notification.test.ts
+++ b/src/core/controllers/notification/notification.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NotificationController } from './notification';
 import * as Config from '@/config';
-import { mockAuthStore, mockNotificationStore, asOpaque } from '@/test-utils';
+import { mockAuthStore, mockNotificationStore } from '@/test-utils/stores';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { NotificationApplication } from '@/application/notification/notification';
 import type { TGetOrFetchNotificationsResponse } from '@/application/notification/notification.types';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/controllers/notification/notification.test.ts
+++ b/src/core/controllers/notification/notification.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NotificationController } from './notification';
-import * as Config from '@/config';
+import { NEXUS_NOTIFICATIONS_LIMIT } from '@/config/nexus';
 import { mockAuthStore, mockNotificationStore } from '@/test-utils/stores';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { NotificationApplication } from '@/application/notification/notification';
@@ -173,8 +173,8 @@ describe('NotificationController', () => {
     beforeEach(() => setupAuthStore());
 
     it.each([
-      { params: {}, expectedOlderThan: Infinity, expectedLimit: Config.NEXUS_NOTIFICATIONS_LIMIT },
-      { params: { olderThan: 5000 }, expectedOlderThan: 5000, expectedLimit: Config.NEXUS_NOTIFICATIONS_LIMIT },
+      { params: {}, expectedOlderThan: Infinity, expectedLimit: NEXUS_NOTIFICATIONS_LIMIT },
+      { params: { olderThan: 5000 }, expectedOlderThan: 5000, expectedLimit: NEXUS_NOTIFICATIONS_LIMIT },
       { params: { limit: 50 }, expectedOlderThan: Infinity, expectedLimit: 50 },
       { params: { olderThan: 8000, limit: 20 }, expectedOlderThan: 8000, expectedLimit: 20 },
     ])('should call application with params: $params', async ({ params, expectedOlderThan, expectedLimit }) => {

--- a/src/core/controllers/notification/notification.ts
+++ b/src/core/controllers/notification/notification.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { NEXUS_NOTIFICATIONS_LIMIT } from '@/config/nexus';
 import { NotificationApplication } from '@/application/notification/notification';
 import type { TGetOrFetchNotificationsResponse } from '@/application/notification/notification.types';
 import type { TGetNotificationsParams } from '@/controllers/notification/notification.types';
@@ -73,7 +73,7 @@ export class NotificationController {
    */
   static async getOrFetchNotifications({
     olderThan = Infinity,
-    limit = Config.NEXUS_NOTIFICATIONS_LIMIT,
+    limit = NEXUS_NOTIFICATIONS_LIMIT,
   }: TGetNotificationsParams): Promise<TGetOrFetchNotificationsResponse> {
     const userId = useAuthStore.getState().selectCurrentUserPubky();
 

--- a/src/core/controllers/post/post.test.ts
+++ b/src/core/controllers/post/post.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mockSession } from '@/test-utils';
+import { mockSession } from '@/test-utils/pubky';
 import { HttpMethod } from '@/libs/http/http.types';
 import { FileApplication } from '@/application/file/file';
 import { PostApplication } from '@/application/post/post';

--- a/src/core/controllers/profile/profile.test.ts
+++ b/src/core/controllers/profile/profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UserResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import type { Pubky } from '@/models/models.types';
 const mockProfileApplication = {
   commitCreate: vi.fn(),

--- a/src/core/controllers/report/report.test.ts
+++ b/src/core/controllers/report/report.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TReportSubmitParams } from './report.types';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { ReportApplication } from '@/application/report/report';
 import type { Pubky } from '@/models/models.types';
 import {

--- a/src/core/controllers/report/report.ts
+++ b/src/core/controllers/report/report.ts
@@ -1,4 +1,4 @@
-import * as Types from './report.types';
+import type { TReportSubmitParams } from './report.types';
 import { ReportApplication } from '@/application/report/report';
 import { ReportValidators } from '@/pipes/report/report.validators';
 /**
@@ -20,7 +20,7 @@ export class ReportController {
    * @param params.name - Reporter's display name
    * @throws AppError if validation fails or submission fails
    */
-  static async submit(params: Types.TReportSubmitParams): Promise<void> {
+  static async submit(params: TReportSubmitParams): Promise<void> {
     // Validate and normalize inputs using pipes layer
     const pubky = ReportValidators.validatePubky(params.pubky);
     const postUrl = ReportValidators.validatePostUrl(params.postUrl);

--- a/src/core/controllers/settings/settings.test.ts
+++ b/src/core/controllers/settings/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SettingsController } from './settings';
-import * as i18nUtils from '@/i18n/utils';
+import { setLocaleCookie } from '@/i18n/utils';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { mockAuthStore, mockSettingsStore } from '@/test-utils/stores';
 import { SettingsApplication } from '@/application/settings/settings';
@@ -13,7 +13,13 @@ import {
   defaultPrivacyPreferences,
   type SettingsState,
 } from '@/stores/settings/settings.types';
+
+vi.mock('@/i18n/utils', () => ({
+  setLocaleCookie: vi.fn(),
+}));
+
 const TEST_PUBKY = 'o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo' as Pubky;
+const mockSetLocaleCookie = vi.mocked(setLocaleCookie);
 
 const mockStoreActions = {
   setNotificationPreference: vi.fn(),
@@ -51,10 +57,10 @@ const mockSettingsState: SettingsState = {
 describe('SettingsController', () => {
   let commitUpdateSpy: ReturnType<typeof vi.spyOn>;
   let extractStateSpy: ReturnType<typeof vi.spyOn>;
-  let setLocaleCookieSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSetLocaleCookie.mockImplementation(() => {});
 
     // Reset pendingCommit between tests to avoid chaining across tests
     // pendingCommit is private; an opaque cast is needed to reset static state between tests
@@ -66,7 +72,6 @@ describe('SettingsController', () => {
 
     extractStateSpy = vi.spyOn(SettingsNormalizer, 'extractState').mockReturnValue(mockSettingsState);
     commitUpdateSpy = vi.spyOn(SettingsApplication, 'commitUpdate').mockResolvedValue(undefined);
-    setLocaleCookieSpy = vi.spyOn(i18nUtils, 'setLocaleCookie').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -106,7 +111,7 @@ describe('SettingsController', () => {
       await SettingsController.setLanguage('es');
 
       expect(mockStoreActions.setLanguage).toHaveBeenCalledWith('es');
-      expect(setLocaleCookieSpy).toHaveBeenCalledWith('es');
+      expect(mockSetLocaleCookie).toHaveBeenCalledWith('es');
       expect(commitUpdateSpy).toHaveBeenCalledWith(mockSettingsState, TEST_PUBKY);
     });
   });

--- a/src/core/controllers/settings/settings.test.ts
+++ b/src/core/controllers/settings/settings.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SettingsController } from './settings';
 import * as i18nUtils from '@/i18n/utils';
-import { asOpaque, mockAuthStore, mockSettingsStore } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockAuthStore, mockSettingsStore } from '@/test-utils/stores';
 import { SettingsApplication } from '@/application/settings/settings';
 import type { Pubky } from '@/models/models.types';
 import { SettingsNormalizer } from '@/pipes/settings/settings.normalizer';

--- a/src/core/controllers/stream/posts/post.test.ts
+++ b/src/core/controllers/stream/posts/post.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import * as Config from '@/config';
+import { NEXUS_POSTS_PER_PAGE } from '@/config/nexus';
 import { StreamPostsController } from './posts';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import type { Pubky } from '@/models/models.types';
@@ -40,7 +40,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -75,7 +75,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -135,7 +135,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         lastPostId,
         streamTail,
@@ -160,7 +160,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -230,7 +230,7 @@ describe('StreamPostsController', () => {
       // Should call with null viewerId (unauthenticated users can still view posts)
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -263,7 +263,7 @@ describe('StreamPostsController', () => {
       // Verify getOrFetchStreamSlice was called (error happened during execution)
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -326,7 +326,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         lastPostId,
         streamTail,
@@ -355,7 +355,7 @@ describe('StreamPostsController', () => {
       // This test verifies the method accepts it without error
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -381,7 +381,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId: engagementStreamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -553,7 +553,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,
@@ -578,7 +578,7 @@ describe('StreamPostsController', () => {
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
-        limit: Config.NEXUS_POSTS_PER_PAGE,
+        limit: NEXUS_POSTS_PER_PAGE,
         streamHead: 0,
         streamTail: 0,
         lastPostId: undefined,

--- a/src/core/controllers/stream/posts/posts.ts
+++ b/src/core/controllers/stream/posts/posts.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { NEXUS_POSTS_PER_PAGE } from '@/config/nexus';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { NOT_FOUND_CACHED_STREAM, SKIP_FETCH_NEW_POSTS } from '@/controllers/stream/posts/post.constants';
 import type {
@@ -31,7 +31,7 @@ export class StreamPostsController {
    * @param params.streamHead - Identifier of the newest post in the current page for pagination.
    * @param params.streamTail - Identifier of the last post in the current page for pagination. timestamp (timeline mode) or skip (engagement mode)
    * @param params.lastPostId - Post ID of the last post in the current page. We use to get the chunk of the stream from the cache.
-   * @param params.limit - Limit of posts to fetch. Default is Config.NEXUS_POSTS_PER_PAGE.
+   * @param params.limit - Limit of posts to fetch. Default is NEXUS_POSTS_PER_PAGE.
    *
    * @returns Promise resolving to stream slice response containing:
    * - nextPageIds: Array of post IDs for the current page
@@ -55,7 +55,7 @@ export class StreamPostsController {
     streamHead = SKIP_FETCH_NEW_POSTS,
     streamTail = NOT_FOUND_CACHED_STREAM,
     lastPostId,
-    limit = Config.NEXUS_POSTS_PER_PAGE,
+    limit = NEXUS_POSTS_PER_PAGE,
     order,
   }: TReadPostStreamChunkParams): Promise<TReadPostStreamChunkResponse> {
     // selectCurrentUserPubky() throws an error when user is not authenticated;

--- a/src/core/controllers/stream/users/users.test.ts
+++ b/src/core/controllers/stream/users/users.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import * as Config from '@/config';
+import { NEXUS_USERS_PER_PAGE } from '@/config/nexus';
 import { StreamUserController } from './users';
 import { UserStreamApplication } from '@/application/stream/users/users';
 import type { Pubky } from '@/models/models.types';
@@ -35,14 +35,14 @@ describe('StreamUserController', () => {
 
       const result = await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip: 0,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId,
       });
       expect(fetchMissingUsersSpy).not.toHaveBeenCalled();
@@ -67,14 +67,14 @@ describe('StreamUserController', () => {
 
       const result = await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip: 0,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId,
       });
       expect(fetchMissingUsersSpy).toHaveBeenCalledWith({
@@ -99,14 +99,14 @@ describe('StreamUserController', () => {
 
       await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId,
       });
     });
@@ -129,19 +129,19 @@ describe('StreamUserController', () => {
 
       await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip: 0,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId: customViewerId,
       });
     });
 
-    it('should use Config.NEXUS_USERS_PER_PAGE as limit', async () => {
+    it('should use NEXUS_USERS_PER_PAGE as limit', async () => {
       const streamId = buildUserCompositeId({ userId: targetUserId, reach: 'followers' });
 
       const getOrFetchStreamSliceSpy = vi.spyOn(UserStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
@@ -152,14 +152,14 @@ describe('StreamUserController', () => {
 
       await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip: 0,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId,
       });
     });
@@ -177,7 +177,7 @@ describe('StreamUserController', () => {
 
       await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
@@ -195,7 +195,7 @@ describe('StreamUserController', () => {
 
       const result = await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
@@ -213,14 +213,14 @@ describe('StreamUserController', () => {
 
       await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 
       expect(getOrFetchStreamSliceSpy).toHaveBeenCalledWith({
         streamId,
         skip: 0,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         viewerId,
       });
     });
@@ -240,7 +240,7 @@ describe('StreamUserController', () => {
 
       const result = await StreamUserController.getOrFetchStreamSlice({
         streamId,
-        limit: Config.NEXUS_USERS_PER_PAGE,
+        limit: NEXUS_USERS_PER_PAGE,
         skip: 0,
       });
 

--- a/src/core/controllers/stream/users/users.ts
+++ b/src/core/controllers/stream/users/users.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { NEXUS_USERS_PER_PAGE } from '@/config/nexus';
 import { UserStreamApplication } from '@/application/stream/users/users';
 import type {
   TGetOrFetchUsersParams,
@@ -26,7 +26,7 @@ export class StreamUserController {
    */
   static async getOrFetchStreamSlice({
     streamId,
-    limit = Config.NEXUS_USERS_PER_PAGE,
+    limit = NEXUS_USERS_PER_PAGE,
     skip,
   }: TReadUserStreamChunkParams): Promise<TReadUserStreamChunkResponse> {
     // selectCurrentUserPubky() throws an error when user is not authenticated;

--- a/src/core/controllers/tag/tag.test.ts
+++ b/src/core/controllers/tag/tag.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TagResult } from 'pubky-app-specs';
 import type { TTagEventParams } from './tag.types';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import { TagKind } from '@/application/tag/tag.types';
 import { db } from '@/database/franky/franky';

--- a/src/core/controllers/user/user.test.ts
+++ b/src/core/controllers/user/user.test.ts
@@ -3,8 +3,6 @@ import { FollowResult } from 'pubky-app-specs';
 import { UserController } from './user';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
-import * as useHomeStoreModule from '@/stores/home/home.store';
-import * as getStreamIdModule from '@/stores/home/home.utils';
 import { UserApplication } from '@/application/user/user';
 import type { Pubky } from '@/models/models.types';
 import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
@@ -12,6 +10,39 @@ import type { UserCountsModel } from '@/models/user/counts/userCounts';
 import { FollowNormalizer } from '@/pipes/follow/follow.normalizer';
 import type { NexusTag, NexusTaggers, NexusUserCounts, NexusUserDetails } from '@/services/nexus/nexus.types';
 import { useHomeStore } from '@/stores/home/home.store';
+import { CONTENT, REACH, SORT } from '@/stores/home/home.types';
+import { getStreamId } from '@/stores/home/home.utils';
+
+vi.mock('@/stores/home/home.store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/stores/home/home.store')>();
+  const useHomeStoreMock = Object.assign(vi.fn(), {
+    getState: vi.fn(),
+  });
+  return {
+    ...actual,
+    useHomeStore: useHomeStoreMock,
+  };
+});
+
+vi.mock('@/stores/home/home.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/stores/home/home.utils')>();
+  return {
+    ...actual,
+    getStreamId: vi.fn(),
+  };
+});
+
+const mockUseHomeStore = vi.mocked(useHomeStore);
+const mockUseHomeStoreGetState = vi.mocked(useHomeStore.getState);
+const mockGetStreamId = vi.mocked(getStreamId);
+
+const createMockHomeState = () =>
+  asOpaque<ReturnType<typeof useHomeStore.getState>>({
+    sort: SORT.TIMELINE,
+    reach: REACH.ALL,
+    content: CONTENT.ALL,
+  });
+
 // Valid 52-character z-base32 encoded pubky IDs for testing
 const TEST_PUBKY = {
   USER_1: '5a1diz4pghi47ywdfyfzpit5f3bdomzt4pugpbmq4rngdd4iub4y' as Pubky,
@@ -21,6 +52,9 @@ const TEST_PUBKY = {
 describe('UserController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseHomeStore.mockReset();
+    mockUseHomeStoreGetState.mockReset();
+    mockGetStreamId.mockReset();
   });
 
   afterEach(() => {
@@ -370,11 +404,7 @@ describe('UserController', () => {
       );
 
       // Mock useHomeStore to return null for activeStreamId (not on /home route)
-      vi.spyOn(useHomeStoreModule, 'useHomeStore').mockReturnValue(
-        asOpaque<typeof useHomeStore>({
-          getState: () => ({ sort: 'all', reach: 'all', content: 'all' }),
-        }),
-      );
+      mockUseHomeStoreGetState.mockReturnValue(createMockHomeState());
       const followSpy = vi.spyOn(UserApplication, 'commitFollow').mockResolvedValue(undefined);
 
       await UserController.commitFollow(HttpMethod.PUT, { follower, followee });
@@ -407,11 +437,7 @@ describe('UserController', () => {
       );
 
       // Mock useHomeStore to return null for activeStreamId (not on /home route)
-      vi.spyOn(useHomeStoreModule, 'useHomeStore').mockReturnValue(
-        asOpaque<typeof useHomeStore>({
-          getState: () => ({ sort: 'all', reach: 'all', content: 'all' }),
-        }),
-      );
+      mockUseHomeStoreGetState.mockReturnValue(createMockHomeState());
       const followSpy = vi.spyOn(UserApplication, 'commitFollow').mockResolvedValue(undefined);
 
       await UserController.commitFollow(HttpMethod.DELETE, { follower, followee });
@@ -454,11 +480,7 @@ describe('UserController', () => {
       );
 
       // Mock useHomeStore to return null for activeStreamId (not on /home route)
-      vi.spyOn(useHomeStoreModule, 'useHomeStore').mockReturnValue(
-        asOpaque<typeof useHomeStore>({
-          getState: () => ({ sort: 'all', reach: 'all', content: 'all' }),
-        }),
-      );
+      mockUseHomeStoreGetState.mockReturnValue(createMockHomeState());
       vi.spyOn(UserApplication, 'commitFollow').mockRejectedValue(new Error('delegate-fail'));
 
       await expect(UserController.commitFollow(HttpMethod.PUT, { follower, followee })).rejects.toThrow(
@@ -488,12 +510,8 @@ describe('UserController', () => {
         writable: true,
       });
       // Mock useHomeStore and getStreamId to return the mock stream ID
-      vi.spyOn(useHomeStoreModule, 'useHomeStore').mockReturnValue(
-        asOpaque<typeof useHomeStore>({
-          getState: () => ({ sort: 'all', reach: 'all', content: 'all' }),
-        }),
-      );
-      vi.spyOn(getStreamIdModule, 'getStreamId').mockReturnValue(mockStreamId);
+      mockUseHomeStoreGetState.mockReturnValue(createMockHomeState());
+      mockGetStreamId.mockReturnValue(mockStreamId);
       const followSpy = vi.spyOn(UserApplication, 'commitFollow').mockResolvedValue(undefined);
 
       await UserController.commitFollow(HttpMethod.PUT, { follower, followee });

--- a/src/core/controllers/user/user.test.ts
+++ b/src/core/controllers/user/user.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FollowResult } from 'pubky-app-specs';
 import { UserController } from './user';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { HttpMethod } from '@/libs/http/http.types';
 import * as useHomeStoreModule from '@/stores/home/home.store';
 import * as getStreamIdModule from '@/stores/home/home.utils';

--- a/src/core/coordinators/notifications/notifications.test.ts
+++ b/src/core/coordinators/notifications/notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { APP_ROUTES, AUTH_ROUTES, ONBOARDING_ROUTES, PROFILE_ROUTES } from '@/app';
-import { asInvalid, asOpaque, mockSession } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
+import { mockSession } from '@/test-utils/pubky';
 import { NotificationController } from '@/controllers/notification/notification';
 import type { PollingServiceConfig } from '@/coordinators/base/coordinators.types';
 import { NotificationCoordinator } from '@/coordinators/notifications/notifications';

--- a/src/core/coordinators/streams/stream.test.ts
+++ b/src/core/coordinators/streams/stream.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { APP_ROUTES, POST_ROUTES } from '@/app/routes';
 import { PubkyAppFeedReach, PubkyAppFeedSort, PubkyAppFeedLayout } from 'pubky-app-specs';
-import { mockHomeStore, mockSession } from '@/test-utils';
+import { mockHomeStore } from '@/test-utils/stores';
+import { mockSession } from '@/test-utils/pubky';
 import { FeedController } from '@/controllers/feed/feed';
 import { SKIP_FETCH_NEW_POSTS } from '@/controllers/stream/posts/post.constants';
 import { StreamPostsController } from '@/controllers/stream/posts/posts';

--- a/src/core/coordinators/ttl/ttl.test.ts
+++ b/src/core/coordinators/ttl/ttl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mockSession } from '@/test-utils';
+import { mockSession } from '@/test-utils/pubky';
 import { TtlController } from '@/controllers/ttl/ttl';
 import { TtlCoordinator } from '@/coordinators/ttl/ttl';
 import type { Pubky } from '@/models/models.types';

--- a/src/core/database/franky/franky.helpers.ts
+++ b/src/core/database/franky/franky.helpers.ts
@@ -1,4 +1,4 @@
-import { DB_NAME } from '@/config';
+import { DB_NAME } from '@/config/database';
 import { db } from '@/database/franky/franky';
 export async function clearDatabase(): Promise<void> {
   if (!db.isOpen()) {

--- a/src/core/database/franky/franky.test.ts
+++ b/src/core/database/franky/franky.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { indexedDB } from 'fake-indexeddb';
-import { DB_NAME, DB_VERSION } from '@/config';
+import { DB_NAME, DB_VERSION } from '@/config/database';
 import { Logger } from '@/libs/logger/logger';
 import { AppDatabase } from '@/database/franky/franky';
 const waitForDatabaseDeletion = async (name: string, onBlocked?: () => void) => {

--- a/src/core/database/franky/franky.ts
+++ b/src/core/database/franky/franky.ts
@@ -1,5 +1,5 @@
 import Dexie from 'dexie';
-import * as Config from '@/config';
+import { DB_NAME, DB_VERSION } from '@/config/database';
 
 import { Logger } from '@/libs/logger/logger';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
@@ -68,11 +68,11 @@ export class AppDatabase extends Dexie {
   // Moderation
   moderation!: Dexie.Table<ModerationModelSchema>;
 
-  constructor(databaseName: string = Config.DB_NAME) {
+  constructor(databaseName: string = DB_NAME) {
     super(databaseName);
 
     try {
-      this.version(Config.DB_VERSION).stores({
+      this.version(DB_VERSION).stores({
         // User related tables
         user_counts: userCountsTableSchema,
         user_details: userDetailsTableSchema,
@@ -189,7 +189,7 @@ export class AppDatabase extends Dexie {
         context: {
           currentVersion,
           rawVersion,
-          expectedVersion: Config.DB_VERSION,
+          expectedVersion: DB_VERSION,
           databaseName: this.name,
         },
         cause: error,
@@ -197,7 +197,7 @@ export class AppDatabase extends Dexie {
     }
 
     try {
-      // Note: expected new DB version is already set in the constructor this.version(Config.DB_VERSION)
+      // Note: expected new DB version is already set in the constructor this.version(DB_VERSION)
       await this.open();
       Logger.info('Database recreated with new schema');
     } catch (error) {
@@ -205,7 +205,7 @@ export class AppDatabase extends Dexie {
         service: ErrorService.Local,
         operation: 'recreateDatabase',
         context: {
-          version: Config.DB_VERSION,
+          version: DB_VERSION,
           rawVersion,
           databaseName: this.name,
         },
@@ -251,12 +251,12 @@ export class AppDatabase extends Dexie {
         return { wasDbReset };
       }
 
-      if (currentVersion !== Config.DB_VERSION) {
-        Logger.info(`Database version mismatch. Current: ${currentVersion}, Expected: ${Config.DB_VERSION}`, {
+      if (currentVersion !== DB_VERSION) {
+        Logger.info(`Database version mismatch. Current: ${currentVersion}, Expected: ${DB_VERSION}`, {
           rawVersion,
           normalizedVersion: currentVersion,
-          expectedVersion: Config.DB_VERSION,
-          expectedInternalVersion: Config.DB_VERSION * AppDatabase.DEXIE_VERSION_MULTIPLIER,
+          expectedVersion: DB_VERSION,
+          expectedInternalVersion: DB_VERSION * AppDatabase.DEXIE_VERSION_MULTIPLIER,
         });
         await this.recreateDatabase(currentVersion, rawVersion);
         wasDbReset = true;

--- a/src/core/models/models.utils.ts
+++ b/src/core/models/models.utils.ts
@@ -1,5 +1,5 @@
-import * as Types from './models.types';
-import * as Defaults from './models.defaults';
+import { COMPOSITE_ID_DELIMITER } from './models.defaults';
+import type { CompositeIdParams, CompositeIdResult } from './models.types';
 import type { Pubky } from '@/models/models.types';
 /**
  * Parses a pubky:// URI to extract the author and ID,
@@ -13,7 +13,7 @@ import type { Pubky } from '@/models/models.types';
  * buildCompositeIdFromUri("pubky://author123/pub/pubky.app/files/file456")
  * // Returns: "author123:file456"
  */
-export function buildCompositeIdFromPubkyUri({ uri, domain }: Types.CompositeIdParams): string | null {
+export function buildCompositeIdFromPubkyUri({ uri, domain }: CompositeIdParams): string | null {
   try {
     const parsed = new URL(uri);
     const pubky = parsed.hostname;
@@ -31,12 +31,12 @@ export function buildCompositeIdFromPubkyUri({ uri, domain }: Types.CompositeIdP
   }
 }
 
-export function buildCompositeId({ pubky, id }: Types.CompositeIdResult): string {
-  return `${pubky}${Defaults.COMPOSITE_ID_DELIMITER}${id}`;
+export function buildCompositeId({ pubky, id }: CompositeIdResult): string {
+  return `${pubky}${COMPOSITE_ID_DELIMITER}${id}`;
 }
 
-export function parseCompositeId(compositeId: string): Types.CompositeIdResult {
-  const sep = compositeId.indexOf(Defaults.COMPOSITE_ID_DELIMITER);
+export function parseCompositeId(compositeId: string): CompositeIdResult {
+  const sep = compositeId.indexOf(COMPOSITE_ID_DELIMITER);
   if (sep <= 0 || sep === compositeId.length - 1) {
     throw new Error(`Invalid composite id: ${compositeId}`);
   }

--- a/src/core/models/notification/notification.ts
+++ b/src/core/models/notification/notification.ts
@@ -1,5 +1,5 @@
 import { Table } from 'dexie';
-import * as Config from '@/config';
+import { NEXUS_NOTIFICATIONS_LIMIT } from '@/config/nexus';
 import { FlatNotification, NotificationType } from './notification.types';
 import { Logger } from '@/libs/logger/logger';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
@@ -83,7 +83,7 @@ export class NotificationModel {
     }
   }
 
-  static async getRecent(limit: number = Config.NEXUS_NOTIFICATIONS_LIMIT): Promise<FlatNotification[]> {
+  static async getRecent(limit: number = NEXUS_NOTIFICATIONS_LIMIT): Promise<FlatNotification[]> {
     try {
       return await this.table.orderBy('timestamp').reverse().limit(limit).toArray();
     } catch (error) {
@@ -119,7 +119,7 @@ export class NotificationModel {
 
   static async getRecentByType(
     type: NotificationType,
-    limit: number = Config.NEXUS_NOTIFICATIONS_LIMIT,
+    limit: number = NEXUS_NOTIFICATIONS_LIMIT,
   ): Promise<FlatNotification[]> {
     try {
       return await this.table
@@ -171,10 +171,7 @@ export class NotificationModel {
    * @param limit - Maximum number of notifications to return
    * @returns Promise resolving to array of notifications ordered by timestamp descending
    */
-  static async getOlderThan(
-    olderThan: number,
-    limit: number = Config.NEXUS_NOTIFICATIONS_LIMIT,
-  ): Promise<FlatNotification[]> {
+  static async getOlderThan(olderThan: number, limit: number = NEXUS_NOTIFICATIONS_LIMIT): Promise<FlatNotification[]> {
     try {
       return await this.table.where('timestamp').below(olderThan).reverse().limit(limit).toArray();
     } catch (error) {

--- a/src/core/pipes/bookmark/bookmark.normalizer.test.ts
+++ b/src/core/pipes/bookmark/bookmark.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BookmarkResult, postUriBuilder } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   TEST_POST_IDS,

--- a/src/core/pipes/copyright/copyright.validators.test.ts
+++ b/src/core/pipes/copyright/copyright.validators.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CopyrightValidators } from './copyright.validators';
-import * as Config from '@/config';
+import { VALIDATION_MESSAGES } from '@/config/forms';
 import { AppError } from '@/libs/error/error';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
@@ -164,7 +164,7 @@ describe('CopyrightValidators', () => {
         const appError = error as AppError;
         expect(appError.code).toBe(ValidationErrorCode.FORMAT_ERROR);
         expect(appError.service).toBe(ErrorService.NextJsServer);
-        expect(appError.message).toBe(Config.VALIDATION_MESSAGES.INVALID_EMAIL);
+        expect(appError.message).toBe(VALIDATION_MESSAGES.INVALID_EMAIL);
       }
     });
   });
@@ -186,7 +186,7 @@ describe('CopyrightValidators', () => {
         const appError = error as AppError;
         expect(appError.code).toBe(ValidationErrorCode.FORMAT_ERROR);
         expect(appError.service).toBe(ErrorService.NextJsServer);
-        expect(appError.message).toBe(Config.VALIDATION_MESSAGES.INVALID_PHONE);
+        expect(appError.message).toBe(VALIDATION_MESSAGES.INVALID_PHONE);
       }
     });
   });
@@ -208,7 +208,7 @@ describe('CopyrightValidators', () => {
         const appError = error as AppError;
         expect(appError.code).toBe(ValidationErrorCode.MISSING_FIELD);
         expect(appError.service).toBe(ErrorService.NextJsServer);
-        expect(appError.message).toBe(Config.VALIDATION_MESSAGES.ROLE_REQUIRED);
+        expect(appError.message).toBe(VALIDATION_MESSAGES.ROLE_REQUIRED);
       }
     });
   });

--- a/src/core/pipes/copyright/copyright.validators.ts
+++ b/src/core/pipes/copyright/copyright.validators.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { VALIDATION_MESSAGES, VALIDATION_PATTERNS } from '@/config/forms';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
@@ -20,8 +20,8 @@ export class CopyrightValidators {
    * @throws AppError if email is invalid
    */
   private static validateEmailFormat(email: string): string {
-    if (!Config.VALIDATION_PATTERNS.EMAIL.test(email)) {
-      throw Err.validation(ValidationErrorCode.FORMAT_ERROR, Config.VALIDATION_MESSAGES.INVALID_EMAIL, {
+    if (!VALIDATION_PATTERNS.EMAIL.test(email)) {
+      throw Err.validation(ValidationErrorCode.FORMAT_ERROR, VALIDATION_MESSAGES.INVALID_EMAIL, {
         service: ErrorService.NextJsServer,
         operation: 'validateEmailFormat',
         context: { field: 'email', value: email },
@@ -62,8 +62,8 @@ export class CopyrightValidators {
    * @throws AppError if phone number is invalid
    */
   private static validatePhoneNumberFormat(phoneNumber: string): string {
-    if (!Config.VALIDATION_PATTERNS.PHONE.test(phoneNumber)) {
-      throw Err.validation(ValidationErrorCode.FORMAT_ERROR, Config.VALIDATION_MESSAGES.INVALID_PHONE, {
+    if (!VALIDATION_PATTERNS.PHONE.test(phoneNumber)) {
+      throw Err.validation(ValidationErrorCode.FORMAT_ERROR, VALIDATION_MESSAGES.INVALID_PHONE, {
         service: ErrorService.NextJsServer,
         operation: 'validatePhoneNumberFormat',
         context: { field: 'phoneNumber', value: phoneNumber },
@@ -206,7 +206,7 @@ export class CopyrightValidators {
     isReportingOnBehalf: boolean | undefined | null,
   ): void {
     if (!isRightsOwner && !isReportingOnBehalf) {
-      throw Err.validation(ValidationErrorCode.MISSING_FIELD, Config.VALIDATION_MESSAGES.ROLE_REQUIRED, {
+      throw Err.validation(ValidationErrorCode.MISSING_FIELD, VALIDATION_MESSAGES.ROLE_REQUIRED, {
         service: ErrorService.NextJsServer,
         operation: 'validateRole',
         context: { field: 'role', isRightsOwner, isReportingOnBehalf },

--- a/src/core/pipes/feed/feed.normalizer.test.ts
+++ b/src/core/pipes/feed/feed.normalizer.test.ts
@@ -7,7 +7,7 @@ import {
   FeedResult,
   PubkySpecsBuilder,
 } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { AppError } from '@/libs/error/error';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/pipes/feedback/feedback.validators.test.ts
+++ b/src/core/pipes/feedback/feedback.validators.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { FeedbackValidators } from './feedback.validators';
-import { FEEDBACK_MAX_CHARACTER_LENGTH } from '@/config';
+import { FEEDBACK_MAX_CHARACTER_LENGTH } from '@/config/posts';
 import { AppError } from '@/libs/error/error';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/pipes/feedback/feedback.validators.ts
+++ b/src/core/pipes/feedback/feedback.validators.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { FEEDBACK_MAX_CHARACTER_LENGTH } from '@/config/posts';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
@@ -42,14 +42,14 @@ export class FeedbackValidators {
       });
     }
 
-    if (comment.length > Config.FEEDBACK_MAX_CHARACTER_LENGTH) {
+    if (comment.length > FEEDBACK_MAX_CHARACTER_LENGTH) {
       throw Err.validation(
         ValidationErrorCode.INVALID_INPUT,
-        `Comment must be no more than ${Config.FEEDBACK_MAX_CHARACTER_LENGTH} characters`,
+        `Comment must be no more than ${FEEDBACK_MAX_CHARACTER_LENGTH} characters`,
         {
           service: ErrorService.NextJsServer,
           operation: 'validateComment',
-          context: { field: 'comment', maxLength: Config.FEEDBACK_MAX_CHARACTER_LENGTH, actualLength: comment.length },
+          context: { field: 'comment', maxLength: FEEDBACK_MAX_CHARACTER_LENGTH, actualLength: comment.length },
         },
       );
     }

--- a/src/core/pipes/file/file.normalizer.test.ts
+++ b/src/core/pipes/file/file.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BlobResult, FileResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   setupUnitTestMocks,

--- a/src/core/pipes/follow/follow.normalizer.test.ts
+++ b/src/core/pipes/follow/follow.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FollowResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   INVALID_INPUTS,

--- a/src/core/pipes/lastRead/lastRead.normalizer.test.ts
+++ b/src/core/pipes/lastRead/lastRead.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LastReadResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   INVALID_INPUTS,

--- a/src/core/pipes/mute/mute.normalizer.test.ts
+++ b/src/core/pipes/mute/mute.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MuteResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   INVALID_INPUTS,

--- a/src/core/pipes/notification/notification.normalizer.test.ts
+++ b/src/core/pipes/notification/notification.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LastReadResult } from 'pubky-app-specs';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   INVALID_INPUTS,

--- a/src/core/pipes/post/post.normalizer.test.ts
+++ b/src/core/pipes/post/post.normalizer.test.ts
@@ -10,7 +10,6 @@ import {
   buildPubkyUri,
 } from '../pipes.test-utils';
 import { Logger } from '@/libs/logger/logger';
-import * as buildCompositeIdFromPubkyUriModule from '@/models/models.utils';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
@@ -19,6 +18,10 @@ import type { TFileAttachmentResult } from '@/pipes/file/file.types';
 import { PubkySpecsSingleton } from '@/pipes/pipes.builder';
 import type { PostValidatorData } from '@/pipes/pipes.types';
 import { PostNormalizer } from '@/pipes/post/post.normalizer';
+
+const spyOnBuildCompositeIdFromPubkyUri = async () =>
+  vi.spyOn(await import('@/models/models.utils'), 'buildCompositeIdFromPubkyUri');
+
 describe('PostNormalizer', () => {
   // Test data factories
   const createBasicPost = (overrides?: Partial<PostValidatorData>): PostValidatorData => ({
@@ -162,7 +165,7 @@ describe('PostNormalizer', () => {
         const embeddedPostId = `${TEST_PUBKY.USER_2}:embedded123`;
 
         it('should create embed object when embed post exists', async () => {
-          vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(embeddedPostId);
+          (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(embeddedPostId);
           vi.spyOn(PostDetailsModel, 'findById').mockResolvedValue(createMockPostDetails(embeddedPostId));
 
           const post = createBasicPost({ embed: embedUri });
@@ -178,7 +181,7 @@ describe('PostNormalizer', () => {
         });
 
         it('should pass null embed when URI is invalid', async () => {
-          vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(null);
+          (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(null);
 
           const post = createBasicPost({ embed: embedUri });
           await PostNormalizer.to(post, TEST_PUBKY.USER_1);
@@ -187,7 +190,7 @@ describe('PostNormalizer', () => {
         });
 
         it('should pass null embed when embedded post not found', async () => {
-          vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(embeddedPostId);
+          (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(embeddedPostId);
           vi.spyOn(PostDetailsModel, 'findById').mockResolvedValue(null);
 
           const post = createBasicPost({ embed: embedUri });
@@ -224,7 +227,7 @@ describe('PostNormalizer', () => {
           const embedUri = buildPubkyUri(TEST_PUBKY.USER_2, 'posts/embed');
           const embeddedPostId = `${TEST_PUBKY.USER_2}:embed`;
 
-          vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(embeddedPostId);
+          (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(embeddedPostId);
           vi.spyOn(PostDetailsModel, 'findById').mockResolvedValue(createMockPostDetails(embeddedPostId));
 
           const post = createBasicPost({
@@ -249,12 +252,10 @@ describe('PostNormalizer', () => {
         it.each([
           [
             'buildCompositeIdFromPubkyUri',
-            () =>
-              vi
-                .spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri')
-                .mockImplementation((_params) => {
-                  throw new Error('URI error');
-                }),
+            async () =>
+              (await spyOnBuildCompositeIdFromPubkyUri()).mockImplementation((_params) => {
+                throw new Error('URI error');
+              }),
           ],
           [
             'createPost',
@@ -264,14 +265,14 @@ describe('PostNormalizer', () => {
               }),
           ],
         ])('should propagate errors from %s', async (_, setupError) => {
-          setupError();
+          await setupError();
           const post = createBasicPost({ embed: 'pubky://embed' });
 
           await expect(PostNormalizer.to(post, TEST_PUBKY.USER_1)).rejects.toThrow();
         });
 
         it('should propagate errors from PostDetailsModel.findById', async () => {
-          vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue('valid-id');
+          (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue('valid-id');
           vi.spyOn(PostDetailsModel, 'findById').mockRejectedValue(new Error('Database error'));
 
           const post = createBasicPost({ embed: 'pubky://embed' });
@@ -559,7 +560,7 @@ describe('PostNormalizer', () => {
         vi.spyOn(PostRelationshipsModel, 'findById').mockResolvedValue(
           createMockPostRelationships({ reposted: repostedUri }),
         );
-        vi.spyOn(buildCompositeIdFromPubkyUriModule, 'buildCompositeIdFromPubkyUri').mockReturnValue(embeddedPostId);
+        (await spyOnBuildCompositeIdFromPubkyUri()).mockReturnValue(embeddedPostId);
 
         await PostNormalizer.toEdit({
           compositePostId,

--- a/src/core/pipes/post/post.normalizer.test.ts
+++ b/src/core/pipes/post/post.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PubkyAppPostKind, PostResult, PubkyAppPostEmbed, PubkyAppPost, type FileResult } from 'pubky-app-specs';
-import { asInvalid, asOpaque } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   TEST_POST_IDS,

--- a/src/core/pipes/settings/settings.normalizer.ts
+++ b/src/core/pipes/settings/settings.normalizer.ts
@@ -1,4 +1,4 @@
-import * as Specs from 'pubky-app-specs';
+import { baseUriBuilder } from 'pubky-app-specs';
 import { Logger } from '@/libs/logger/logger';
 import type { Pubky } from '@/models/models.types';
 import { defaultNotificationPreferences, defaultPrivacyPreferences } from '@/stores/settings/settings.types';
@@ -72,7 +72,7 @@ export class SettingsNormalizer {
    * URL format: pubky://{pubky}/pub/pubky.app/settings.json
    */
   static buildUrl(pubky: Pubky): string {
-    const baseUri = Specs.baseUriBuilder(pubky);
+    const baseUri = baseUriBuilder(pubky);
     return `${baseUri}settings.json`;
   }
 

--- a/src/core/pipes/tag/tag.normalizer.test.ts
+++ b/src/core/pipes/tag/tag.normalizer.test.ts
@@ -12,12 +12,14 @@ import {
 import { AppError } from '@/libs/error/error';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
-import * as parseCompositeIdModule from '@/models/models.utils';
 import { TagKind } from '@/application/tag/tag.types';
 import type { TTagEventParams } from '@/controllers/tag/tag.types';
 import { parseCompositeId } from '@/models/models.utils';
 import { PubkySpecsSingleton } from '@/pipes/pipes.builder';
 import { TagNormalizer } from '@/pipes/tag/tag.normalizer';
+
+const spyOnParseCompositeId = async () => vi.spyOn(await import('@/models/models.utils'), 'parseCompositeId');
+
 describe('TagNormalizer', () => {
   const createMockBuilder = (overrides?: Partial<{ createTag: ReturnType<typeof vi.fn> }>) => ({
     createTag: vi.fn((uri: string, label: string) =>
@@ -276,8 +278,8 @@ describe('TagNormalizer', () => {
       afterEach(restoreMocks);
 
       describe('POST tag creation', () => {
-        it('should parse composite ID and build post URI', () => {
-          vi.spyOn(parseCompositeIdModule, 'parseCompositeId').mockReturnValue({
+        it('should parse composite ID and build post URI', async () => {
+          (await spyOnParseCompositeId()).mockReturnValue({
             pubky: TEST_PUBKY.USER_2,
             id: TEST_POST_IDS.POST_1,
           });
@@ -298,8 +300,8 @@ describe('TagNormalizer', () => {
           );
         });
 
-        it('should return normalized response with lowercase label', () => {
-          vi.spyOn(parseCompositeIdModule, 'parseCompositeId').mockReturnValue({
+        it('should return normalized response with lowercase label', async () => {
+          (await spyOnParseCompositeId()).mockReturnValue({
             pubky: TEST_PUBKY.USER_2,
             id: TEST_POST_IDS.POST_1,
           });
@@ -355,8 +357,8 @@ describe('TagNormalizer', () => {
       });
 
       describe('error handling', () => {
-        it('should throw AppError with correct properties when parseCompositeId fails', () => {
-          vi.spyOn(parseCompositeIdModule, 'parseCompositeId').mockImplementation(() => {
+        it('should throw AppError with correct properties when parseCompositeId fails', async () => {
+          (await spyOnParseCompositeId()).mockImplementation(() => {
             throw 'Invalid composite ID';
           });
 
@@ -381,8 +383,8 @@ describe('TagNormalizer', () => {
           }
         });
 
-        it('should throw AppError when createTag fails', () => {
-          vi.spyOn(parseCompositeIdModule, 'parseCompositeId').mockReturnValue({
+        it('should throw AppError when createTag fails', async () => {
+          (await spyOnParseCompositeId()).mockReturnValue({
             pubky: TEST_PUBKY.USER_2,
             id: TEST_POST_IDS.POST_1,
           });

--- a/src/core/pipes/tag/tag.normalizer.test.ts
+++ b/src/core/pipes/tag/tag.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TagResult, postUriBuilder } from 'pubky-app-specs';
-import { asInvalid, asOpaque } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   TEST_POST_IDS,

--- a/src/core/pipes/user/user.normalizer.test.ts
+++ b/src/core/pipes/user/user.normalizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { UserResult } from 'pubky-app-specs';
-import { asInvalid, asOpaque } from '@/test-utils';
+import { asInvalid, asOpaque } from '@/test-utils/type-assertions';
 import {
   TEST_PUBKY,
   setupUnitTestMocks,

--- a/src/core/pipes/user/user.validator.ts
+++ b/src/core/pipes/user/user.validator.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { USER_NAME_MIN_LENGTH, USER_NAME_MAX_LENGTH, USER_BIO_MAX_LENGTH } from '@/config';
+import { USER_NAME_MIN_LENGTH, USER_NAME_MAX_LENGTH, USER_BIO_MAX_LENGTH } from '@/config/user';
 
 export class UserValidator {
   static check(name: string, bio: string, links: { label: string; url: string }[], avatarFile: File | null) {

--- a/src/core/services/chatwoot/chatwoot.test.ts
+++ b/src/core/services/chatwoot/chatwoot.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { asOpaque, mockResponse } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockResponse } from '@/test-utils/dom';
 import type {
   TChatwootContact,
   TChatwootContactSearchResponse,

--- a/src/core/services/chatwoot/chatwoot.ts
+++ b/src/core/services/chatwoot/chatwoot.ts
@@ -1,4 +1,8 @@
-import * as Types from './chatwoot.types';
+import type {
+  TChatwootContact,
+  TChatwootContactSearchResponse,
+  TChatwootCreateContactResponse,
+} from './chatwoot.types';
 import { chatwootApi } from './chatwoot.api';
 import { Env } from '@/libs/env/env';
 import { HttpMethod, JSON_HEADERS } from '@/libs/http/http.types';
@@ -85,7 +89,7 @@ export class ChatwootService {
    * @returns Chatwoot contact object
    * @throws AppError if API calls fail
    */
-  static async createOrFindContact(email: string, name: string, inboxId: number): Promise<Types.TChatwootContact> {
+  static async createOrFindContact(email: string, name: string, inboxId: number): Promise<TChatwootContact> {
     const config = this.getBaseConfig();
 
     // Search for existing contact
@@ -101,7 +105,7 @@ export class ChatwootService {
       throw httpResponseToError(searchResponse, ErrorService.Chatwoot, 'searchContact', searchUrl);
     }
 
-    const searchData = await parseResponseOrThrow<Types.TChatwootContactSearchResponse>(
+    const searchData = await parseResponseOrThrow<TChatwootContactSearchResponse>(
       searchResponse,
       ErrorService.Chatwoot,
       'searchContact',
@@ -137,7 +141,7 @@ export class ChatwootService {
       throw httpResponseToError(createResponse, ErrorService.Chatwoot, 'createContact', createUrl);
     }
 
-    const createData = await parseResponseOrThrow<Types.TChatwootCreateContactResponse>(
+    const createData = await parseResponseOrThrow<TChatwootCreateContactResponse>(
       createResponse,
       ErrorService.Chatwoot,
       'createContact',

--- a/src/core/services/chatwoot/chatwoot.utils.test.ts
+++ b/src/core/services/chatwoot/chatwoot.utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildChatwootEmail, extractSourceId, CHATWOOT_EMAIL_DOMAIN } from './chatwoot.utils';
 import type { TChatwootContact } from './chatwoot.types';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 
 const testData = {
   pubky: 'o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo',

--- a/src/core/services/exchangerate/exchangerate.test.ts
+++ b/src/core/services/exchangerate/exchangerate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { ExchangerateService } from './exchangerate';
 import { exchangerateQueryClient } from './exchangerate.query-client';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { Env } from '@/libs/env/env';
 import { NetworkErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/services/exchangerate/exchangerate.ts
+++ b/src/core/services/exchangerate/exchangerate.ts
@@ -1,4 +1,4 @@
-import { EXCHANGE_RATE_API } from '@/config';
+import { EXCHANGE_RATE_API } from '@/config/network';
 import { exchangerateQueryClient } from './exchangerate.query-client';
 import { BlockTankResponse, BtcRate } from './exchangerate.types';
 import { HttpMethod } from '@/libs/http/http.types';

--- a/src/core/services/homegate/homegate.api.ts
+++ b/src/core/services/homegate/homegate.api.ts
@@ -1,4 +1,4 @@
-import { HOMEGATE_URL } from '@/config';
+import { HOMEGATE_URL } from '@/config/network';
 
 /**
  * Homegate API Endpoints

--- a/src/core/services/homegate/homegate.prelude.test.ts
+++ b/src/core/services/homegate/homegate.prelude.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 
 const mockDispatchSignals = vi.fn();
 vi.mock('@prelude.so/js-sdk/signals', () => ({

--- a/src/core/services/homegate/homegate.test.ts
+++ b/src/core/services/homegate/homegate.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HomegateService } from './homegate';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 
 const mockFetch = vi.fn();
 global.fetch = asOpaque<typeof global.fetch>(mockFetch);

--- a/src/core/services/homeserver/homeserver.test.ts
+++ b/src/core/services/homeserver/homeserver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Session, Keypair, PublicKey } from '@synonymdev/pubky';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { AppError } from '@/libs/error/error';
 import { AuthErrorCode, ClientErrorCode, ServerErrorCode, ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/services/homeserver/homeserver.ts
+++ b/src/core/services/homeserver/homeserver.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { DEFAULT_HTTP_RELAY, HOMESERVER, PKARR_RELAYS, TESTNET } from '@/config/network';
 import {
   Pubky,
   PublicKey,
@@ -48,7 +48,7 @@ import type {
   THomeserverSignUpParams,
 } from '@/services/homeserver/homeserver.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
-const TESTNET = Config.TESTNET.toString() === 'true';
+const IS_TESTNET = TESTNET.toString() === 'true';
 
 const CAPABILITIES = '/pub/pubky.app/:rw';
 const PUB_PATH_PREFIX = '/pub/' as const;
@@ -65,10 +65,10 @@ export class HomeserverService {
    */
   private static getPubkySdk(): Pubky {
     if (!this.pubkySdk) {
-      if (TESTNET) {
+      if (IS_TESTNET) {
         this.pubkySdk = Pubky.testnet();
       } else {
-        const client = new Client({ pkarr: { relays: Config.PKARR_RELAYS } });
+        const client = new Client({ pkarr: { relays: PKARR_RELAYS } });
         this.pubkySdk = Pubky.withClient(client);
       }
     }
@@ -120,7 +120,7 @@ export class HomeserverService {
    */
   static async signUp({ keypair, signupToken }: THomeserverSignUpParams): Promise<THomeserverSessionResult> {
     try {
-      const homeserverPublicKey = PublicKey.from(Config.HOMESERVER);
+      const homeserverPublicKey = PublicKey.from(HOMESERVER);
       const signer = this.getSigner(keypair);
       const session = await signer.signup(homeserverPublicKey, signupToken);
 
@@ -156,7 +156,7 @@ export class HomeserverService {
     } catch (signinError) {
       try {
         // Republish keypair's homeserver
-        const homeserverPublicKey = PublicKey.from(Config.HOMESERVER);
+        const homeserverPublicKey = PublicKey.from(HOMESERVER);
         await signer.pkdns.publishHomeserverForce(homeserverPublicKey);
         Logger.debug('Republish homeserver successful', { keypair: Identity.pubkyFromKeypair(keypair) });
         // Return undefined to signal caller should retry signin after republish
@@ -182,7 +182,7 @@ export class HomeserverService {
 
     try {
       const pubkySdk = this.getPubkySdk();
-      const flow = pubkySdk.startAuthFlow(capabilities, AuthFlowKind.signin(), Config.DEFAULT_HTTP_RELAY);
+      const flow = pubkySdk.startAuthFlow(capabilities, AuthFlowKind.signin(), DEFAULT_HTTP_RELAY);
       const approval = createCancelableAuthApproval(flow);
 
       return {
@@ -191,7 +191,7 @@ export class HomeserverService {
         cancelAuthFlow: approval.cancel,
       };
     } catch (error) {
-      return handleError({ error, additionalContext: { capabilities, relay: Config.DEFAULT_HTTP_RELAY } });
+      return handleError({ error, additionalContext: { capabilities, relay: DEFAULT_HTTP_RELAY } });
     }
   }
 

--- a/src/core/services/local/file/file.test.ts
+++ b/src/core/services/local/file/file.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { BlobResult, FileResult } from 'pubky-app-specs';
 import { LocalFileService } from './file';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/services/local/stream/posts/posts.test.ts
+++ b/src/core/services/local/stream/posts/posts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';

--- a/src/core/services/local/stream/users/users.test.ts
+++ b/src/core/services/local/stream/users/users.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import * as Config from '@/config';
+import { MODERATED_TAGS, MODERATION_ID } from '@/config/moderation';
 import type { Pubky } from '@/models/models.types';
 import { ModerationModel } from '@/models/moderation/moderation';
 import { ModerationType } from '@/models/moderation/moderation.schema';
@@ -380,8 +380,8 @@ describe('LocalStreamUsersService', () => {
         const userId = 'user-moderated' as Pubky;
         const moderatedTags: NexusTag[] = [
           {
-            label: Config.MODERATED_TAGS[0],
-            taggers: [Config.MODERATION_ID],
+            label: MODERATED_TAGS[0],
+            taggers: [MODERATION_ID],
             taggers_count: 1,
             relationship: true,
           },
@@ -418,7 +418,7 @@ describe('LocalStreamUsersService', () => {
         const userId = 'user-wrong-tagger' as Pubky;
         const tagsWithWrongTagger: NexusTag[] = [
           {
-            label: Config.MODERATED_TAGS[0],
+            label: MODERATED_TAGS[0],
             taggers: ['wrong-tagger-id'],
             taggers_count: 1,
             relationship: true,
@@ -439,8 +439,8 @@ describe('LocalStreamUsersService', () => {
         const moderatedUser = createMockNexusUser(moderatedUserId, {
           tags: [
             {
-              label: Config.MODERATED_TAGS[0],
-              taggers: [Config.MODERATION_ID],
+              label: MODERATED_TAGS[0],
+              taggers: [MODERATION_ID],
               taggers_count: 1,
               relationship: true,
             },

--- a/src/core/services/nextjs/og-metadata/og-metadata.test.ts
+++ b/src/core/services/nextjs/og-metadata/og-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config';
+import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config/urls';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { AuthErrorCode, NetworkErrorCode, ServerErrorCode, ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/core/services/nextjs/og-metadata/og-metadata.test.ts
+++ b/src/core/services/nextjs/og-metadata/og-metadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { AuthErrorCode, NetworkErrorCode, ServerErrorCode, ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { HttpStatusCode } from '@/libs/http/http.types';

--- a/src/core/services/nextjs/og-metadata/og-metadata.utils.test.ts
+++ b/src/core/services/nextjs/og-metadata/og-metadata.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config';
+import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config/urls';
 import { AuthErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory } from '@/libs/error/error.types';
 import { HttpStatusCode } from '@/libs/http/http.types';

--- a/src/core/services/nextjs/og-metadata/og-metadata.utils.ts
+++ b/src/core/services/nextjs/og-metadata/og-metadata.utils.ts
@@ -1,4 +1,4 @@
-import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config';
+import { URL_TRUNCATE_LENGTH, TITLE_TRUNCATE_LENGTH } from '@/config/urls';
 import { normalizeImageUrl, isHttpProtocol } from '../nextjs.utils';
 import { extractFromHtml, OG_PATTERNS } from '@/libs/html/html';
 import { HttpStatusCode } from '@/libs/http/http.types';

--- a/src/core/services/nexus/file/file.test.ts
+++ b/src/core/services/nexus/file/file.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { filesApi, buildFileBodyUrl } from './file.api';
 import { FileVariant, type TFileParams, type TFileBody } from './file.types';
-import * as Config from '@/config';
+import { CDN_URL, NEXUS_URL } from '@/config/nexus';
 
 const pubky = 'qr3xqyz3e5cyf9npgxc5zfp15ehhcis6gqsxob4une7bwwazekry';
 const encodedPubky = encodeURIComponent(pubky);
@@ -12,13 +12,13 @@ describe('File API', () => {
   describe('filesApi.getAvatarUrl', () => {
     it('should generate correct avatar URL for valid pubky', () => {
       const result = filesApi.getAvatarUrl(pubky);
-      expect(result).toBe(`${Config.CDN_URL}/avatar/${encodedPubky}`);
+      expect(result).toBe(`${CDN_URL}/avatar/${encodedPubky}`);
     });
 
     it('should append version query param when provided', () => {
       const version = 12345;
       const result = filesApi.getAvatarUrl(pubky, version);
-      expect(result).toBe(`${Config.CDN_URL}/avatar/${encodedPubky}?v=${version}`);
+      expect(result).toBe(`${CDN_URL}/avatar/${encodedPubky}?v=${version}`);
     });
   });
 
@@ -31,7 +31,7 @@ describe('File API', () => {
       };
 
       const result = filesApi.getFileUrl(params);
-      expect(result).toBe(`${Config.CDN_URL}/files/${encodedPubky}/${encodedFileId}/small`);
+      expect(result).toBe(`${CDN_URL}/files/${encodedPubky}/${encodedFileId}/small`);
     });
 
     it('should generate correct URL for FEED variant', () => {
@@ -42,7 +42,7 @@ describe('File API', () => {
       };
 
       const result = filesApi.getFileUrl(params);
-      expect(result).toBe(`${Config.CDN_URL}/files/${encodedPubky}/${encodedFileId}/feed`);
+      expect(result).toBe(`${CDN_URL}/files/${encodedPubky}/${encodedFileId}/feed`);
     });
 
     it('should generate correct URL for MAIN variant', () => {
@@ -53,7 +53,7 @@ describe('File API', () => {
       };
 
       const result = filesApi.getFileUrl(params);
-      expect(result).toBe(`${Config.CDN_URL}/files/${encodedPubky}/${encodedFileId}/main`);
+      expect(result).toBe(`${CDN_URL}/files/${encodedPubky}/${encodedFileId}/main`);
     });
   });
 
@@ -62,7 +62,7 @@ describe('File API', () => {
       const fileUris = [pubky];
       const result = filesApi.getFiles(fileUris);
 
-      expect(result.url).toBe(`${Config.NEXUS_URL}/v0/files/by_ids`);
+      expect(result.url).toBe(`${NEXUS_URL}/v0/files/by_ids`);
       expect(result.body).toEqual({ uris: fileUris });
     });
 
@@ -70,7 +70,7 @@ describe('File API', () => {
       const fileUris = [pubky, `${pubky}-2`, `${pubky}-3`];
       const result = filesApi.getFiles(fileUris);
 
-      expect(result.url).toBe(`${Config.NEXUS_URL}/v0/files/by_ids`);
+      expect(result.url).toBe(`${NEXUS_URL}/v0/files/by_ids`);
       expect(result.body).toEqual({ uris: fileUris });
     });
 
@@ -78,7 +78,7 @@ describe('File API', () => {
       const fileUris = Array.from({ length: 100 }, (_, i) => `${pubky}-${i}`);
       const result = filesApi.getFiles(fileUris);
 
-      expect(result.url).toBe(`${Config.NEXUS_URL}/v0/files/by_ids`);
+      expect(result.url).toBe(`${NEXUS_URL}/v0/files/by_ids`);
       expect(result.body).toEqual({ uris: fileUris });
       expect(result.body.uris).toHaveLength(100);
     });
@@ -87,7 +87,7 @@ describe('File API', () => {
       const fileUris: string[] = [];
       const result = filesApi.getFiles(fileUris);
 
-      expect(result.url).toBe(`${Config.NEXUS_URL}/v0/files/by_ids`);
+      expect(result.url).toBe(`${NEXUS_URL}/v0/files/by_ids`);
       expect(result.body).toEqual({ uris: [] });
       expect(result.body.uris).toHaveLength(0);
     });

--- a/src/core/services/nexus/hot/hot.test.ts
+++ b/src/core/services/nexus/hot/hot.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NexusHotService } from './hot';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { queryNexus } from '@/services/nexus/nexus.utils';
 import { UserStreamReach, UserStreamTimeframe, type NexusHotTag } from '@/services/nexus/nexus.types';
 import { tagApi } from '@/services/nexus/tag/tag.api';
 import type { TTagHotParams } from '@/services/nexus/tag/tag.types';
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
+
 describe('NexusHotService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,7 +42,7 @@ describe('NexusHotService', () => {
         limit: 10,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
 
       const result = await NexusHotService.fetch(params);
 
@@ -56,7 +67,7 @@ describe('NexusHotService', () => {
         limit: 20,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
 
       const result = await NexusHotService.fetch(params);
 
@@ -69,7 +80,7 @@ describe('NexusHotService', () => {
         timeframe: UserStreamTimeframe.TODAY,
       };
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      mockQueryNexus.mockResolvedValue([]);
 
       const result = await NexusHotService.fetch(params);
 
@@ -91,7 +102,7 @@ describe('NexusHotService', () => {
         user_id: 'user-123',
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -116,7 +127,7 @@ describe('NexusHotService', () => {
         taggers_limit: 2,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -134,7 +145,7 @@ describe('NexusHotService', () => {
         limit: 0,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -152,7 +163,7 @@ describe('NexusHotService', () => {
         skip: 0,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -170,7 +181,7 @@ describe('NexusHotService', () => {
         limit: 10_000,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -199,7 +210,7 @@ describe('NexusHotService', () => {
         taggers_limit: 3,
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
       const tagApiHotSpy = vi.spyOn(tagApi, 'hot');
 
       const result = await NexusHotService.fetch(params);
@@ -215,14 +226,14 @@ describe('NexusHotService', () => {
         timeframe: UserStreamTimeframe.TODAY,
       };
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockRejectedValue(new Error('nexus-fail'));
+      mockQueryNexus.mockRejectedValue(new Error('nexus-fail'));
 
       await expect(NexusHotService.fetch(params)).rejects.toThrow('nexus-fail');
     });
 
     it('should handle different reach values', async () => {
       const mockHotTags = [] as NexusHotTag[];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
 
       await NexusHotService.fetch({ reach: UserStreamReach.FOLLOWING, timeframe: UserStreamTimeframe.TODAY });
       await NexusHotService.fetch({ reach: UserStreamReach.FRIENDS, timeframe: UserStreamTimeframe.TODAY });
@@ -233,7 +244,7 @@ describe('NexusHotService', () => {
 
     it('should handle different timeframe values', async () => {
       const mockHotTags = [] as NexusHotTag[];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockHotTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockHotTags);
 
       await NexusHotService.fetch({ timeframe: UserStreamTimeframe.TODAY });
       await NexusHotService.fetch({ timeframe: UserStreamTimeframe.THIS_WEEK });

--- a/src/core/services/nexus/nexus.utils.test.ts
+++ b/src/core/services/nexus/nexus.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import * as Config from '@/config';
+import { CDN_URL, NEXUS_URL } from '@/config/nexus';
 import { buildNexusUrl, buildCdnUrl, buildUrlWithQuery, createFetchOptions, queryNexus } from './nexus.utils';
 import { mockResponse } from '@/test-utils/dom';
 import { asOpaque } from '@/test-utils/type-assertions';
@@ -11,13 +11,13 @@ import { parseResponseOrThrow } from '@/libs/http/response.utils';
 describe('nexus.utils', () => {
   describe('buildNexusUrl', () => {
     it('should build correct Nexus URL', () => {
-      expect(buildNexusUrl('v0/users')).toBe(`${Config.NEXUS_URL}/v0/users`);
+      expect(buildNexusUrl('v0/users')).toBe(`${NEXUS_URL}/v0/users`);
     });
   });
 
   describe('buildCdnUrl', () => {
     it('should build correct CDN URL', () => {
-      expect(buildCdnUrl('avatar/user123')).toBe(`${Config.CDN_URL}/avatar/user123`);
+      expect(buildCdnUrl('avatar/user123')).toBe(`${CDN_URL}/avatar/user123`);
     });
   });
 

--- a/src/core/services/nexus/nexus.utils.test.ts
+++ b/src/core/services/nexus/nexus.utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as Config from '@/config';
 import { buildNexusUrl, buildCdnUrl, buildUrlWithQuery, createFetchOptions, queryNexus } from './nexus.utils';
-import { mockResponse, asOpaque } from '@/test-utils';
+import { mockResponse } from '@/test-utils/dom';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { ClientErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { HttpMethod } from '@/libs/http/http.types';

--- a/src/core/services/nexus/nexus.utils.ts
+++ b/src/core/services/nexus/nexus.utils.ts
@@ -1,4 +1,4 @@
-import * as Config from '@/config';
+import { CDN_URL, NEXUS_URL } from '@/config/nexus';
 import { nexusQueryClient } from './nexus.query-client';
 import type {
   TBuildUrlWithQueryParams,
@@ -12,11 +12,11 @@ import { httpResponseToError, safeFetch } from '@/libs/error/error.http';
 import { ErrorService } from '@/libs/error/error.types';
 
 export function buildNexusUrl(endpoint: string): string {
-  return `${Config.NEXUS_URL}/${endpoint}`;
+  return `${NEXUS_URL}/${endpoint}`;
 }
 
 export function buildCdnUrl(endpoint: string): string {
-  return `${Config.CDN_URL}/${endpoint}`;
+  return `${CDN_URL}/${endpoint}`;
 }
 
 /**

--- a/src/core/services/nexus/post/post.test.ts
+++ b/src/core/services/nexus/post/post.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { postApi } from './post.api';
 import { type TPostViewParams, type TPostBase, type TPostTaggersParams, type TPostTagsParams } from './post.types';
-import * as Config from '@/config';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { NEXUS_URL } from '@/config/nexus';
+import { queryNexus } from '@/services/nexus/nexus.utils';
 import type { Pubky } from '@/models/models.types';
 import type { NexusTaggers } from '@/services/nexus/nexus.types';
 import { NexusPostService } from '@/services/nexus/post/post';
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
+
 const pubky = 'qr3xqyz3e5cyf9npgxc5zfp15ehhcis6gqsxob4une7bwwazekry';
 const postId = 'test-post-123';
 
@@ -18,7 +29,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.view(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}`);
     });
 
     it('should generate correct view URL with viewer_id', () => {
@@ -29,7 +40,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.view(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}?viewer_id=${pubky}-viewer`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}?viewer_id=${pubky}-viewer`);
     });
 
     it('should generate correct view URL with tag pagination parameters', () => {
@@ -41,7 +52,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.view(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}?limit_tags=10&limit_taggers=5`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}?limit_tags=10&limit_taggers=5`);
     });
   });
 
@@ -53,7 +64,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.bookmarks(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/bookmarks`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/bookmarks`);
     });
 
     it('should generate correct bookmarks URL with viewer_id', () => {
@@ -64,7 +75,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.bookmarks(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/bookmarks?viewer_id=${pubky}-viewer`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/bookmarks?viewer_id=${pubky}-viewer`);
     });
   });
 
@@ -76,7 +87,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.counts(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/counts`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/counts`);
     });
   });
 
@@ -88,7 +99,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.details(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/details`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/details`);
     });
   });
 
@@ -101,7 +112,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.taggers(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label`);
     });
 
     it('should generate correct taggers URL with pagination parameters', () => {
@@ -114,7 +125,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.taggers(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label?skip=10&limit=20`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label?skip=10&limit=20`);
     });
 
     it('should generate correct taggers URL with viewer_id', () => {
@@ -126,9 +137,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.taggers(params);
-      expect(result).toBe(
-        `${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label?viewer_id=${pubky}-viewer`,
-      );
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/test-label?viewer_id=${pubky}-viewer`);
     });
   });
 
@@ -140,7 +149,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.tags(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/tags`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/tags`);
     });
 
     it('should generate correct tags URL with tag pagination parameters', () => {
@@ -153,9 +162,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.tags(params);
-      expect(result).toBe(
-        `${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/tags?limit_tags=15&limit_taggers=8&skip_tags=5`,
-      );
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/tags?limit_tags=15&limit_taggers=8&skip_tags=5`);
     });
 
     it('should generate correct tags URL with viewer_id', () => {
@@ -166,7 +173,7 @@ describe('Post API', () => {
       };
 
       const result = postApi.tags(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/tags?viewer_id=${pubky}-viewer`);
+      expect(result).toBe(`${NEXUS_URL}/v0/post/${pubky}/${postId}/tags?viewer_id=${pubky}-viewer`);
     });
   });
 
@@ -243,7 +250,7 @@ describe('NexusPostService', () => {
   describe('getPostTaggers', () => {
     it('should construct correct URL and return queryNexus response', async () => {
       const mockTaggers: NexusTaggers = { relationship: false, users: ['user1' as Pubky] };
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockTaggers);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockTaggers);
 
       const result = await NexusPostService.getPostTaggers({
         compositeId: `${pubky}:${postId}`,
@@ -255,7 +262,7 @@ describe('NexusPostService', () => {
 
       expect(result).toEqual(mockTaggers);
       expect(queryNexusSpy).toHaveBeenCalledWith({
-        url: `${Config.NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/rust%20%26%20wasm?skip=10&limit=5&viewer_id=${testViewerId}`,
+        url: `${NEXUS_URL}/v0/post/${pubky}/${postId}/taggers/rust%20%26%20wasm?skip=10&limit=5&viewer_id=${testViewerId}`,
       });
     });
   });

--- a/src/core/services/nexus/search/search.test.ts
+++ b/src/core/services/nexus/search/search.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NexusSearchService } from './search';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { queryNexus } from '@/services/nexus/nexus.utils';
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
+
 describe('NexusSearchService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -9,7 +20,7 @@ describe('NexusSearchService', () => {
   describe('usersById', () => {
     it('should call queryNexus with correct URL and return user IDs', async () => {
       const mockUserIds = ['user1', 'user2'];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockUserIds);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockUserIds);
 
       const result = await NexusSearchService.usersById({ prefix: 'pxnu33', skip: 0, limit: 5 });
 
@@ -20,7 +31,7 @@ describe('NexusSearchService', () => {
     });
 
     it('should return empty array when queryNexus returns empty array', async () => {
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      mockQueryNexus.mockResolvedValue([]);
 
       const result = await NexusSearchService.usersById({ prefix: 'nonexistent', skip: 0, limit: 5 });
 
@@ -28,7 +39,7 @@ describe('NexusSearchService', () => {
     });
 
     it('should include pagination params in URL', async () => {
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
 
       await NexusSearchService.usersById({ prefix: 'test', skip: 10, limit: 20 });
 
@@ -44,7 +55,7 @@ describe('NexusSearchService', () => {
   describe('usersByName', () => {
     it('should call queryNexus with correct URL and return user IDs', async () => {
       const mockUserIds = ['user1', 'user2'];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockUserIds);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockUserIds);
 
       const result = await NexusSearchService.usersByName({ prefix: 'Test', skip: 0, limit: 5 });
 
@@ -55,7 +66,7 @@ describe('NexusSearchService', () => {
     });
 
     it('should return empty array when queryNexus returns empty array', async () => {
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      mockQueryNexus.mockResolvedValue([]);
 
       const result = await NexusSearchService.usersByName({ prefix: 'nonexistent', skip: 0, limit: 5 });
 
@@ -66,7 +77,7 @@ describe('NexusSearchService', () => {
   describe('tags', () => {
     it('should call queryNexus with correct URL and return tags', async () => {
       const mockTags = ['bitcoin', 'bitkit', 'bits'];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockTags);
 
       const result = await NexusSearchService.tags({ prefix: 'bit', skip: 0, limit: 5 });
 
@@ -77,7 +88,7 @@ describe('NexusSearchService', () => {
     });
 
     it('should return empty array when queryNexus returns empty array', async () => {
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      mockQueryNexus.mockResolvedValue([]);
 
       const result = await NexusSearchService.tags({ prefix: 'xyz', skip: 0, limit: 5 });
 
@@ -85,7 +96,7 @@ describe('NexusSearchService', () => {
     });
 
     it('should handle special characters in prefix', async () => {
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
 
       await NexusSearchService.tags({ prefix: 'tag#123', skip: 0, limit: 5 });
 

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -3,7 +3,7 @@ import { postStreamApi } from './postStream.api';
 import { StreamKind, StreamOrder } from './postStream.types';
 import { createPostStreamParams, breakDownStreamId } from './postStream.utils';
 import { NexusPostStreamService } from './postStream';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { queryNexus } from '@/services/nexus/nexus.utils';
 import type { Pubky } from '@/models/models.types';
 import { PostStreamTypes, type PostStreamId } from '@/models/stream/post/postStream.types';
 import { StreamSorting, type NexusPost, type NexusPostsKeyStream } from '@/services/nexus/nexus.types';
@@ -19,6 +19,16 @@ import type {
   TStreamWithObserverParams,
 } from '@/services/nexus/stream/posts/postStream.types';
 //TODO: Split the suite by module (postStream.api.test.ts, postStream.utils.test.ts, postStream.service.test.ts) so each file targets the key behaviours of that module under @posts.
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
 
 function callStreamEndpoint(
   endpoint: keyof typeof postStreamApi,
@@ -711,7 +721,7 @@ describe('NexusPostStreamService', () => {
         post_keys: [],
         last_post_score: 0,
       };
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockResponse);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockResponse);
 
       const fetchParams: TPostStreamFetchParams = {
         params,
@@ -783,7 +793,7 @@ describe('NexusPostStreamService', () => {
         last_post_score: 123456,
       };
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockResponse);
+      mockQueryNexus.mockResolvedValue(mockResponse);
 
       const params: TPostStreamFetchParams = {
         params: { limit: 10, viewer_id: mockViewerId },
@@ -808,7 +818,7 @@ describe('NexusPostStreamService', () => {
         { details: { id: 'post2', author: 'author1' } } as NexusPost,
         { details: { id: 'post3', author: 'author2' } } as NexusPost,
       ];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockPosts);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockPosts);
 
       // Act
       const result = await NexusPostStreamService.fetchByIds({
@@ -830,7 +840,7 @@ describe('NexusPostStreamService', () => {
       // Arrange
       const mockPostIds = ['author1:post1'];
       const mockPosts: NexusPost[] = [{ details: { id: 'post1', author: 'author1' } } as NexusPost];
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockPosts);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockPosts);
 
       // Act
       const result = await NexusPostStreamService.fetchByIds({ post_ids: mockPostIds });
@@ -846,7 +856,7 @@ describe('NexusPostStreamService', () => {
 
     it('should return empty array when fetching empty post IDs', async () => {
       // Arrange
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
 
       // Act
       const result = await NexusPostStreamService.fetchByIds({ post_ids: [] });

--- a/src/core/services/nexus/stream/users/userStream.test.ts
+++ b/src/core/services/nexus/stream/users/userStream.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { userStreamApi, buildUserStreamBodyUrl } from './userStream.api';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { buildUserCompositeId } from '@/models/stream/user/userStream.helper';
 import { UserStreamTypes } from '@/models/stream/user/userStream.types';
 import { UserStreamReach, UserStreamTimeframe } from '@/services/nexus/nexus.types';

--- a/src/core/services/nexus/tag/tag.test.ts
+++ b/src/core/services/nexus/tag/tag.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { tagApi } from './tag.api';
 import { TTagViewParams, TTagHotParams, TTagTaggersParams } from './tag.types';
-import * as Config from '@/config';
+import { NEXUS_URL } from '@/config/nexus';
 import { UserStreamReach } from '@/services/nexus/nexus.types';
 const testTaggerId = 'qr3xqyz3e5cyf9npgxc5zfp15ehhcis6gqsxob4une7bwwazekry';
 const testTagId = 'test_tag';
@@ -15,7 +15,7 @@ describe('Tag API', () => {
       };
 
       const result = tagApi.view(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/tags/${testTaggerId}/${testTagId}`);
+      expect(result).toBe(`${NEXUS_URL}/v0/tags/${testTaggerId}/${testTagId}`);
     });
 
     it('should handle different parameters', () => {
@@ -25,7 +25,7 @@ describe('Tag API', () => {
       };
 
       const result = tagApi.view(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/tags/${testTaggerId}/differentTag`);
+      expect(result).toBe(`${NEXUS_URL}/v0/tags/${testTaggerId}/differentTag`);
     });
   });
 
@@ -37,7 +37,7 @@ describe('Tag API', () => {
         limit: 20,
       };
       const result = tagApi.hot(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/tags/hot?user_id=test_user&reach=followers&limit=20`);
+      expect(result).toBe(`${NEXUS_URL}/v0/tags/hot?user_id=test_user&reach=followers&limit=20`);
     });
   });
 
@@ -49,7 +49,7 @@ describe('Tag API', () => {
         limit: 30,
       };
       const result = tagApi.taggers(params);
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/tags/taggers/test_label?reach=friends&limit=30`);
+      expect(result).toBe(`${NEXUS_URL}/v0/tags/taggers/test_label?reach=friends&limit=30`);
     });
   });
 

--- a/src/core/services/nexus/user/user.test.ts
+++ b/src/core/services/nexus/user/user.test.ts
@@ -9,11 +9,22 @@ import {
   USER_PATH_PARAMS,
 } from './user.types';
 import { buildUrlWithQuery } from '../nexus.utils';
-import * as Config from '@/config';
-import * as queryNexusModule from '@/services/nexus/nexus.utils';
+import { NEXUS_URL } from '@/config/nexus';
+import { queryNexus } from '@/services/nexus/nexus.utils';
 import type { Pubky } from '@/models/models.types';
 import type { NexusTag, NexusUserDetails, TUserId } from '@/services/nexus/nexus.types';
 import { NexusUserService } from '@/services/nexus/user/user';
+
+vi.mock('@/services/nexus/nexus.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/nexus/nexus.utils')>();
+  return {
+    ...actual,
+    queryNexus: vi.fn(),
+  };
+});
+
+const mockQueryNexus = vi.mocked(queryNexus);
+
 const testUserId = 'qr3xqyz3e5cyf9npgxc5zfp15ehhcis6gqsxob4une7bwwazekry';
 const testViewerId = 'viewer123';
 
@@ -28,7 +39,7 @@ describe('User API', () => {
       const baseRoute = 'v0/user/test';
 
       const result = buildUrlWithQuery({ baseRoute, params, excludeKeys: USER_PATH_PARAMS });
-      expect(result).toBe(`${Config.NEXUS_URL}/v0/user/test?depth=2&viewer_id=${testViewerId}`);
+      expect(result).toBe(`${NEXUS_URL}/v0/user/test?depth=2&viewer_id=${testViewerId}`);
     });
 
     it('should exclude path parameters from query string', () => {
@@ -48,8 +59,8 @@ describe('User API', () => {
     it('should generate correct URLs for basic endpoints', () => {
       const params: TUserId = { user_id: testUserId };
 
-      expect(userApi.counts(params)).toBe(`${Config.NEXUS_URL}/v0/user/${testUserId}/counts`);
-      expect(userApi.details(params)).toBe(`${Config.NEXUS_URL}/v0/user/${testUserId}/details`);
+      expect(userApi.counts(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/counts`);
+      expect(userApi.details(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/details`);
     });
 
     it('should generate correct URLs for view endpoints', () => {
@@ -59,12 +70,12 @@ describe('User API', () => {
         viewer_id: testViewerId,
       };
 
-      expect(userApi.view(params)).toBe(`${Config.NEXUS_URL}/v0/user/${testUserId}?depth=2&viewer_id=${testViewerId}`);
+      expect(userApi.view(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}?depth=2&viewer_id=${testViewerId}`);
       expect(userApi.followers(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/followers?depth=2&viewer_id=${testViewerId}`,
+        `${NEXUS_URL}/v0/user/${testUserId}/followers?depth=2&viewer_id=${testViewerId}`,
       );
       expect(userApi.following(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/following?depth=2&viewer_id=${testViewerId}`,
+        `${NEXUS_URL}/v0/user/${testUserId}/following?depth=2&viewer_id=${testViewerId}`,
       );
     });
 
@@ -74,9 +85,7 @@ describe('User API', () => {
         viewer_id: testViewerId,
       };
 
-      expect(userApi.relationship(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/relationship/${testViewerId}`,
-      );
+      expect(userApi.relationship(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/relationship/${testViewerId}`);
     });
 
     it('should generate correct URL for friends endpoint', () => {
@@ -87,7 +96,7 @@ describe('User API', () => {
       };
 
       expect(userApi.friends(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/friends?depth=2&viewer_id=${testViewerId}`,
+        `${NEXUS_URL}/v0/user/${testUserId}/friends?depth=2&viewer_id=${testViewerId}`,
       );
     });
 
@@ -98,9 +107,7 @@ describe('User API', () => {
         viewer_id: testViewerId,
       };
 
-      expect(userApi.muted(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/muted?depth=2&viewer_id=${testViewerId}`,
-      );
+      expect(userApi.muted(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/muted?depth=2&viewer_id=${testViewerId}`);
     });
 
     it('should generate correct URL for notifications endpoint', () => {
@@ -113,7 +120,7 @@ describe('User API', () => {
       };
 
       expect(userApi.notifications(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/notifications?skip=0&limit=10&start=1000&end=2000`,
+        `${NEXUS_URL}/v0/user/${testUserId}/notifications?skip=0&limit=10&start=1000&end=2000`,
       );
     });
 
@@ -125,9 +132,7 @@ describe('User API', () => {
         limit: 10,
       };
 
-      expect(userApi.taggers(params)).toBe(
-        `${Config.NEXUS_URL}/v0/user/${testUserId}/taggers/test-tag?skip=0&limit=10`,
-      );
+      expect(userApi.taggers(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/taggers/test-tag?skip=0&limit=10`);
     });
 
     it('should generate correct URL for tags endpoint', () => {
@@ -137,7 +142,7 @@ describe('User API', () => {
         limit_tags: 10,
       };
 
-      expect(userApi.tags(params)).toBe(`${Config.NEXUS_URL}/v0/user/${testUserId}/tags?skip_tags=0&limit_tags=10`);
+      expect(userApi.tags(params)).toBe(`${NEXUS_URL}/v0/user/${testUserId}/tags?skip_tags=0&limit_tags=10`);
     });
   });
 
@@ -173,7 +178,7 @@ describe('NexusUserService', () => {
         { label: 'developer', taggers: [] as Pubky[], taggers_count: 0, relationship: false },
       ] as NexusTag[];
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockTags);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockTags);
 
       const result = await NexusUserService.tags({
         user_id: testUserId,
@@ -183,14 +188,14 @@ describe('NexusUserService', () => {
 
       expect(result).toEqual(mockTags);
       expect(queryNexusSpy).toHaveBeenCalledWith({
-        url: `${Config.NEXUS_URL}/v0/user/${testUserId}/tags?skip_tags=5&limit_tags=20`,
+        url: `${NEXUS_URL}/v0/user/${testUserId}/tags?skip_tags=5&limit_tags=20`,
       });
     });
   });
 
   describe('taggers', () => {
     it('should construct correct URL with encoded label', async () => {
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue([]);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue([]);
 
       await NexusUserService.taggers({
         user_id: testUserId,
@@ -218,12 +223,12 @@ describe('NexusUserService', () => {
         indexed_at: Date.now(),
       };
 
-      const queryNexusSpy = vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockUserDetails);
+      const queryNexusSpy = mockQueryNexus.mockResolvedValue(mockUserDetails);
 
       const result = await NexusUserService.details({ user_id: testUserId });
 
       expect(result).toEqual(mockUserDetails);
-      expect(queryNexusSpy).toHaveBeenCalledWith({ url: `${Config.NEXUS_URL}/v0/user/${testUserId}/details` });
+      expect(queryNexusSpy).toHaveBeenCalledWith({ url: `${NEXUS_URL}/v0/user/${testUserId}/details` });
     });
 
     it('should handle user with complete profile data', async () => {
@@ -240,7 +245,7 @@ describe('NexusUserService', () => {
         indexed_at: 1234567890,
       };
 
-      vi.spyOn(queryNexusModule, 'queryNexus').mockResolvedValue(mockUserDetails);
+      mockQueryNexus.mockResolvedValue(mockUserDetails);
 
       const result = await NexusUserService.details({ user_id: testUserId });
 

--- a/src/hooks/useAuthStatus/useAuthStatus.test.tsx
+++ b/src/hooks/useAuthStatus/useAuthStatus.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import type { Session } from '@synonymdev/pubky';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mockSession as buildSession } from '@/test-utils';
+import { mockSession as buildSession } from '@/test-utils/pubky';
 import { useAuthStatus } from './useAuthStatus';
 
 const mockSession = buildSession();

--- a/src/hooks/useAuthUrl/useAuthUrl.test.tsx
+++ b/src/hooks/useAuthUrl/useAuthUrl.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Session } from '@synonymdev/pubky';
-import { mockSession } from '@/test-utils';
+import { mockSession } from '@/test-utils/pubky';
 import { useAuthUrl } from './useAuthUrl';
 import { AppError } from '@/libs/error/error';
 import { AuthErrorCode, TimeoutErrorCode } from '@/libs/error/error.codes';

--- a/src/hooks/useBookmark/useBookmark.test.ts
+++ b/src/hooks/useBookmark/useBookmark.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useBookmark } from './useBookmark';
-import { mockAuthStore } from '@/test-utils';
+import { mockAuthStore } from '@/test-utils/stores';
 import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import type { Pubky } from '@/models/models.types';
 import { useAuthStore } from '@/stores/auth/auth.store';

--- a/src/hooks/useClosingPresence/useClosingPresence.test.ts
+++ b/src/hooks/useClosingPresence/useClosingPresence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockAnimationEvent } from '@/test-utils';
+import { mockAnimationEvent } from '@/test-utils/react-events';
 import { useClosingPresence } from './useClosingPresence';
 
 describe('useClosingPresence', () => {

--- a/src/hooks/useCopyrightForm/useCopyrightForm.test.tsx
+++ b/src/hooks/useCopyrightForm/useCopyrightForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { useCopyrightForm } from './useCopyrightForm';
 import { COPYRIGHT_ROLES } from './useCopyrightForm.constants';
 

--- a/src/hooks/useEmojiInsert/useEmojiInsert.test.ts
+++ b/src/hooks/useEmojiInsert/useEmojiInsert.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { useEmojiInsert } from './useEmojiInsert';
 
 describe('useEmojiInsert', () => {

--- a/src/hooks/useEnterSubmit/useEnterSubmit.test.tsx
+++ b/src/hooks/useEnterSubmit/useEnterSubmit.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { mockKeyboardEvent } from '@/test-utils';
+import { mockKeyboardEvent } from '@/test-utils/react-events';
 import { useEnterSubmit } from './useEnterSubmit';
 
 describe('useEnterSubmit', () => {

--- a/src/hooks/useLinkConfirmation/useLinkConfirmation.test.ts
+++ b/src/hooks/useLinkConfirmation/useLinkConfirmation.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mockMouseEvent } from '@/test-utils';
+import { mockMouseEvent } from '@/test-utils/react-events';
 import { useLinkConfirmation } from './useLinkConfirmation';
 import { defaultPrivacyPreferences } from '@/stores/settings/settings.types';
 const mockUseSettingsStore = vi.fn();

--- a/src/hooks/useListboxNavigation/useListboxNavigation.test.ts
+++ b/src/hooks/useListboxNavigation/useListboxNavigation.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mockKeyboardEvent } from '@/test-utils';
+import { mockKeyboardEvent } from '@/test-utils/react-events';
 import { useListboxNavigation } from './useListboxNavigation';
 
 describe('useListboxNavigation', () => {

--- a/src/hooks/useLocalFirstQuery/useLocalFirstQuery.test.ts
+++ b/src/hooks/useLocalFirstQuery/useLocalFirstQuery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { useLocalFirstQuery } from './useLocalFirstQuery';
 import type { UseLocalFirstQueryParams } from './useLocalFirstQuery.types';
 

--- a/src/hooks/useMentionAutocomplete/useMentionAutocomplete.test.ts
+++ b/src/hooks/useMentionAutocomplete/useMentionAutocomplete.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mockKeyboardEvent } from '@/test-utils';
+import { mockKeyboardEvent } from '@/test-utils/react-events';
 import { useMentionAutocomplete } from './useMentionAutocomplete';
 import type { Pubky } from '@/models/models.types';
 import type { NexusUserDetails } from '@/services/nexus/nexus.types';

--- a/src/hooks/usePostInput/usePostInput.test.ts
+++ b/src/hooks/usePostInput/usePostInput.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { asOpaque, mockClipboardEvent, mockDragEvent } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockClipboardEvent, mockDragEvent } from '@/test-utils/react-events';
 import { usePostInput } from './usePostInput';
 import { POST_INPUT_VARIANT } from '@/organisms/PostInput/PostInput.constants';
 

--- a/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
+++ b/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { usePostMenuActions } from './usePostMenuActions';
 import { POST_MENU_ACTION_IDS } from './usePostMenuActions.constants';
 import { isAppError } from '@/libs/error/error.utils';

--- a/src/hooks/usePostTags/usePostTags.test.tsx
+++ b/src/hooks/usePostTags/usePostTags.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { usePostTags } from './usePostTags';
 import { TAGS_PER_PAGE } from './usePostTags.constants';
-import { mockAuthStore } from '@/test-utils';
+import { mockAuthStore } from '@/test-utils/stores';
 import * as DexieHooks from 'dexie-react-hooks';
 import { TagController } from '@/controllers/tag/tag';
 import { useAuthStore } from '@/stores/auth/auth.store';

--- a/src/hooks/useProfileNavigation/useProfileNavigation.test.tsx
+++ b/src/hooks/useProfileNavigation/useProfileNavigation.test.tsx
@@ -19,7 +19,7 @@ vi.mock('next/navigation', () => ({
 const mockPubky = 'user123';
 const mockIsOwnProfile = vi.fn(() => true);
 
-vi.mock('@/providers', () => ({
+vi.mock('@/providers/ProfileProvider/ProfileProvider', () => ({
   useProfileContext: () => ({
     pubky: mockPubky,
     isOwnProfile: mockIsOwnProfile(),

--- a/src/hooks/useProfileNavigation/useProfileNavigation.ts
+++ b/src/hooks/useProfileNavigation/useProfileNavigation.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { PROFILE_ROUTES } from '@/app';
 import { PROFILE_PAGE_TYPES, ProfilePageType, FilterBarPageType } from '@/app/profile/types';
-import * as Providers from '@/providers';
+import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
 
 /**
@@ -190,7 +190,7 @@ export function useProfileNavigation(): UseProfileNavigationReturn {
   const router = useRouter();
   const isMobile = useIsMobile();
 
-  const { pubky, isOwnProfile } = Providers.useProfileContext();
+  const { pubky, isOwnProfile } = useProfileContext();
 
   /**
    * Determine the active page from the current pathname

--- a/src/hooks/useTagInput/useTagInput.test.ts
+++ b/src/hooks/useTagInput/useTagInput.test.ts
@@ -1,7 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { RefObject } from 'react';
-import { asOpaque, mockClipboardEvent } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockClipboardEvent } from '@/test-utils/react-events';
 import { useTagInput } from './useTagInput';
 import { TAG_MAX_LENGTH } from '@/config';
 

--- a/src/hooks/useUserDetailsFromIds/useUserDetailsFromIds.test.ts
+++ b/src/hooks/useUserDetailsFromIds/useUserDetailsFromIds.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { useUserDetailsFromIds } from './useUserDetailsFromIds';
 import type { Pubky } from '@/models/models.types';
 import type { NexusUserDetails } from '@/services/nexus/nexus.types';

--- a/src/hooks/useUserInfoPopoverActions/useUserInfoPopoverActions.test.tsx
+++ b/src/hooks/useUserInfoPopoverActions/useUserInfoPopoverActions.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { mockMouseEvent } from '@/test-utils';
+import { mockMouseEvent } from '@/test-utils/react-events';
 import { useUserInfoPopoverActions } from './useUserInfoPopoverActions';
 
 const mockPush = vi.fn();

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,2 +1,0 @@
-export * from './constants';
-export * from './routing';

--- a/src/libs/identity/identity.test.ts
+++ b/src/libs/identity/identity.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Identity } from './identity';
 import { Keypair } from '@synonymdev/pubky';
 import * as bip39 from 'bip39';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 import { ClientErrorCode, ValidationErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory } from '@/libs/error/error.types';
 

--- a/src/libs/image/cropImage.test.ts
+++ b/src/libs/image/cropImage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { asOpaque } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { cropImageToBlob } from './cropImage';
 
 describe('cropImage', () => {

--- a/src/libs/share/shareTarget.test.ts
+++ b/src/libs/share/shareTarget.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { asOpaque, mockResponse } from '@/test-utils';
+import { asOpaque } from '@/test-utils/type-assertions';
+import { mockResponse } from '@/test-utils/dom';
 import { getSharedFiles, composeShareContent } from './shareTarget';
 
 function createMockResponse(blob: Blob, headers: Headers): Response {

--- a/src/libs/utils/utils.test.ts
+++ b/src/libs/utils/utils.test.ts
@@ -28,7 +28,7 @@ import {
   radixIdSerializer,
 } from './utils';
 import { RADIX_ID_TEST_REGEX, RADIX_ID_REGEX, TAG_BANNED_CHARS } from './utils.constants';
-import { asInvalid } from '@/test-utils';
+import { asInvalid } from '@/test-utils/type-assertions';
 
 describe('Utils', () => {
   describe('radixIdSerializer', () => {

--- a/src/providers/DatabaseProvider/DatabaseProvider.test.tsx
+++ b/src/providers/DatabaseProvider/DatabaseProvider.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
-import { DatabaseProvider, DatabaseContext, type DatabaseContextType } from '@/providers';
+import { DatabaseProvider, DatabaseContext } from '@/providers/DatabaseProvider/DatabaseProvider';
+import { type DatabaseContextType } from '@/providers/DatabaseProvider/DatabaseProvider.types';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';

--- a/src/providers/DatabaseProvider/DatabaseProvider.tsx
+++ b/src/providers/DatabaseProvider/DatabaseProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import * as Atoms from '@/atoms';
-import { DatabaseContextType } from '@/providers';
+import { type DatabaseContextType } from '@/providers/DatabaseProvider/DatabaseProvider.types';
 import { AppError } from '@/libs/error/error';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';

--- a/src/providers/DatabaseProvider/index.ts
+++ b/src/providers/DatabaseProvider/index.ts
@@ -1,2 +1,0 @@
-export * from './DatabaseProvider';
-export * from './DatabaseProvider.types';

--- a/src/providers/ErrorBoundaryProvider/index.ts
+++ b/src/providers/ErrorBoundaryProvider/index.ts
@@ -1,3 +1,0 @@
-export { ErrorBoundaryProvider } from './ErrorBoundaryProvider';
-export { ErrorFallback } from './ErrorFallback';
-export type { ErrorBoundaryProviderProps, ErrorFallbackProps } from './ErrorBoundaryProvider.types';

--- a/src/providers/GlobalErrorHandlerProvider/index.ts
+++ b/src/providers/GlobalErrorHandlerProvider/index.ts
@@ -1,1 +1,0 @@
-export { GlobalErrorHandlerProvider } from './GlobalErrorHandlerProvider';

--- a/src/providers/IntlProvider/index.ts
+++ b/src/providers/IntlProvider/index.ts
@@ -1,1 +1,0 @@
-export * from './IntlProvider';

--- a/src/providers/ProfileProvider/index.ts
+++ b/src/providers/ProfileProvider/index.ts
@@ -1,2 +1,0 @@
-export * from './ProfileProvider';
-export * from './ProfileProvider.types';

--- a/src/providers/RouteGuardProvider/RouteGuardProvider.test.tsx
+++ b/src/providers/RouteGuardProvider/RouteGuardProvider.test.tsx
@@ -55,8 +55,8 @@ vi.mock('@/app', () => ({
   isDynamicPublicRoute: (path: string) => path.startsWith('/post/') || path.startsWith('/profile/'),
 }));
 
-// Mock @/providers
-vi.mock('@/providers', () => ({
+// Mock @/providers/RouteGuardProvider/RouteGuardProvider.constants
+vi.mock('@/providers/RouteGuardProvider/RouteGuardProvider.constants', () => ({
   ROUTE_ACCESS_MAP: {
     AUTHENTICATED: { allowedRoutes: ['/feed', '/settings'], redirectTo: '/feed' },
     UNAUTHENTICATED: { allowedRoutes: ['/login', '/landing'], redirectTo: '/login' },

--- a/src/providers/RouteGuardProvider/RouteGuardProvider.tsx
+++ b/src/providers/RouteGuardProvider/RouteGuardProvider.tsx
@@ -4,7 +4,7 @@ import { useAuthStatus } from '@/hooks/useAuthStatus/useAuthStatus';
 import { useEffect, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useTranslations, useLocale } from 'next-intl';
-import * as Providers from '@/providers';
+import { ROUTE_ACCESS_MAP } from '@/providers/RouteGuardProvider/RouteGuardProvider.constants';
 import * as App from '@/app';
 import * as Atoms from '@/atoms';
 import { Logger } from '@/libs/logger/logger';
@@ -138,7 +138,7 @@ export function RouteGuardProvider({ children }: RouteGuardProviderProps) {
     if (isLoading) return false;
 
     // Get the allowed routes for the current authentication status
-    const routeAccess = Providers.ROUTE_ACCESS_MAP[status];
+    const routeAccess = ROUTE_ACCESS_MAP[status];
 
     // Check if current pathname matches any allowed route (exact match or sub-route)
     return routeAccess.allowedRoutes.some((route) => {
@@ -161,7 +161,7 @@ export function RouteGuardProvider({ children }: RouteGuardProviderProps) {
     if (isRouteAccessible) return;
 
     // Redirect user to the appropriate default route for their authentication status
-    const routeAccess = Providers.ROUTE_ACCESS_MAP[status];
+    const routeAccess = ROUTE_ACCESS_MAP[status];
     const redirectTo = routeAccess.redirectTo;
 
     // Runtime validation: ensure redirect target is actually in allowed routes

--- a/src/providers/RouteGuardProvider/index.ts
+++ b/src/providers/RouteGuardProvider/index.ts
@@ -1,2 +1,0 @@
-export * from './RouteGuardProvider';
-export * from './RouteGuardProvider.constants';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,0 @@
-export * from './DatabaseProvider';
-export * from './ErrorBoundaryProvider';
-export * from './GlobalErrorHandlerProvider';
-export * from './IntlProvider';
-export * from './ProfileProvider';
-export * from './RouteGuardProvider';

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,5 +1,0 @@
-export * from './type-assertions';
-export * from './pubky';
-export * from './stores';
-export * from './react-events';
-export * from './dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -77,6 +77,9 @@
       "@/hooks/*": [
         "./src/hooks/*"
       ],
+      "@/providers/*": [
+        "./src/providers/*"
+      ],
       "@/libs/*": [
         "./src/libs/*"
       ],


### PR DESCRIPTION
## Summary
- Removed barrel files from `src/i18n`, `src/providers`, and `src/test-utils`.
- Replaced root barrel imports/mocks with direct module imports across app code and tests.
- Added Cypress TypeScript namespace support via the root `tsconfig.json` and updated docs examples.


Resolves: #1755