### PR TITLE
fix(tags): forward viewer_id when fetching post tags (#1721)

### DIFF
--- a/src/core/application/post/post.ts
+++ b/src/core/application/post/post.ts
@@ -86,8 +86,8 @@ export class PostApplication {
    * @param limit - Maximum number of tags to return
    * @returns Array of tags from Nexus
    */
-  static async fetchTags({ compositeId, skip, limit }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
-    const nexusTags = await NexusPostService.getPostTags({ compositeId, skip, limit });
+  static async fetchTags({ compositeId, skip, limit, viewerId }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
+    const nexusTags = await NexusPostService.getPostTags({ compositeId, skip, limit, viewerId });
 
     // Persist new tags to local DB (merge with existing)
     if (nexusTags.length > 0) {

--- a/src/core/controllers/post/post.ts
+++ b/src/core/controllers/post/post.ts
@@ -115,8 +115,8 @@ export class PostController {
    * @param params.limit - Maximum number of tags to return
    * @returns Array of tags from Nexus
    */
-  static async fetchTags({ compositeId, skip, limit }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
-    return await PostApplication.fetchTags({ compositeId, skip, limit });
+  static async fetchTags({ compositeId, skip, limit, viewerId }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
+    return await PostApplication.fetchTags({ compositeId, skip, limit, viewerId });
   }
 
   /**

--- a/src/core/controllers/post/post.types.ts
+++ b/src/core/controllers/post/post.types.ts
@@ -33,6 +33,7 @@ export interface TNormalizeTagsParams {
 export interface TFetchMorePostTagsParams extends TCompositeId {
   skip?: number;
   limit?: number;
+  viewerId?: Pubky;
 }
 
 export interface TFetchPostTaggersParams extends TCompositeId {

--- a/src/core/services/nexus/post/post.ts
+++ b/src/core/services/nexus/post/post.ts
@@ -30,10 +30,10 @@ export class NexusPostService {
    * @returns An array of tags (empty array if post has no tags)
    * @throws {NexusError} When post is not found or request fails
    */
-  static async getPostTags({ compositeId, skip, limit }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
+  static async getPostTags({ compositeId, skip, limit, viewerId }: TFetchMorePostTagsParams): Promise<NexusTag[]> {
     const { pubky: author_id, id: post_id } = parseCompositeId(compositeId);
 
-    const url = postApi.tags({ author_id, post_id, skip_tags: skip, limit_tags: limit });
+    const url = postApi.tags({ author_id, post_id, skip_tags: skip, limit_tags: limit, viewer_id: viewerId });
     return await queryNexus<NexusTag[]>({ url });
   }
 

--- a/src/hooks/usePostTags/usePostTags.test.tsx
+++ b/src/hooks/usePostTags/usePostTags.test.tsx
@@ -135,6 +135,7 @@ describe('usePostTags', () => {
           compositeId: 'author:post123',
           skip: 0,
           limit: TAGS_PER_PAGE,
+          viewerId: 'mock-user-id',
         });
       });
     });
@@ -345,6 +346,7 @@ describe('usePostTags', () => {
         compositeId: 'author:post123',
         skip: 25,
         limit: TAGS_PER_PAGE,
+        viewerId: 'viewer-123',
       });
     });
 
@@ -394,6 +396,7 @@ describe('usePostTags', () => {
         compositeId: 'author:post123',
         skip: 25,
         limit: TAGS_PER_PAGE,
+        viewerId: 'viewer-123',
       });
 
       // Second loadMore - skip should now be 25 + TAGS_PER_PAGE
@@ -402,6 +405,7 @@ describe('usePostTags', () => {
         compositeId: 'author:post123',
         skip: 25 + TAGS_PER_PAGE,
         limit: TAGS_PER_PAGE,
+        viewerId: 'viewer-123',
       });
     });
 
@@ -482,6 +486,7 @@ describe('usePostTags', () => {
         compositeId: 'author:post1',
         skip: 25,
         limit: TAGS_PER_PAGE,
+        viewerId: 'viewer-123',
       });
 
       // Change postId - this should reset the skip
@@ -505,6 +510,7 @@ describe('usePostTags', () => {
         compositeId: 'author:post2',
         skip: 15,
         limit: TAGS_PER_PAGE,
+        viewerId: 'viewer-123',
       });
     });
   });

--- a/src/hooks/usePostTags/usePostTags.tsx
+++ b/src/hooks/usePostTags/usePostTags.tsx
@@ -110,6 +110,12 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
     return () => {
       stale = true;
     };
+    // `viewerId` is listed for parity with the user-tags hook (`useTagged`),
+    // but the `hasFetched` guard above means a mid-mount viewer change
+    // (e.g. user logs in on the same page) will not trigger a re-fetch.
+    // This matches existing behaviour and is out of scope for #1721.
+    // To support that case in the future, reset `hasFetched` when viewerId
+    // changes — see the `prevPostIdRef` pattern below for the shape.
   }, [postId, hasFetched, viewerId]);
 
   const isLoading = tagsCollection === undefined;

--- a/src/hooks/usePostTags/usePostTags.tsx
+++ b/src/hooks/usePostTags/usePostTags.tsx
@@ -90,6 +90,7 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
           compositeId: postId,
           skip: 0,
           limit: TAGS_PER_PAGE,
+          viewerId: viewerId ?? undefined,
         });
 
         if (stale) return;
@@ -109,7 +110,7 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
     return () => {
       stale = true;
     };
-  }, [postId, hasFetched]);
+  }, [postId, hasFetched, viewerId]);
 
   const isLoading = tagsCollection === undefined;
 
@@ -202,6 +203,7 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
         compositeId: postId,
         skip,
         limit: TAGS_PER_PAGE,
+        viewerId: viewerId ?? undefined,
       });
 
       // IMPORTANT: Increment by fetched count, not by unique tags in UI.
@@ -219,7 +221,7 @@ export function usePostTags(postId: string | null | undefined, options: UsePostT
     } finally {
       setIsLoadingMore(false);
     }
-  }, [postId, isLoadingMore, hasMore, tTags]);
+  }, [postId, isLoadingMore, hasMore, viewerId, tTags]);
 
   const handleTagAdd = useCallback(
     async (tagString: string): Promise<{ success: boolean; error?: string }> => {


### PR DESCRIPTION
## Summary
Fixes #1721 — tags the viewer has already supported or added now show as selected on first load, and clicking them removes them in one click as expected.

## Root cause
- The post-tags request to Nexus omitted the viewer's identity, so the server replied with "viewer hasn't tagged this" for every tag.
- That stale answer got merged into local storage and overwrote the correct state from the viewer's earlier tag actions.
- Result: a tag the viewer had personally added rendered without the selected outline, and the first click was interpreted as "add" (toast: "added"; tag was re-added) instead of "remove" — needing a second click to actually remove.

## Fix
- **Pass the viewer's id when fetching post tags** — Nexus then returns the correct selected state, matching the user-tags path that already does this.
- **Pass it through every layer** — the request, the controller, the application, and the service all carry the viewer's id now.

## Testing
- Updated existing unit tests to assert the viewer id is included in fetch calls.
- Manual smoke: on a single post page where the viewer's avatar appears next to a tag, the tag now shows the selected outline on initial load and refresh; one click removes it and shows the "removed" toast.

## Notes
- `viewerId` is in the effect's deps but the `hasFetched` guard skips a re-fetch when the viewer changes mid-view (e.g. logging in on the same page). Same as the user-tags hook (`useTagged.tsx:82–87`); #1721 only covers the initial-load case.
- Found a separate bug while testing: a slow server reply can briefly undo a tag click. Tracked in #1781.