### PR TITLE
[DEMO] feat(ui): add public explore for hot and search

### DIFF
--- a/src/app/routes.test.ts
+++ b/src/app/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isDynamicPublicRoute } from './routes';
+import { isDynamicPublicRoute, isExplorePublicRoute } from './routes';
 
 describe('isDynamicPublicRoute', () => {
   describe('invite routes', () => {
@@ -121,5 +121,30 @@ describe('isDynamicPublicRoute', () => {
       expect(isDynamicPublicRoute('/onboarding')).toBe(false);
       expect(isDynamicPublicRoute('/onboarding/profile')).toBe(false);
     });
+  });
+});
+
+describe('isExplorePublicRoute', () => {
+  it('returns true for /hot and /search', () => {
+    expect(isExplorePublicRoute('/hot')).toBe(true);
+    expect(isExplorePublicRoute('/search')).toBe(true);
+  });
+
+  it('returns true for dynamic public routes', () => {
+    const longPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
+    expect(isExplorePublicRoute(`/profile/${longPubky}`)).toBe(true);
+    expect(isExplorePublicRoute(`/post/${longPubky}/0034BBBDFK83G`)).toBe(true);
+  });
+
+  it('returns false for authenticated-app routes', () => {
+    expect(isExplorePublicRoute('/home')).toBe(false);
+    expect(isExplorePublicRoute('/feed')).toBe(false);
+    expect(isExplorePublicRoute('/bookmarks')).toBe(false);
+    expect(isExplorePublicRoute('/settings')).toBe(false);
+    expect(isExplorePublicRoute('/')).toBe(false);
+  });
+
+  it('returns false for /profile without pubky (isDynamicPublicRoute is false)', () => {
+    expect(isExplorePublicRoute('/profile')).toBe(false);
   });
 });

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -62,6 +62,8 @@ export enum COPYRIGHT_ROUTES {
 // This includes routes that need to be accessible during auth transitions (like logout).
 // Note: Dynamic public routes like /profile/[pubky] and /post/[userId]/[postId]
 // are handled by isDynamicPublicRoute() in RouteGuardProvider.
+// Explore surfaces /hot and /search are listed here for the route guard; usePublicRoute
+// uses isExplorePublicRoute() so header/footer match other browse-only public pages.
 export const PUBLIC_ROUTES: string[] = [
   AUTH_ROUTES.LOGOUT,
   // Profile is public to prevent RouteGuard redirect during logout.
@@ -71,6 +73,8 @@ export const PUBLIC_ROUTES: string[] = [
   COPYRIGHT_ROUTES.COPYRIGHT,
   // Language settings page is public to allow language changes without auth issues
   SETTINGS_ROUTES.LANGUAGE,
+  APP_ROUTES.HOT,
+  APP_ROUTES.SEARCH,
 ];
 
 export const ALLOWED_ROUTES = [
@@ -146,6 +150,15 @@ export function isDynamicPublicRoute(pathname: string): boolean {
     default:
       return false;
   }
+}
+
+/**
+ * Routes that should use "public browse" UI (e.g. HeaderJoin, hide mobile app footer)
+ * for unauthenticated users. Narrower than PUBLIC_ROUTES — do not include /profile,
+ * /copyright, or /settings/language, which keep their own chrome.
+ */
+export function isExplorePublicRoute(pathname: string): boolean {
+  return isDynamicPublicRoute(pathname) || pathname === APP_ROUTES.HOT || pathname === APP_ROUTES.SEARCH;
 }
 
 // ============================================================================

--- a/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
@@ -79,6 +79,25 @@ describe('FilterReach', () => {
     expect(mockOnTabChange).not.toHaveBeenCalled();
   });
 
+  it('disables only keys in disabledReachKeys and blocks their clicks', () => {
+    const mockOnTabChange = vi.fn();
+    render(
+      <FilterReach
+        selectedTab={REACH.ALL}
+        onTabChange={mockOnTabChange}
+        disabledReachKeys={[REACH.FOLLOWING, REACH.FRIENDS]}
+      />,
+    );
+
+    expect(screen.getByLabelText('Following')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByLabelText('Friends')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByLabelText('All')).not.toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(screen.getByLabelText('Following'));
+    fireEvent.click(screen.getByLabelText('Friends'));
+    expect(mockOnTabChange).not.toHaveBeenCalled();
+  });
+
   it('items are not disabled by default', () => {
     render(<FilterReach />);
 

--- a/src/components/molecules/Filters/FilterReach/FilterReach.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.tsx
@@ -8,36 +8,47 @@ import { REACH, type ReachType } from '@/stores/home/home.types';
 import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
 import { BaseFilterProps } from '../Filters.types';
 
+export type FilterReachProps = BaseFilterProps<ReachType> & {
+  /**
+   * Disable specific reach options (e.g. following/friends when logged out on Hot).
+   * Combined with `disabled`: an item is disabled if either applies.
+   */
+  disabledReachKeys?: readonly ReachType[];
+};
+
 export function FilterReach({
   selectedTab,
   defaultSelectedTab = REACH.ALL,
   onTabChange,
   disabled,
-}: BaseFilterProps<ReachType>) {
+  disabledReachKeys,
+}: FilterReachProps) {
   const t = useTranslations('filters.reach');
-  const items = React.useMemo(
-    () => [
+  const disabledReachSet = React.useMemo(() => new Set(disabledReachKeys ?? []), [disabledReachKeys]);
+
+  const items = React.useMemo(() => {
+    const itemDisabled = (key: ReachType) => Boolean(disabled) || disabledReachSet.has(key);
+    return [
       {
         key: REACH.ALL,
         label: t('all'),
         icon: Radio,
-        disabled,
+        ...(itemDisabled(REACH.ALL) ? { disabled: true as const } : {}),
       },
       {
         key: REACH.FOLLOWING,
         label: t('following'),
         icon: UsersRound2,
-        disabled,
+        ...(itemDisabled(REACH.FOLLOWING) ? { disabled: true as const } : {}),
       },
       {
         key: REACH.FRIENDS,
         label: t('friends'),
         icon: HeartHandshake,
-        disabled,
+        ...(itemDisabled(REACH.FRIENDS) ? { disabled: true as const } : {}),
       },
-    ],
-    [t, disabled],
-  );
+    ];
+  }, [t, disabled, disabledReachSet]);
   return (
     <FilterRadioGroup
       title={t('title')}

--- a/src/components/molecules/Filters/FilterReach/FilterReach.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.tsx
@@ -24,9 +24,8 @@ export function FilterReach({
   disabledReachKeys,
 }: FilterReachProps) {
   const t = useTranslations('filters.reach');
-  const disabledReachSet = React.useMemo(() => new Set(disabledReachKeys ?? []), [disabledReachKeys]);
-
   const items = React.useMemo(() => {
+    const disabledReachSet = new Set(disabledReachKeys ?? []);
     const itemDisabled = (key: ReachType) => Boolean(disabled) || disabledReachSet.has(key);
     return [
       {
@@ -48,7 +47,7 @@ export function FilterReach({
         ...(itemDisabled(REACH.FRIENDS) ? { disabled: true as const } : {}),
       },
     ];
-  }, [t, disabled, disabledReachSet]);
+  }, [t, disabled, disabledReachKeys]);
   return (
     <FilterRadioGroup
       title={t('title')}

--- a/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx
+++ b/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx
@@ -62,6 +62,26 @@ describe('HomeFeedRightSidebar', () => {
     expect(screen.getByTestId('feedback-card')).toBeInTheDocument();
   });
 
+  it('hides WhoToFollow and FeedbackCard for guests when guestPublicExplore', () => {
+    authState.currentUserPubky = null;
+    render(<HomeFeedRightSidebar guestPublicExplore />);
+
+    expect(screen.queryByTestId('who-to-follow')).not.toBeInTheDocument();
+    expect(screen.getByTestId('active-users')).toBeInTheDocument();
+    expect(screen.getByTestId('hot-tags')).toBeInTheDocument();
+    expect(screen.queryByTestId('feedback-card')).not.toBeInTheDocument();
+  });
+
+  it('shows all blocks for signed-in user when guestPublicExplore', () => {
+    authState.currentUserPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
+    render(<HomeFeedRightSidebar guestPublicExplore />);
+
+    expect(screen.getByTestId('who-to-follow')).toBeInTheDocument();
+    expect(screen.getByTestId('active-users')).toBeInTheDocument();
+    expect(screen.getByTestId('hot-tags')).toBeInTheDocument();
+    expect(screen.getByTestId('feedback-card')).toBeInTheDocument();
+  });
+
   it('matches snapshot', () => {
     const { container } = render(<HomeFeedRightSidebar />);
     expect(container).toMatchSnapshot();
@@ -76,6 +96,16 @@ describe('HomeFeedRightDrawer', () => {
     expect(screen.getByTestId('active-users')).toBeInTheDocument();
     expect(screen.getByTestId('hot-tags')).toBeInTheDocument();
     expect(screen.getByTestId('feedback-card')).toBeInTheDocument();
+  });
+
+  it('hides WhoToFollow and FeedbackCard for guests when guestPublicExplore', () => {
+    authState.currentUserPubky = null;
+    render(<HomeFeedRightDrawer guestPublicExplore />);
+
+    expect(screen.queryByTestId('who-to-follow')).not.toBeInTheDocument();
+    expect(screen.getByTestId('active-users')).toBeInTheDocument();
+    expect(screen.getByTestId('hot-tags')).toBeInTheDocument();
+    expect(screen.queryByTestId('feedback-card')).not.toBeInTheDocument();
   });
 
   it('matches snapshot', () => {

--- a/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx
+++ b/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   HomeFeedRightDrawer,
   HomeFeedRightDrawerMobile,
@@ -7,6 +7,14 @@ import {
   HotFeedRightDrawer,
   HotFeedRightSidebar,
 } from './FeedRightSidebar';
+
+const { authState } = vi.hoisted(() => ({
+  authState: { currentUserPubky: null as string | null },
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}));
 
 // Mock Molecules
 vi.mock('@/molecules/FeedSection/FeedSection', () => {
@@ -38,6 +46,10 @@ vi.mock('@/organisms/WhoToFollowSidebar/WhoToFollowSidebar', () => {
   return {
     WhoToFollowSidebar: () => <div data-testid="who-to-follow">WhoToFollowSidebar</div>,
   };
+});
+
+beforeEach(() => {
+  authState.currentUserPubky = null;
 });
 
 describe('HomeFeedRightSidebar', () => {
@@ -86,28 +98,60 @@ describe('HomeFeedRightDrawerMobile', () => {
 });
 
 describe('HotFeedRightSidebar', () => {
-  it('renders WhoToFollow and FeedbackCard', () => {
+  it('hides WhoToFollow and FeedbackCard when logged out', () => {
+    authState.currentUserPubky = null;
+    render(<HotFeedRightSidebar />);
+
+    expect(screen.queryByTestId('who-to-follow')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feedback-card')).not.toBeInTheDocument();
+  });
+
+  it('shows WhoToFollow and FeedbackCard when authenticated', () => {
+    authState.currentUserPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
     render(<HotFeedRightSidebar />);
 
     expect(screen.getByTestId('who-to-follow')).toBeInTheDocument();
     expect(screen.getByTestId('feedback-card')).toBeInTheDocument();
   });
 
-  it('matches snapshot', () => {
+  it('matches snapshot when logged out', () => {
+    authState.currentUserPubky = null;
+    const { container } = render(<HotFeedRightSidebar />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot when authenticated', () => {
+    authState.currentUserPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
     const { container } = render(<HotFeedRightSidebar />);
     expect(container).toMatchSnapshot();
   });
 });
 
 describe('HotFeedRightDrawer', () => {
-  it('renders WhoToFollow and FeedbackCard', () => {
+  it('hides WhoToFollow and FeedbackCard when logged out', () => {
+    authState.currentUserPubky = null;
+    render(<HotFeedRightDrawer />);
+
+    expect(screen.queryByTestId('who-to-follow')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feedback-card')).not.toBeInTheDocument();
+  });
+
+  it('shows WhoToFollow and FeedbackCard when authenticated', () => {
+    authState.currentUserPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
     render(<HotFeedRightDrawer />);
 
     expect(screen.getByTestId('who-to-follow')).toBeInTheDocument();
     expect(screen.getByTestId('feedback-card')).toBeInTheDocument();
   });
 
-  it('matches snapshot', () => {
+  it('matches snapshot when logged out', () => {
+    authState.currentUserPubky = null;
+    const { container } = render(<HotFeedRightDrawer />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot when authenticated', () => {
+    authState.currentUserPubky = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
     const { container } = render(<HotFeedRightDrawer />);
     expect(container).toMatchSnapshot();
   });

--- a/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx.snap
+++ b/src/components/organisms/FeedRightSidebar/FeedRightSidebar.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`HomeFeedRightSidebar > matches snapshot 1`] = `
 </div>
 `;
 
-exports[`HotFeedRightDrawer > matches snapshot 1`] = `
+exports[`HotFeedRightDrawer > matches snapshot when authenticated 1`] = `
 <div>
   <div
     class="flex flex-col gap-6"
@@ -85,7 +85,9 @@ exports[`HotFeedRightDrawer > matches snapshot 1`] = `
 </div>
 `;
 
-exports[`HotFeedRightSidebar > matches snapshot 1`] = `
+exports[`HotFeedRightDrawer > matches snapshot when logged out 1`] = `<div />`;
+
+exports[`HotFeedRightSidebar > matches snapshot when authenticated 1`] = `
 <div>
   <div
     data-testid="who-to-follow"
@@ -104,3 +106,5 @@ exports[`HotFeedRightSidebar > matches snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`HotFeedRightSidebar > matches snapshot when logged out 1`] = `<div />`;

--- a/src/components/organisms/FeedRightSidebar/FeedRightSidebar.tsx
+++ b/src/components/organisms/FeedRightSidebar/FeedRightSidebar.tsx
@@ -11,6 +11,7 @@
 import { Pencil, UsersRound } from 'lucide-react';
 import { Container } from '@/atoms/Container/Container';
 import { FeedSection } from '@/molecules/FeedSection/FeedSection';
+import { useAuthStore } from '@/stores/auth/auth.store';
 import { ActiveUsers } from '../ActiveUsers/ActiveUsers';
 import { FeedbackCard } from '../FeedbackCard/FeedbackCard';
 import { HotTags } from '../HotTags/HotTags';
@@ -85,33 +86,44 @@ export function HomeFeedRightDrawerMobile() {
 // Hot Feed Right Sidebar Components
 // ============================================================================
 
-/**
- * HotFeedRightSidebar
- *
- * Right sidebar for Hot feed - displays WhoToFollow, FeedbackCard.
- * Desktop version with sticky positioning.
- */
-export function HotFeedRightSidebar() {
-  return (
-    <>
-      <WhoToFollowSidebar />
-      <Container overrideDefaults className="sticky top-[100px] self-start">
-        <FeedbackCard />
-      </Container>
-    </>
-  );
-}
-
-/**
- * HotFeedRightDrawer
- *
- * Right drawer for Hot feed (tablet/mobile) - displays WhoToFollow, FeedbackCard.
- */
-export function HotFeedRightDrawer() {
+function AuthenticatedHotRightContent({ layout }: { layout: 'sidebar' | 'drawer' }) {
+  if (layout === 'sidebar') {
+    return (
+      <>
+        <WhoToFollowSidebar />
+        <Container overrideDefaults className="sticky top-[100px] self-start">
+          <FeedbackCard />
+        </Container>
+      </>
+    );
+  }
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
       <WhoToFollowSidebar />
       <FeedbackCard />
     </Container>
   );
+}
+
+/**
+ * HotFeedRightSidebar
+ *
+ * Right sidebar for Hot feed — WhoToFollow and FeedbackCard when signed in only.
+ * Logged-out /hot avoids login-centric sidebar blocks (public explore).
+ */
+export function HotFeedRightSidebar() {
+  const isAuthenticated = useAuthStore((state) => Boolean(state.currentUserPubky));
+  if (!isAuthenticated) return null;
+  return <AuthenticatedHotRightContent layout="sidebar" />;
+}
+
+/**
+ * HotFeedRightDrawer
+ *
+ * Right drawer for Hot feed (tablet/mobile) — same content policy as sidebar.
+ */
+export function HotFeedRightDrawer() {
+  const isAuthenticated = useAuthStore((state) => Boolean(state.currentUserPubky));
+  if (!isAuthenticated) return null;
+  return <AuthenticatedHotRightContent layout="drawer" />;
 }

--- a/src/components/organisms/FeedRightSidebar/FeedRightSidebar.tsx
+++ b/src/components/organisms/FeedRightSidebar/FeedRightSidebar.tsx
@@ -1,13 +1,5 @@
 'use client';
-// ============================================================================
-// Shared Components
-// ============================================================================
-/**
- * HomeFeedContent
- *
- * Shared content for Home feed sidebars - WhoToFollow, ActiveUsers, HotTags, FeedbackCard.
- * Used by both HomeFeedRightSidebar (desktop) and HomeFeedRightDrawer (tablet).
- */
+
 import { Pencil, UsersRound } from 'lucide-react';
 import { Container } from '@/atoms/Container/Container';
 import { FeedSection } from '@/molecules/FeedSection/FeedSection';
@@ -17,16 +9,36 @@ import { FeedbackCard } from '../FeedbackCard/FeedbackCard';
 import { HotTags } from '../HotTags/HotTags';
 import { WhoToFollowSidebar } from '../WhoToFollowSidebar/WhoToFollowSidebar';
 
-function HomeFeedContent() {
+// ============================================================================
+// Shared Components
+// ============================================================================
+/**
+ * Shared content for Home feed sidebars - WhoToFollow, ActiveUsers, HotTags, FeedbackCard.
+ * Used by both HomeFeedRightSidebar (desktop) and HomeFeedRightDrawer (tablet).
+ *
+ * With `guestPublicExplore`: logged-out viewers skip WhoToFollow and FeedbackCard
+ * (same policy as Hot), but still see ActiveUsers and HotTags.
+ */
+function HomeFeedContent({ guestPublicExplore = false }: { guestPublicExplore?: boolean }) {
+  const isAuthenticated = useAuthStore((state) => Boolean(state.currentUserPubky));
+  const hideSignupSidebarBlocks = guestPublicExplore && !isAuthenticated;
+
   return (
     <>
-      <WhoToFollowSidebar />
+      {!hideSignupSidebarBlocks && <WhoToFollowSidebar />}
       <ActiveUsers />
       <HotTags />
-      <FeedbackCard />
+      {!hideSignupSidebarBlocks && <FeedbackCard />}
     </>
   );
 }
+
+export type HomeFeedRightPanelProps = {
+  /**
+   * When true, anonymous users on this surface (e.g. /search) do not see WhoToFollow or FeedbackCard.
+   */
+  guestPublicExplore?: boolean;
+};
 
 // ============================================================================
 // Home Feed Right Sidebar Components
@@ -38,8 +50,8 @@ function HomeFeedContent() {
  * Right sidebar for Home feed - displays WhoToFollow, ActiveUsers, HotTags, FeedbackCard.
  * Desktop version.
  */
-export function HomeFeedRightSidebar() {
-  return <HomeFeedContent />;
+export function HomeFeedRightSidebar({ guestPublicExplore = false }: HomeFeedRightPanelProps) {
+  return <HomeFeedContent guestPublicExplore={guestPublicExplore} />;
 }
 
 /**
@@ -47,10 +59,10 @@ export function HomeFeedRightSidebar() {
  *
  * Right drawer for Home feed (tablet) - displays WhoToFollow, ActiveUsers, HotTags, FeedbackCard.
  */
-export function HomeFeedRightDrawer() {
+export function HomeFeedRightDrawer({ guestPublicExplore = false }: HomeFeedRightPanelProps) {
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
-      <HomeFeedContent />
+      <HomeFeedContent guestPublicExplore={guestPublicExplore} />
     </Container>
   );
 }

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.test.tsx
@@ -1,16 +1,57 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { REACH } from '@/stores/home/home.types';
 import { TIMEFRAME } from '@/stores/hot/hot.types';
 import { FilterTimeframe, HotFeedDrawer, HotFeedSidebar } from './HotFeedFilters';
 
-// Mock store
-vi.mock('@/stores/hot/hot.store', () => ({
-  useHotStore: vi.fn(() => ({
-    reach: 'all',
-    setReach: vi.fn(),
+const { authPubkyRef, filterReachLastProps, hotStoreMock } = vi.hoisted(() => {
+  const authPubkyRef = { current: null as string | null };
+  const filterReachLastProps = { current: null as Record<string, unknown> | null };
+  let reach = 'all';
+  const setReach = vi.fn((r: string) => {
+    reach = r;
+  });
+  const hotStoreMock = {
+    get reach() {
+      return reach;
+    },
+    setReach,
     timeframe: 'today',
     setTimeframe: vi.fn(),
+    resetReach(r = 'all') {
+      reach = r;
+    },
+    resetMocks() {
+      reach = REACH.ALL;
+      setReach.mockClear();
+      hotStoreMock.setTimeframe.mockClear();
+    },
+  };
+  return { authPubkyRef, filterReachLastProps, hotStoreMock };
+});
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: vi.fn((selector: (s: { currentUserPubky: string | null }) => unknown) =>
+    selector({ currentUserPubky: authPubkyRef.current }),
+  ),
+}));
+
+vi.mock('@/stores/hot/hot.store', () => ({
+  useHotStore: vi.fn(() => ({
+    get reach() {
+      return hotStoreMock.reach;
+    },
+    setReach: hotStoreMock.setReach,
+    timeframe: hotStoreMock.timeframe,
+    setTimeframe: hotStoreMock.setTimeframe,
   })),
+}));
+
+vi.mock('@/molecules/Filters/FilterReach/FilterReach', () => ({
+  FilterReach: (props: Record<string, unknown>) => {
+    filterReachLastProps.current = props;
+    return <div data-testid="filter-reach">FilterReach</div>;
+  },
 }));
 
 // Mock Atoms
@@ -43,13 +84,6 @@ vi.mock('@/atoms/Filter/Filter', () => {
   };
 });
 
-// Mock Molecules
-vi.mock('@/molecules/Filters/FilterReach/FilterReach', () => {
-  return {
-    FilterReach: () => <div data-testid="filter-reach">FilterReach</div>,
-  };
-});
-
 describe('FilterTimeframe', () => {
   it('renders all timeframe options', () => {
     render(<FilterTimeframe />);
@@ -75,11 +109,42 @@ describe('FilterTimeframe', () => {
 });
 
 describe('HotFeedSidebar', () => {
+  beforeEach(() => {
+    authPubkyRef.current = null;
+    hotStoreMock.resetMocks();
+    filterReachLastProps.current = null;
+  });
+
   it('renders FilterReach and FilterTimeframe', () => {
     render(<HotFeedSidebar />);
 
     expect(screen.getByTestId('filter-reach')).toBeInTheDocument();
     expect(screen.getByText('Today')).toBeInTheDocument();
+  });
+
+  it('passes disabledReachKeys when logged out', () => {
+    authPubkyRef.current = null;
+    render(<HotFeedSidebar />);
+
+    expect(filterReachLastProps.current?.disabledReachKeys).toEqual([REACH.FOLLOWING, REACH.FRIENDS]);
+  });
+
+  it('does not pass disabledReachKeys when logged in', () => {
+    authPubkyRef.current = 'gujx6qd8ksydh1makdphd3bxu351d9b8waqka8hfg6q7hnqkxexo';
+    render(<HotFeedSidebar />);
+
+    expect(filterReachLastProps.current?.disabledReachKeys).toBeUndefined();
+  });
+
+  it('resets reach to all when logged out and reach was following', async () => {
+    authPubkyRef.current = null;
+    hotStoreMock.resetReach(REACH.FOLLOWING);
+
+    render(<HotFeedSidebar />);
+
+    await waitFor(() => {
+      expect(hotStoreMock.setReach).toHaveBeenCalledWith(REACH.ALL);
+    });
   });
 
   it('matches snapshot', () => {
@@ -89,11 +154,24 @@ describe('HotFeedSidebar', () => {
 });
 
 describe('HotFeedDrawer', () => {
+  beforeEach(() => {
+    authPubkyRef.current = null;
+    hotStoreMock.resetMocks();
+    filterReachLastProps.current = null;
+  });
+
   it('renders FilterReach and FilterTimeframe', () => {
     render(<HotFeedDrawer />);
 
     expect(screen.getByTestId('filter-reach')).toBeInTheDocument();
     expect(screen.getByText('Today')).toBeInTheDocument();
+  });
+
+  it('passes disabledReachKeys when logged out', () => {
+    authPubkyRef.current = null;
+    render(<HotFeedDrawer />);
+
+    expect(filterReachLastProps.current?.disabledReachKeys).toEqual([REACH.FOLLOWING, REACH.FRIENDS]);
   });
 
   it('matches snapshot', () => {

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Calendar, CalendarRange, Clock, Star } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {
@@ -11,6 +12,8 @@ import {
   FilterRoot,
 } from '@/atoms/Filter/Filter';
 import { FilterReach } from '@/molecules/Filters/FilterReach/FilterReach';
+import { useAuthStore } from '@/stores/auth/auth.store';
+import { REACH } from '@/stores/home/home.types';
 import { useHotStore } from '@/stores/hot/hot.store';
 import { TIMEFRAME, type TimeframeType } from '@/stores/hot/hot.types';
 
@@ -82,6 +85,39 @@ export function FilterTimeframe({ selectedTab = TIMEFRAME.THIS_MONTH, onTabChang
 // Sidebar & Drawer Components
 // ============================================================================
 
+function HotReachAndTimeframeFilters({ variant }: { variant: 'sidebar' | 'drawer' }) {
+  const { reach, setReach, timeframe, setTimeframe } = useHotStore();
+  const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
+
+  useEffect(() => {
+    if (currentUserPubky) return;
+    if (reach === REACH.FOLLOWING || reach === REACH.FRIENDS) {
+      setReach(REACH.ALL);
+    }
+  }, [currentUserPubky, reach, setReach]);
+
+  const disabledReachKeys = currentUserPubky ? undefined : ([REACH.FOLLOWING, REACH.FRIENDS] as const);
+
+  const reachFilter = <FilterReach selectedTab={reach} onTabChange={setReach} disabledReachKeys={disabledReachKeys} />;
+  const timeframeFilter = <FilterTimeframe selectedTab={timeframe} onTabChange={setTimeframe} />;
+
+  if (variant === 'sidebar') {
+    return (
+      <>
+        {reachFilter}
+        <div className="sticky top-[100px] w-full self-start">{timeframeFilter}</div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {reachFilter}
+      {timeframeFilter}
+    </>
+  );
+}
+
 /**
  * HotFeedSidebar
  *
@@ -90,15 +126,7 @@ export function FilterTimeframe({ selectedTab = TIMEFRAME.THIS_MONTH, onTabChang
  * Desktop version with sticky positioning.
  */
 export function HotFeedSidebar() {
-  const { reach, setReach, timeframe, setTimeframe } = useHotStore();
-  return (
-    <>
-      <FilterReach selectedTab={reach} onTabChange={setReach} />
-      <div className="sticky top-[100px] w-full self-start">
-        <FilterTimeframe selectedTab={timeframe} onTabChange={setTimeframe} />
-      </div>
-    </>
-  );
+  return <HotReachAndTimeframeFilters variant="sidebar" />;
 }
 
 /**
@@ -108,11 +136,9 @@ export function HotFeedSidebar() {
  * Uses the hot store for state management.
  */
 export function HotFeedDrawer() {
-  const { reach, setReach, timeframe, setTimeframe } = useHotStore();
   return (
     <div className="flex flex-col gap-6">
-      <FilterReach selectedTab={reach} onTabChange={setReach} />
-      <FilterTimeframe selectedTab={timeframe} onTabChange={setTimeframe} />
+      <HotReachAndTimeframeFilters variant="drawer" />
     </div>
   );
 }

--- a/src/components/templates/Feed/Search/Search.test.tsx
+++ b/src/components/templates/Feed/Search/Search.test.tsx
@@ -5,6 +5,15 @@ import { Search } from './Search';
 const mockUseIsMobile = vi.fn(() => false);
 const mockUseSearchTags = vi.fn(() => ['pubky']);
 
+const { mockHomeFeedRightSidebar, mockHomeFeedRightDrawer } = vi.hoisted(() => ({
+  mockHomeFeedRightSidebar: vi.fn((_props?: { guestPublicExplore?: boolean }) => (
+    <div data-testid="home-feed-right-sidebar">HomeFeedRightSidebar</div>
+  )),
+  mockHomeFeedRightDrawer: vi.fn((_props?: { guestPublicExplore?: boolean }) => (
+    <div data-testid="home-feed-right-drawer">HomeFeedRightDrawer</div>
+  )),
+}));
+
 vi.mock('@/hooks/useIsMobile/useIsMobile', () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
@@ -15,8 +24,20 @@ vi.mock('@/hooks/useSearchStreamId/useSearchStreamId', () => ({
 
 vi.mock('@/organisms/ContentLayout/ContentLayout', () => {
   return {
-    ContentLayout: ({ children, feedVariant }: { children: React.ReactNode; feedVariant?: string }) => (
+    ContentLayout: ({
+      children,
+      feedVariant,
+      rightSidebarContent,
+      rightDrawerContent,
+    }: {
+      children: React.ReactNode;
+      feedVariant?: string;
+      rightSidebarContent?: React.ReactNode;
+      rightDrawerContent?: React.ReactNode;
+    }) => (
       <div data-testid="content-layout" data-feed-variant={feedVariant}>
+        {rightSidebarContent}
+        {rightDrawerContent}
         {children}
       </div>
     ),
@@ -29,12 +50,10 @@ vi.mock('@/organisms/DialogWelcome/DialogWelcome', () => {
   };
 });
 
-vi.mock('@/organisms/FeedRightSidebar/FeedRightSidebar', () => {
-  return {
-    HomeFeedRightSidebar: () => <div data-testid="home-feed-right-sidebar">HomeFeedRightSidebar</div>,
-    HomeFeedRightDrawer: () => <div data-testid="home-feed-right-drawer">HomeFeedRightDrawer</div>,
-  };
-});
+vi.mock('@/organisms/FeedRightSidebar/FeedRightSidebar', () => ({
+  HomeFeedRightSidebar: (props: { guestPublicExplore?: boolean }) => mockHomeFeedRightSidebar(props),
+  HomeFeedRightDrawer: (props: { guestPublicExplore?: boolean }) => mockHomeFeedRightDrawer(props),
+}));
 
 vi.mock('@/organisms/HomeFeedSidebar/HomeFeedSidebar', () => {
   return {
@@ -97,6 +116,13 @@ describe('Search', () => {
     render(<Search />);
 
     expect(screen.getByTestId('content-layout')).toHaveAttribute('data-feed-variant', 'search');
+  });
+
+  it('requests guest explore chrome on home right panels so anonymous users skip signup-heavy blocks', () => {
+    render(<Search />);
+
+    expect(mockHomeFeedRightSidebar).toHaveBeenCalledWith(expect.objectContaining({ guestPublicExplore: true }));
+    expect(mockHomeFeedRightDrawer).toHaveBeenCalledWith(expect.objectContaining({ guestPublicExplore: true }));
   });
 
   it('renders search results when tags are present', () => {

--- a/src/components/templates/Feed/Search/Search.tsx
+++ b/src/components/templates/Feed/Search/Search.tsx
@@ -23,6 +23,7 @@ import { TimelineFeed } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFee
  * - Displays search results when tags are provided
  * - Shows empty state when no tags in URL
  * - Reuses HomeFeedSidebar for sort/content filters
+ * - Right panel omits Who to follow / feedback for anonymous users (guestPublicExplore)
  * - Uses TimelineFeed with SEARCH variant for infinite scroll
  * - Shows SearchInput on mobile (hidden on desktop where it's in the header)
  */
@@ -41,11 +42,11 @@ export function Search() {
         leftSidebarContent={
           <HomeFeedSidebar hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.SEARCH} />
         }
-        rightSidebarContent={<HomeFeedRightSidebar />}
+        rightSidebarContent={<HomeFeedRightSidebar guestPublicExplore />}
         leftDrawerContent={
           <HomeFeedDrawer hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.SEARCH} />
         }
-        rightDrawerContent={<HomeFeedRightDrawer />}
+        rightDrawerContent={<HomeFeedRightDrawer guestPublicExplore />}
         leftDrawerContentMobile={
           <HomeFeedDrawerMobile hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.SEARCH} />
         }

--- a/src/hooks/usePublicRoute/usePublicRoute.test.tsx
+++ b/src/hooks/usePublicRoute/usePublicRoute.test.tsx
@@ -40,6 +40,22 @@ describe('usePublicRoute', () => {
 
       expect(result.current.isPublicRoute).toBe(true);
     });
+
+    it('returns isPublicRoute: true for /hot', () => {
+      mockPathname.mockReturnValue('/hot');
+
+      const { result } = renderHook(() => usePublicRoute());
+
+      expect(result.current.isPublicRoute).toBe(true);
+    });
+
+    it('returns isPublicRoute: true for /search', () => {
+      mockPathname.mockReturnValue('/search');
+
+      const { result } = renderHook(() => usePublicRoute());
+
+      expect(result.current.isPublicRoute).toBe(true);
+    });
   });
 
   describe('non-public routes', () => {

--- a/src/hooks/usePublicRoute/usePublicRoute.ts
+++ b/src/hooks/usePublicRoute/usePublicRoute.ts
@@ -2,17 +2,16 @@
 
 import { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
-import { isDynamicPublicRoute } from '@/app/routes';
+import { isExplorePublicRoute } from '@/app/routes';
 import type { UsePublicRouteResult } from './usePublicRoute.types';
 
 export type { UsePublicRouteResult } from './usePublicRoute.types';
 
 /**
- * Hook for checking if the current route is a dynamic public route.
+ * Hook for checking if the current route is a public browse surface.
  *
- * Dynamic public routes are routes that should be accessible without authentication:
- * - /post/[userId]/[postId] - viewing a single post
- * - /profile/[pubky] - viewing another user's profile
+ * Includes dynamic public routes (single post, another user's profile) plus
+ * /hot and /search for logged-out exploration.
  *
  * This hook only handles route awareness. It does NOT check authentication status.
  * Use this in combination with `useRequireAuth` when you need both.
@@ -20,7 +19,7 @@ export type { UsePublicRouteResult } from './usePublicRoute.types';
 export function usePublicRoute(): UsePublicRouteResult {
   const pathname = usePathname();
 
-  const isPublicRoute = useMemo(() => isDynamicPublicRoute(pathname), [pathname]);
+  const isPublicRoute = useMemo(() => isExplorePublicRoute(pathname), [pathname]);
 
   return { isPublicRoute };
 }

--- a/src/hooks/usePublicRoute/usePublicRoute.types.ts
+++ b/src/hooks/usePublicRoute/usePublicRoute.types.ts
@@ -1,7 +1,7 @@
 export interface UsePublicRouteResult {
   /**
-   * Whether the current route is a dynamic public route.
-   * True for routes like /post/[userId]/[postId] and /profile/[pubky].
+   * Whether the current route uses public browse chrome (logged-out explorers).
+   * True for dynamic public routes (e.g. /post/..., /profile/<pubky>) plus /hot and /search.
    */
   isPublicRoute: boolean;
 }


### PR DESCRIPTION
Allow unauthenticated access to /hot and /search via PUBLIC_ROUTES and isExplorePublicRoute so header and mobile footer match other browse-only surfaces. Hot Following and Friends reach options are disabled without a session, with reach reset to All when logged out. Hide Who to follow and feedback sidebar on Hot for logged-out viewers. FilterReach supports disabledReachKeys without changing enabled-item snapshots.