### PR TITLE
fix(tags): protect viewer's toggled tag from stale Nexus merges (#1781)

### DIFF
--- a/docs/adr/0001-local-first-writes.md
+++ b/docs/adr/0001-local-first-writes.md
@@ -41,12 +41,19 @@ The suffix indicates the mutation shape:
 
 This naming pattern aligns controller APIs with the local-first write model defined in this ADR.
 
+### Indexer lag and viewer-owned state
+
+Reads are served by Nexus, which indexes the homeserver asynchronously and can lag it by minutes. A background fetch landing after a viewer's local mutation may therefore carry pre-mutation state. For fields the viewer just changed, **Nexus must not be trusted blindly** — reconciliation has to preserve the viewer's intent until the indexer catches up.
+
+Currently applied to the tag feature (see `src/core/services/local/tag/post/`). The same constraint applies to any future local-first write whose read side goes through Nexus.
+
 ## Consequences
 
 - ✅ Perceived responsiveness stays high; UI reflects the local intent instantly.
 - ✅ Offline edits and intermittent connectivity are supported without special UI flows.
 - ⚠️ Requires reconciliation logic for conflicts, retries, and TTL/expiry management.
 - ⚠️ Local data can momentarily diverge from server truth until synchronization completes.
+- ⚠️ Nexus indexer lag can produce snap-back of viewer-owned state; reconciliation must preserve the viewer's intent (see "Indexer lag and viewer-owned state").
 
 ## Alternatives Considered
 

--- a/src/config/viewerTagMarker.ts
+++ b/src/config/viewerTagMarker.ts
@@ -1,0 +1,10 @@
+/**
+ * Wall-clock TTL for viewer-mutation markers in sessionStorage.
+ * Roughly the Nexus indexer lag window — after this, any Nexus response
+ * is assumed to reflect the viewer's mutation, so the marker no longer
+ * needs to protect anything.
+ */
+export const MARKER_TTL_MS = 300_000;
+
+/** Prefix for sessionStorage keys storing viewer-mutation markers. */
+export const VIEWER_TAG_MARKER_STORAGE_PREFIX = 'pubky-app:viewer-tag-marker:';

--- a/src/core/application/post/post.ts
+++ b/src/core/application/post/post.ts
@@ -91,7 +91,7 @@ export class PostApplication {
 
     // Persist new tags to local DB (merge with existing)
     if (nexusTags.length > 0) {
-      await LocalPostTagService.mergeTags({ postId: compositeId, tags: nexusTags });
+      await LocalPostTagService.mergeTags({ postId: compositeId, tags: nexusTags, viewerId: viewerId ?? null });
     }
 
     return nexusTags;

--- a/src/core/application/tag/tag.test.ts
+++ b/src/core/application/tag/tag.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TagKind } from '@/application/tag/tag.types';
+import { ClientErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
 import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 import { LocalPostTagService } from '@/services/local/tag/post/tag.post';
+import { ViewerTagMarkerStorage } from '@/services/local/tag/post/viewerTagMarkerStorage';
 import { LocalUserTagService } from '@/services/local/tag/user/tag.user';
 import { TagApplication } from './tag';
 import type { TCreateTagInput, TDeleteTagInput } from './tag.types';
@@ -14,6 +18,14 @@ vi.mock('@/services/homeserver/homeserver', () => ({
     request: vi.fn(),
   },
 }));
+
+// Build a real AppError for the relevant client status so the layered
+// `error instanceof AppError && error.code === ...` checks pass.
+const httpError = (code: ClientErrorCode, operation: string) =>
+  Err.client(code, code, {
+    service: ErrorService.Homeserver,
+    operation,
+  });
 
 describe('Tag Application', () => {
   // Test data factory
@@ -250,6 +262,34 @@ describe('Tag Application', () => {
 
       expect(deleteSpy).toHaveBeenCalledOnce();
       expect(requestSpy).not.toHaveBeenCalled();
+    });
+
+    it('should treat 404 (Not Found) as already-deleted and skip rollback', async () => {
+      const mockData = createMockDeleteData();
+      const { createSpy, deleteSpy, requestSpy } = setupMocks();
+
+      deleteSpy.mockResolvedValue(true);
+      // Tag URL is content-addressed; 404 means the exact tag is already gone on HS.
+      requestSpy.mockRejectedValue(httpError(ClientErrorCode.NOT_FOUND, 'commitDelete'));
+
+      // Should resolve, not throw — local delete is already correct.
+      await TagApplication.commitDelete(mockData);
+
+      expect(deleteSpy).toHaveBeenCalledOnce();
+      expect(requestSpy).toHaveBeenCalledOnce();
+      // Without this, rollback re-creates the tag and the user is stuck with a
+      // ghost tag they can't remove (HS keeps returning 404 on every retry).
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearViewerMarkers', () => {
+    it('delegates to ViewerTagMarkerStorage.clearForUser', () => {
+      const spy = vi.spyOn(ViewerTagMarkerStorage, 'clearForUser').mockImplementation(() => {});
+
+      TagApplication.clearViewerMarkers('user-pubky' as Pubky);
+
+      expect(spy).toHaveBeenCalledWith('user-pubky');
     });
   });
 });

--- a/src/core/application/tag/tag.ts
+++ b/src/core/application/tag/tag.ts
@@ -1,8 +1,12 @@
 import { TagKind, type TCreateTagListInput, type TDeleteTagInput } from '@/application/tag/tag.types';
+import { AppError } from '@/libs/error/error';
+import { ClientErrorCode } from '@/libs/error/error.codes';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
+import type { Pubky } from '@/models/models.types';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 import { LocalPostTagService } from '@/services/local/tag/post/tag.post';
+import { ViewerTagMarkerStorage } from '@/services/local/tag/post/viewerTagMarkerStorage';
 import { LocalUserTagService } from '@/services/local/tag/user/tag.user';
 
 /**
@@ -84,6 +88,20 @@ export class TagApplication {
       try {
         await HomeserverService.request({ method: HttpMethod.DELETE, url: tagUrl });
       } catch (error) {
+        // 404 means the tag is already gone on the homeserver. Local just made the
+        // same change, so the two states match — accept the delete and skip rollback.
+        // Without this, the rollback re-creates the tag locally and the user is left
+        // with a "ghost" tag they can't remove (HS keeps returning 404).
+        if (error instanceof AppError && error.code === ClientErrorCode.NOT_FOUND) {
+          Logger.warn('[TagApplication.commitDelete] Homeserver returned 404; treating as already deleted', {
+            taggedId,
+            label,
+            taggerId,
+            taggedKind,
+          });
+          return;
+        }
+
         try {
           if (taggedKind === TagKind.POST) {
             await LocalPostTagService.create({ taggerId, taggedId, label });
@@ -103,5 +121,14 @@ export class TagApplication {
         throw error;
       }
     }
+  }
+
+  /**
+   * Clears all viewer-mutation tag markers (sessionStorage) for the given user.
+   * Called from logout / session-cleanup paths to drop stale markers before the
+   * next user signs in on the same tab.
+   */
+  static clearViewerMarkers(pubky: Pubky) {
+    ViewerTagMarkerStorage.clearForUser(pubky);
   }
 }

--- a/src/core/controllers/auth/auth.ts
+++ b/src/core/controllers/auth/auth.ts
@@ -3,6 +3,7 @@ import type { TKeypairParams } from '@/application/auth/auth.types';
 import { BootstrapApplication, type BootstrapProgressCallback } from '@/application/bootstrap/bootstrap';
 import { SettingsApplication } from '@/application/settings/settings';
 import { postStreamQueue } from '@/application/stream/posts/muting/post-stream-queue';
+import { TagApplication } from '@/application/tag/tag';
 import type {
   TLoginWithEncryptedFileParams,
   TLoginWithMnemonicParams,
@@ -255,6 +256,12 @@ export class AuthController {
    * Used by both logout() and restorePersistedSession() on failure.
    */
   private static async cleanupLocalState() {
+    // Capture pubky before resetting auth store; used to scope marker cleanup.
+    const pubky = useAuthStore.getState().currentUserPubky;
+    if (pubky) {
+      TagApplication.clearViewerMarkers(pubky);
+    }
+
     // Reset singletons
     PubkySpecsSingleton.reset();
     TtlCoordinator.resetInstance();

--- a/src/core/services/local/tag/post/tag.post.test.ts
+++ b/src/core/services/local/tag/post/tag.post.test.ts
@@ -1,12 +1,15 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@/database/franky/franky';
+import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';
 import { PostCountsModel } from '@/models/post/counts/postCounts';
 import { PostTagsModel } from '@/models/post/tags/postTags';
 import { PostTtlModel } from '@/models/post/ttl/postTtl';
 import { UserCountsModel } from '@/models/user/counts/userCounts';
 import { LocalPostTagService } from '@/services/local/tag/post/tag.post';
+import { ViewerTagMarkerStorage } from '@/services/local/tag/post/viewerTagMarkerStorage';
 import type { TLocalTagParams } from '@/services/local/tag/tag.types';
+import type { NexusTag } from '@/services/nexus/nexus.types';
 
 // Test data
 const testData = {
@@ -84,6 +87,18 @@ const setupUserCounts = async (userId: Pubky, tagged: number = 0) => {
   });
 };
 
+// Build a Nexus tag payload. Counts default to taggers.length, relationship to false.
+const nexusTag = (
+  label: string,
+  taggers: Pubky[],
+  options: { count?: number; relationship?: boolean } = {},
+): NexusTag => ({
+  label,
+  taggers,
+  taggers_count: options.count ?? taggers.length,
+  relationship: options.relationship ?? false,
+});
+
 describe('LocalTagService', () => {
   beforeEach(async () => {
     await db.initialize();
@@ -97,6 +112,8 @@ describe('LocalTagService', () => {
         await PostTtlModel.table.clear();
       },
     );
+    // Clear viewer-mutation markers so prior tests don't bleed across describes.
+    window.sessionStorage.clear();
   });
 
   describe('create', () => {
@@ -194,6 +211,37 @@ describe('LocalTagService', () => {
       expect(postTtl!.lastUpdatedAt).toBeGreaterThanOrEqual(beforeTimestamp);
       expect(postTtl!.lastUpdatedAt).toBeLessThanOrEqual(afterTimestamp);
     });
+
+    it('should write a PUT marker so mergeTags can protect this change from stale Nexus', async () => {
+      await LocalPostTagService.create(createTagParams('javascript'));
+
+      const marker = ViewerTagMarkerStorage.get({
+        pubky: testData.taggerPubky,
+        postId: testData.postId,
+        label: 'javascript',
+      });
+      expect(marker?.op).toBe(HttpMethod.PUT);
+    });
+
+    it('should not write a marker when create is a no-op (idempotent)', async () => {
+      // Pre-condition: sessionStorage is empty (cleared by beforeEach), so there
+      // is no marker for 'javascript'.
+      // Set up IndexedDB so the viewer already has this tag — make the create
+      // call a no-op. (`setupExistingTag` only touches IndexedDB, not sessionStorage.)
+      await setupExistingTag('javascript', [testData.taggerPubky], true);
+
+      // No-op create: addTagger returns null, the transaction reports `mutated=false`,
+      // and the marker-write branch (`if (mutated)`) is skipped entirely.
+      await LocalPostTagService.create(createTagParams('javascript'));
+
+      // Therefore no marker was ever written — null here means "absent", not "deleted".
+      const marker = ViewerTagMarkerStorage.get({
+        pubky: testData.taggerPubky,
+        postId: testData.postId,
+        label: 'javascript',
+      });
+      expect(marker).toBeNull();
+    });
   });
 
   describe('remove', () => {
@@ -270,6 +318,218 @@ describe('LocalTagService', () => {
       expect(postTtl).toBeTruthy();
       expect(postTtl!.lastUpdatedAt).toBeGreaterThanOrEqual(beforeTimestamp);
       expect(postTtl!.lastUpdatedAt).toBeLessThanOrEqual(afterTimestamp);
+    });
+
+    it('should write a DELETE marker so mergeTags can protect this change from stale Nexus', async () => {
+      await LocalPostTagService.delete(createRemoveParams('javascript'));
+
+      const marker = ViewerTagMarkerStorage.get({
+        pubky: testData.taggerPubky,
+        postId: testData.postId,
+        label: 'javascript',
+      });
+      expect(marker?.op).toBe(HttpMethod.DELETE);
+    });
+  });
+
+  describe('mergeTags', () => {
+    it('replaces taggers_count with the Nexus value (Math.max regression check)', async () => {
+      // Pretend local IndexedDB has an outdated count of 5 for this tag.
+      // The old code did Math.max(local, nexus) — it always picked the bigger
+      // number, so a wrong-too-high count like this would never come back down.
+      // The new code must replace local with Nexus's value.
+      await PostTagsModel.upsert({
+        id: testData.postId,
+        tags: [{ label: 'a', taggers: [testData.anotherTaggerPubky], taggers_count: 5, relationship: false }],
+      });
+
+      // Simulate Nexus returning the same tag with `count: 2` (the real value).
+      // `nexusTag(...)` builds a Nexus response payload — `{ count: 2 }` is
+      // what Nexus reports for `taggers_count`.
+      await LocalPostTagService.mergeTags({
+        postId: testData.postId,
+        tags: [nexusTag('a', [testData.anotherTaggerPubky], { count: 2 })],
+        viewerId: testData.taggerPubky,
+      });
+
+      // After merge, local should be 2 (not 5).
+      const saved = await getSavedTags();
+      expect(saved!.tags[0].taggers_count).toBe(2);
+    });
+
+    it('keeps cached other-user taggers that fall outside the Nexus top-N sample', async () => {
+      // Nexus only returns top-N taggers per label, so a flat replace would drop
+      // taggers we have cached but Nexus didn't include in this response.
+      await PostTagsModel.upsert({
+        id: testData.postId,
+        tags: [
+          {
+            label: 'a',
+            taggers: [testData.anotherTaggerPubky, 'extra-tagger' as Pubky],
+            taggers_count: 2,
+            relationship: false,
+          },
+        ],
+      });
+
+      await LocalPostTagService.mergeTags({
+        postId: testData.postId,
+        tags: [nexusTag('a', [testData.anotherTaggerPubky], { count: 2 })],
+        viewerId: testData.taggerPubky,
+      });
+
+      const saved = await getSavedTags();
+      expect(saved!.tags[0].taggers).toContain(testData.anotherTaggerPubky);
+      expect(saved!.tags[0].taggers).toContain('extra-tagger');
+    });
+
+    it('leaves labels missing from the Nexus response alone (pagination safety)', async () => {
+      // Two labels in IndexedDB; Nexus only returned one (e.g., the other is on a
+      // later page). The unseen label must be preserved.
+      await PostTagsModel.upsert({
+        id: testData.postId,
+        tags: [
+          { label: 'a', taggers: [testData.anotherTaggerPubky], taggers_count: 1, relationship: false },
+          { label: 'b', taggers: [testData.anotherTaggerPubky], taggers_count: 1, relationship: false },
+        ],
+      });
+
+      await LocalPostTagService.mergeTags({
+        postId: testData.postId,
+        tags: [nexusTag('a', [testData.anotherTaggerPubky], { count: 1 })],
+        viewerId: testData.taggerPubky,
+      });
+
+      const saved = await getSavedTags();
+      const labels = saved!.tags.map((t) => t.label);
+      expect(labels).toContain('a');
+      expect(labels).toContain('b');
+    });
+
+    describe('viewer marker protection', () => {
+      it('keeps viewer out when DELETE marker conflicts with stale Nexus (viewer still listed)', async () => {
+        // Viewer just removed themselves locally — Nexus hasn't reindexed yet.
+        ViewerTagMarkerStorage.set({
+          pubky: testData.taggerPubky,
+          postId: testData.postId,
+          label: 'a',
+          op: HttpMethod.DELETE,
+        });
+
+        await LocalPostTagService.mergeTags({
+          postId: testData.postId,
+          tags: [nexusTag('a', [testData.taggerPubky], { count: 1, relationship: true })],
+          viewerId: testData.taggerPubky,
+        });
+
+        const saved = await getSavedTags();
+        const tag = saved!.tags[0];
+        // Marker wins for viewer fields. Nexus's count was 1 because it still
+        // counted the viewer; with the viewer taken out, the final count is 0.
+        expect(tag.taggers).not.toContain(testData.taggerPubky);
+        expect(tag.relationship).toBe(false);
+        expect(tag.taggers_count).toBe(0);
+      });
+
+      it('keeps viewer in when PUT marker conflicts with stale Nexus (viewer not listed)', async () => {
+        // Viewer just added themselves locally — Nexus hasn't reindexed yet.
+        ViewerTagMarkerStorage.set({
+          pubky: testData.taggerPubky,
+          postId: testData.postId,
+          label: 'a',
+          op: HttpMethod.PUT,
+        });
+
+        await LocalPostTagService.mergeTags({
+          postId: testData.postId,
+          tags: [nexusTag('a', [testData.anotherTaggerPubky], { count: 1, relationship: false })],
+          viewerId: testData.taggerPubky,
+        });
+
+        const saved = await getSavedTags();
+        const tag = saved!.tags[0];
+        // Marker wins. Nexus's count was 1 because it didn't know the viewer
+        // tagged yet; with the viewer added in, the final count is 2.
+        expect(tag.taggers).toContain(testData.taggerPubky);
+        expect(tag.relationship).toBe(true);
+        expect(tag.taggers_count).toBe(2);
+      });
+
+      it('trusts Nexus when no marker is present', async () => {
+        await LocalPostTagService.mergeTags({
+          postId: testData.postId,
+          tags: [nexusTag('a', [testData.taggerPubky], { count: 1, relationship: true })],
+          viewerId: testData.taggerPubky,
+        });
+
+        const saved = await getSavedTags();
+        expect(saved!.tags[0].relationship).toBe(true);
+        expect(saved!.tags[0].taggers_count).toBe(1);
+      });
+
+      it('skips marker lookup when viewerId is null (unauthenticated viewer)', async () => {
+        // Even if a marker exists for a known user, an unauthenticated merge
+        // ignores it and applies Nexus values as-is.
+        ViewerTagMarkerStorage.set({
+          pubky: testData.taggerPubky,
+          postId: testData.postId,
+          label: 'a',
+          op: HttpMethod.DELETE,
+        });
+
+        await LocalPostTagService.mergeTags({
+          postId: testData.postId,
+          tags: [nexusTag('a', [testData.taggerPubky], { count: 1, relationship: true })],
+          // `viewerId: null` is what the caller passes when no user is logged in.
+          // mergeTags must not look up any marker in this case.
+          viewerId: null,
+        });
+
+        const saved = await getSavedTags();
+        expect(saved!.tags[0].taggers_count).toBe(1);
+        expect(saved!.tags[0].relationship).toBe(true);
+      });
+    });
+
+    it('auto-corrects a previously drifted entry on the next merge', async () => {
+      // Pretend a user's IndexedDB is in a bad state left over from the old code:
+      // it still shows the viewer as a tagger with count = 1, even though the
+      // tag should have been gone by now.
+      await PostTagsModel.upsert({
+        id: testData.postId,
+        tags: [{ label: 'a', taggers: [testData.taggerPubky], taggers_count: 1, relationship: true }],
+      });
+
+      // Important: no marker is set here (and beforeEach cleared sessionStorage).
+      // Without an active marker, mergeTags trusts Nexus directly — that's how
+      // the stale local state gets overwritten with Nexus's correct values below.
+      await LocalPostTagService.mergeTags({
+        postId: testData.postId,
+        // Nexus has caught up: the tag now has no taggers and the viewer is out.
+        tags: [nexusTag('a', [], { count: 0, relationship: false })],
+        viewerId: testData.taggerPubky,
+      });
+
+      const saved = await getSavedTags();
+      const tag = saved!.tags[0];
+      expect(tag.taggers).toHaveLength(0);
+      expect(tag.taggers_count).toBe(0);
+      expect(tag.relationship).toBe(false);
+    });
+
+    it('triggers ViewerTagMarkerStorage.sweepExpired so stale markers do not accumulate', async () => {
+      // Storage-internal cleanup behavior is verified in viewerTagMarkerStorage.test.ts.
+      // Here we only assert that mergeTags wires the sweep call into its flow.
+      const sweepSpy = vi.spyOn(ViewerTagMarkerStorage, 'sweepExpired');
+
+      await LocalPostTagService.mergeTags({
+        postId: testData.postId,
+        tags: [nexusTag('other', [testData.anotherTaggerPubky], { count: 1 })],
+        viewerId: testData.taggerPubky,
+      });
+
+      expect(sweepSpy).toHaveBeenCalled();
+      sweepSpy.mockRestore();
     });
   });
 });

--- a/src/core/services/local/tag/post/tag.post.ts
+++ b/src/core/services/local/tag/post/tag.post.ts
@@ -2,12 +2,14 @@ import { db } from '@/database/franky/franky';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
+import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import type { Pubky } from '@/models/models.types';
 import { PostCountsModel } from '@/models/post/counts/postCounts';
 import { PostTagsModel, type PostTagsModelSchema } from '@/models/post/tags/postTags';
 import { PostTtlModel } from '@/models/post/ttl/postTtl';
 import { UserCountsModel } from '@/models/user/counts/userCounts';
+import { ViewerTagMarkerStorage } from '@/services/local/tag/post/viewerTagMarkerStorage';
 import type { TLocalTagParams } from '@/services/local/tag/tag.types';
 import type { NexusTag } from '@/services/nexus/nexus.types';
 
@@ -33,8 +35,14 @@ export class LocalPostTagService {
    * @throws {DatabaseError} When database operations fail
    */
   static async create({ taggedId: postId, label, taggerId }: TLocalTagParams): Promise<boolean> {
+    // True only when the transaction actually changed IndexedDB state.
+    // We use this to decide whether to write the viewer-mutation marker after
+    // the transaction commits: if nothing changed (e.g., the user already had
+    // this tag), there's no local state to protect from stale Nexus responses,
+    // so we skip the marker.
+    let mutated = false;
     try {
-      return await db.transaction('rw', this.TAG_TABLES, async () => {
+      mutated = await db.transaction('rw', this.TAG_TABLES, async () => {
         const postTagsModel = await PostTagsModel.getOrCreate<string, PostTagsModelSchema>(postId);
         const status = postTagsModel.addTagger(label, taggerId);
         // Idempotent: user already tagged this post with this label
@@ -57,6 +65,14 @@ export class LocalPostTagService {
         cause: error,
       });
     }
+
+    if (mutated) {
+      // Record this viewer change so mergeTags ignores stale Nexus responses
+      // for the next ~5 minutes (until Nexus catches up).
+      ViewerTagMarkerStorage.set({ pubky: taggerId, postId, label, op: HttpMethod.PUT });
+    }
+
+    return mutated;
   }
 
   /**
@@ -95,7 +111,6 @@ export class LocalPostTagService {
         await UserCountsModel.updateCounts({ userId: taggerId, countChanges: { tagged: -1 } });
         await PostTtlModel.upsert({ id: postId, lastUpdatedAt: Date.now() });
       });
-      return true;
     } catch (error) {
       throw Err.database(DatabaseErrorCode.WRITE_FAILED, 'Failed to delete post tag', {
         service: ErrorService.Local,
@@ -104,6 +119,11 @@ export class LocalPostTagService {
         cause: error,
       });
     }
+
+    // Record this viewer change so mergeTags ignores stale Nexus responses
+    // for the next ~5 minutes (until Nexus catches up).
+    ViewerTagMarkerStorage.set({ pubky: taggerId, postId, label, op: HttpMethod.DELETE });
+    return true;
   }
 
   /**
@@ -147,13 +167,29 @@ export class LocalPostTagService {
   }
 
   /**
-   * Merges new tags from Nexus with existing local tags.
-   * Updates existing tags or adds new ones without removing any.
+   * Merges Nexus tags into local IndexedDB using a per-field policy:
    *
-   * @param postId - Unique identifier of the post
-   * @param tags - Array of NexusTags to merge
+   * - `taggers_count`: replaced with the Nexus value (Nexus is authoritative
+   *   for the total).
+   * - Viewer's `relationship` and the viewer's entry in `taggers`: an active
+   *   sessionStorage marker (set by `create` / `delete`) overrides; otherwise
+   *   the Nexus value is used.
+   * - Other users in `taggers`: union of existing + Nexus. The Nexus `taggers`
+   *   array is a truncated top-N sample, so replacing would drop locally-cached
+   *   taggers.
+   * - Labels in IndexedDB but not in `tags`: left alone, since Nexus paginates
+   *   by label and absent labels may exist on later pages.
+   *
+   * @param postId - Composite post ID
+   * @param tags - Tags from the Nexus response
+   * @param viewerId - Current viewer pubky for marker lookup. Null when the
+   *   user is unauthenticated, in which case Nexus values are used as-is.
    */
-  static async mergeTags({ postId, tags }: { postId: string; tags: NexusTag[] }) {
+  static async mergeTags({ postId, tags, viewerId }: { postId: string; tags: NexusTag[]; viewerId: Pubky | null }) {
+    // Side-effect GC: drop expired markers across the board so sessionStorage
+    // doesn't accumulate them.
+    ViewerTagMarkerStorage.sweepExpired();
+
     try {
       await db.transaction('rw', [PostTagsModel.table], async () => {
         const existing = await PostTagsModel.findById(postId);
@@ -170,18 +206,40 @@ export class LocalPostTagService {
           const key = newTag.label.toLowerCase();
           const existingTag = tagMap.get(key);
 
-          if (existingTag) {
-            // Merge taggers - combine unique taggers
-            const mergedTaggers = [...new Set([...(existingTag.taggers ?? []), ...(newTag.taggers ?? [])])];
-            tagMap.set(key, {
-              ...existingTag,
-              ...newTag,
-              taggers: mergedTaggers,
-              taggers_count: Math.max(existingTag.taggers_count ?? 0, newTag.taggers_count ?? mergedTaggers.length),
-            });
-          } else {
-            tagMap.set(key, newTag);
+          // If the viewer just toggled this tag locally, the marker tells us
+          // the intended viewer-state — trust it over a possibly stale Nexus
+          // value for the next ~5 minutes.
+          const marker = viewerId ? ViewerTagMarkerStorage.get({ pubky: viewerId, postId, label: newTag.label }) : null;
+          const nexusSaysViewerIsTagger = Boolean(newTag.relationship);
+          const viewerIsTagger = marker ? marker.op === HttpMethod.PUT : nexusSaysViewerIsTagger;
+
+          // Other users: union of existing + Nexus, viewer excluded
+          // (viewer's slot is decided by `viewerIsTagger`).
+          const otherTaggers = new Set(
+            [...(existingTag?.taggers ?? []), ...(newTag.taggers ?? [])].filter((tagger) => tagger !== viewerId),
+          );
+          const mergedTaggers: Pubky[] = Array.from(otherTaggers);
+          if (viewerIsTagger && viewerId) {
+            mergedTaggers.push(viewerId);
           }
+
+          // Default: trust Nexus's count.
+          // Exception: if the marker says the viewer is a tagger but Nexus
+          // doesn't know yet, Nexus's count is one short — add 1. If the marker
+          // says the viewer is NOT a tagger but Nexus still counts them, Nexus's
+          // count is one too high — subtract 1. This keeps `taggers_count`
+          // matching the final `taggers` / `relationship` we write below.
+          let taggers_count = newTag.taggers_count;
+          if (marker && viewerIsTagger !== nexusSaysViewerIsTagger) {
+            taggers_count = viewerIsTagger ? taggers_count + 1 : Math.max(0, taggers_count - 1);
+          }
+
+          tagMap.set(key, {
+            ...newTag,
+            taggers_count,
+            taggers: mergedTaggers,
+            relationship: viewerIsTagger,
+          });
         }
 
         // Convert map back to array

--- a/src/core/services/local/tag/post/tag.post.ts
+++ b/src/core/services/local/tag/post/tag.post.ts
@@ -31,6 +31,7 @@ export class LocalPostTagService {
    * @param params.label - Normalized tag label (must be pre-normalized by caller)
    * @param params.taggerId - Unique identifier of the user adding the tag
    *
+   * @returns {boolean} true if local state changed; false if the tagger already had this tag (idempotent — no writes, no viewer marker)
    * @throws {AppError} When user has already tagged this post with the same label
    * @throws {DatabaseError} When database operations fail
    */

--- a/src/core/services/local/tag/post/tag.post.ts
+++ b/src/core/services/local/tag/post/tag.post.ts
@@ -186,8 +186,7 @@ export class LocalPostTagService {
    *   user is unauthenticated, in which case Nexus values are used as-is.
    */
   static async mergeTags({ postId, tags, viewerId }: { postId: string; tags: NexusTag[]; viewerId: Pubky | null }) {
-    // Side-effect GC: drop expired markers across the board so sessionStorage
-    // doesn't accumulate them.
+    // Piggyback GC: drop expired markers so sessionStorage doesn't accumulate them.
     ViewerTagMarkerStorage.sweepExpired();
 
     try {

--- a/src/core/services/local/tag/post/viewerTagMarkerStorage.test.ts
+++ b/src/core/services/local/tag/post/viewerTagMarkerStorage.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MARKER_TTL_MS, VIEWER_TAG_MARKER_STORAGE_PREFIX } from '@/config/viewerTagMarker';
+import { HttpMethod } from '@/libs/http/http.types';
+import type { Pubky } from '@/models/models.types';
+import { ViewerTagMarkerStorage } from './viewerTagMarkerStorage';
+
+const VIEWER_A = 'viewer-a' as Pubky;
+const VIEWER_B = 'viewer-b' as Pubky;
+const POST_ID = 'author:post123';
+
+// Build the raw sessionStorage key the same way the helper does internally — used
+// for direct sessionStorage assertions.
+const buildKey = (viewer: Pubky, postId: string, label: string) =>
+  `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${viewer}:${postId}:${label.toLowerCase()}`;
+
+describe('ViewerTagMarkerStorage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('set + get', () => {
+    it('round-trips a PUT (viewer added) marker', () => {
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'abc', op: HttpMethod.PUT });
+
+      const marker = ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' });
+      expect(marker?.op).toBe(HttpMethod.PUT);
+    });
+
+    it('round-trips a DELETE (viewer removed) marker', () => {
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'abc', op: HttpMethod.DELETE });
+
+      const marker = ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' });
+      expect(marker?.op).toBe(HttpMethod.DELETE);
+    });
+
+    it('returns null when no marker exists', () => {
+      const marker = ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' });
+      expect(marker).toBeNull();
+    });
+
+    // Local writes come through TagNormalizer with a lowercased label, but Nexus
+    // responses can use any case. Storage normalizes at the boundary so reads
+    // match writes regardless.
+    it('normalizes the label so set and get match regardless of case', () => {
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'ABC', op: HttpMethod.PUT });
+
+      // Direct check: the raw sessionStorage key uses the lowercased label,
+      // and the uppercase variant is never stored.
+      const lowercaseKey = `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${VIEWER_A}:${POST_ID}:abc`;
+      const uppercaseKey = `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${VIEWER_A}:${POST_ID}:ABC`;
+      expect(window.sessionStorage.getItem(lowercaseKey)).not.toBeNull();
+      expect(window.sessionStorage.getItem(uppercaseKey)).toBeNull();
+
+      // And `get` finds the same marker whether the caller passes 'abc' or 'ABC'.
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' })?.op).toBe(HttpMethod.PUT);
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'ABC' })?.op).toBe(HttpMethod.PUT);
+    });
+  });
+
+  describe('expiry (TTL)', () => {
+    it('returns null and removes the key once expiresAt has passed', () => {
+      const start = 1_000_000;
+      vi.useFakeTimers();
+      vi.setSystemTime(start);
+
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'abc', op: HttpMethod.PUT });
+
+      // Step past the TTL window — Nexus is assumed to have caught up by now.
+      vi.setSystemTime(start + MARKER_TTL_MS + 1);
+
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' })).toBeNull();
+      // The expired key should be cleaned out of sessionStorage as a side effect (lazy GC).
+      expect(window.sessionStorage.getItem(buildKey(VIEWER_A, POST_ID, 'abc'))).toBeNull();
+    });
+  });
+
+  describe('defensive handling', () => {
+    it('returns null and removes the entry when stored JSON is corrupted', () => {
+      const key = buildKey(VIEWER_A, POST_ID, 'abc');
+      // Plant invalid JSON to simulate a corrupted entry.
+      window.sessionStorage.setItem(key, '{not valid json');
+
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' })).toBeNull();
+      expect(window.sessionStorage.getItem(key)).toBeNull();
+    });
+
+    it('returns null and removes the entry when op is not PUT or DELETE', () => {
+      // A garbage `op` value mustn't be treated as a valid marker — otherwise
+      // mergeTags would silently fall through to "DELETE behavior" since
+      // `marker.op === HttpMethod.PUT` is false.
+      const key = buildKey(VIEWER_A, POST_ID, 'abc');
+      window.sessionStorage.setItem(
+        key,
+        JSON.stringify({ op: 'NOT_A_METHOD', ts: Date.now(), expiresAt: Date.now() + 60_000 }),
+      );
+
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' })).toBeNull();
+      expect(window.sessionStorage.getItem(key)).toBeNull();
+    });
+
+    it('returns null and removes the entry when required fields are missing or wrong type', () => {
+      const key = buildKey(VIEWER_A, POST_ID, 'abc');
+      window.sessionStorage.setItem(
+        key,
+        // Missing `ts`, expiresAt is a string instead of a number.
+        JSON.stringify({ op: HttpMethod.PUT, expiresAt: '2099-01-01' }),
+      );
+
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'abc' })).toBeNull();
+      expect(window.sessionStorage.getItem(key)).toBeNull();
+    });
+  });
+
+  describe('sweepExpired', () => {
+    it('removes expired markers but keeps fresh ones', () => {
+      const start = 1_000_000;
+      vi.useFakeTimers();
+      vi.setSystemTime(start);
+
+      // Marker that will be stale by the time we sweep.
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'stale', op: HttpMethod.PUT });
+
+      // Jump close to (but not past) TTL, then write a "fresh" marker.
+      vi.setSystemTime(start + MARKER_TTL_MS - 1000);
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'fresh', op: HttpMethod.PUT });
+
+      // Jump past the first marker's expiry but not the second's.
+      vi.setSystemTime(start + MARKER_TTL_MS + 1);
+
+      ViewerTagMarkerStorage.sweepExpired();
+
+      expect(window.sessionStorage.getItem(buildKey(VIEWER_A, POST_ID, 'stale'))).toBeNull();
+      expect(window.sessionStorage.getItem(buildKey(VIEWER_A, POST_ID, 'fresh'))).not.toBeNull();
+    });
+
+    it('removes corrupted entries under our prefix', () => {
+      const key = buildKey(VIEWER_A, POST_ID, 'corrupt');
+      window.sessionStorage.setItem(key, '{bad');
+
+      ViewerTagMarkerStorage.sweepExpired();
+
+      expect(window.sessionStorage.getItem(key)).toBeNull();
+    });
+
+    it('removes invalid-shape entries even if they have a future expiresAt', () => {
+      // Future-dated but malformed (unknown op) — without shape validation this
+      // would linger in storage forever.
+      const key = buildKey(VIEWER_A, POST_ID, 'invalid');
+      window.sessionStorage.setItem(
+        key,
+        JSON.stringify({ op: 'GARBAGE', ts: Date.now(), expiresAt: Date.now() + 60_000 }),
+      );
+
+      ViewerTagMarkerStorage.sweepExpired();
+
+      expect(window.sessionStorage.getItem(key)).toBeNull();
+    });
+
+    it('does not touch sessionStorage keys outside our prefix', () => {
+      window.sessionStorage.setItem('unrelated:key', 'data');
+
+      ViewerTagMarkerStorage.sweepExpired();
+
+      expect(window.sessionStorage.getItem('unrelated:key')).toBe('data');
+    });
+  });
+
+  describe('clearForUser', () => {
+    it('removes only markers belonging to the given user', () => {
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_A, postId: POST_ID, label: 'a', op: HttpMethod.PUT });
+      ViewerTagMarkerStorage.set({ pubky: VIEWER_B, postId: POST_ID, label: 'a', op: HttpMethod.PUT });
+
+      ViewerTagMarkerStorage.clearForUser(VIEWER_A);
+
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_A, postId: POST_ID, label: 'a' })).toBeNull();
+      // Other user's marker is preserved.
+      expect(ViewerTagMarkerStorage.get({ pubky: VIEWER_B, postId: POST_ID, label: 'a' })?.op).toBe(HttpMethod.PUT);
+    });
+
+    it('does not touch sessionStorage keys outside our prefix', () => {
+      window.sessionStorage.setItem('unrelated:key', 'data');
+
+      ViewerTagMarkerStorage.clearForUser(VIEWER_A);
+
+      expect(window.sessionStorage.getItem('unrelated:key')).toBe('data');
+    });
+  });
+});

--- a/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
+++ b/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
@@ -19,18 +19,6 @@ function userPrefix(pubky: Pubky): string {
   return `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${pubky}:`;
 }
 
-function isStorageAvailable(): boolean {
-  return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
-}
-
-function safeRemove(key: string): void {
-  try {
-    window.sessionStorage.removeItem(key);
-  } catch {
-    /* sessionStorage best-effort */
-  }
-}
-
 // Parses + structurally validates a marker. Returns null for anything that
 // isn't a recognizable marker (bad JSON, wrong shape, unknown `op`, etc.).
 function parseMarker(raw: string): ViewerTagMarker | null {
@@ -55,18 +43,12 @@ function parseMarker(raw: string): ViewerTagMarker | null {
 // Reads one marker, validates it, and lazy-deletes the entry if it's invalid
 // (corrupted/unknown op/missing fields) or expired. Returns null in those cases.
 function readMarkerOrNull(key: string, now: number): ViewerTagMarker | null {
-  let raw: string | null;
-  try {
-    raw = window.sessionStorage.getItem(key);
-  } catch {
-    return null;
-  }
+  const raw = window.sessionStorage.getItem(key);
   if (raw === null) return null;
 
   const marker = parseMarker(raw);
   if (!marker || marker.expiresAt <= now) {
-    // remove the marker because it's invalid or expired
-    safeRemove(key);
+    window.sessionStorage.removeItem(key);
     return null;
   }
   return marker;
@@ -75,18 +57,13 @@ function readMarkerOrNull(key: string, now: number): ViewerTagMarker | null {
 // Iterates sessionStorage keys and removes the ones that match `predicate`.
 // Collects matching keys first so removals don't shift indices mid-iteration.
 function removeKeysMatching(predicate: (key: string) => boolean): void {
-  if (!isStorageAvailable()) return;
-  try {
-    const keysToRemove: string[] = [];
-    for (let i = 0; i < window.sessionStorage.length; i++) {
-      const key = window.sessionStorage.key(i);
-      if (key !== null && predicate(key)) keysToRemove.push(key);
-    }
-    for (const key of keysToRemove) {
-      window.sessionStorage.removeItem(key);
-    }
-  } catch {
-    /* sessionStorage best-effort */
+  const keysToRemove: string[] = [];
+  for (let i = 0; i < window.sessionStorage.length; i++) {
+    const key = window.sessionStorage.key(i);
+    if (key !== null && predicate(key)) keysToRemove.push(key);
+  }
+  for (const key of keysToRemove) {
+    window.sessionStorage.removeItem(key);
   }
 }
 
@@ -104,20 +81,17 @@ export class ViewerTagMarkerStorage {
     label: string;
     op: ViewerTagMarkerOp;
   }): void {
-    if (!isStorageAvailable()) return;
-
     const ts = Date.now();
     const marker: ViewerTagMarker = { op, ts, expiresAt: ts + MARKER_TTL_MS };
 
     try {
       window.sessionStorage.setItem(buildKey(pubky, postId, label), JSON.stringify(marker));
     } catch {
-      /* sessionStorage best-effort */
+      // setItem can throw QuotaExceededError; markers are best-effort, so swallow.
     }
   }
 
   static get({ pubky, postId, label }: { pubky: Pubky; postId: string; label: string }): ViewerTagMarker | null {
-    if (!isStorageAvailable()) return null;
     return readMarkerOrNull(buildKey(pubky, postId, label), Date.now());
   }
 
@@ -126,30 +100,24 @@ export class ViewerTagMarkerStorage {
    * Called from mergeTags so stale markers don't accumulate.
    */
   static sweepExpired(): void {
-    if (!isStorageAvailable()) return;
     const now = Date.now();
-
     const keysToRemove: string[] = [];
-    try {
-      for (let i = 0; i < window.sessionStorage.length; i++) {
-        const key = window.sessionStorage.key(i);
-        if (key === null || !key.startsWith(VIEWER_TAG_MARKER_STORAGE_PREFIX)) continue;
 
-        const raw = window.sessionStorage.getItem(key);
-        if (raw === null) continue;
+    for (let i = 0; i < window.sessionStorage.length; i++) {
+      const key = window.sessionStorage.key(i);
+      if (key === null || !key.startsWith(VIEWER_TAG_MARKER_STORAGE_PREFIX)) continue;
 
-        const marker = parseMarker(raw);
-        if (!marker || marker.expiresAt <= now) {
-          keysToRemove.push(key);
-        }
+      const raw = window.sessionStorage.getItem(key);
+      if (raw === null) continue;
+
+      const marker = parseMarker(raw);
+      if (!marker || marker.expiresAt <= now) {
+        keysToRemove.push(key);
       }
-    } catch {
-      /* sessionStorage best-effort */
-      return;
     }
 
     for (const key of keysToRemove) {
-      safeRemove(key);
+      window.sessionStorage.removeItem(key);
     }
   }
 

--- a/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
+++ b/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
@@ -122,30 +122,34 @@ export class ViewerTagMarkerStorage {
   }
 
   /**
-   * Sweeps all expired or invalid marker entries across sessionStorage. Called
-   * from mergeTags as a side-effect GC so stale markers don't accumulate.
+   * Removes all expired or invalid marker entries across sessionStorage.
+   * Called from mergeTags so stale markers don't accumulate.
    */
   static sweepExpired(): void {
     if (!isStorageAvailable()) return;
     const now = Date.now();
 
-    // Collect prefix-matching keys first so removals (inside readMarkerOrNull)
-    // don't shift indices mid-iteration.
-    const keys: string[] = [];
+    const keysToRemove: string[] = [];
     try {
       for (let i = 0; i < window.sessionStorage.length; i++) {
         const key = window.sessionStorage.key(i);
-        if (key !== null && key.startsWith(VIEWER_TAG_MARKER_STORAGE_PREFIX)) keys.push(key);
+        if (key === null || !key.startsWith(VIEWER_TAG_MARKER_STORAGE_PREFIX)) continue;
+
+        const raw = window.sessionStorage.getItem(key);
+        if (raw === null) continue;
+
+        const marker = parseMarker(raw);
+        if (!marker || marker.expiresAt <= now) {
+          keysToRemove.push(key);
+        }
       }
     } catch {
       /* sessionStorage best-effort */
       return;
     }
 
-    // readMarkerOrNull lazy-deletes invalid/expired entries as a side effect,
-    // so we only need to call it — no separate removal pass.
-    for (const key of keys) {
-      readMarkerOrNull(key, now);
+    for (const key of keysToRemove) {
+      safeRemove(key);
     }
   }
 

--- a/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
+++ b/src/core/services/local/tag/post/viewerTagMarkerStorage.ts
@@ -1,0 +1,156 @@
+import { MARKER_TTL_MS, VIEWER_TAG_MARKER_STORAGE_PREFIX } from '@/config/viewerTagMarker';
+import { HttpMethod } from '@/libs/http/http.types';
+import type { Pubky } from '@/models/models.types';
+
+/** PUT = viewer created the tag, DELETE = viewer removed it. */
+type ViewerTagMarkerOp = HttpMethod.PUT | HttpMethod.DELETE;
+
+interface ViewerTagMarker {
+  op: ViewerTagMarkerOp;
+  ts: number;
+  expiresAt: number;
+}
+
+function buildKey(pubky: Pubky, postId: string, label: string): string {
+  return `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${pubky}:${postId}:${label.toLowerCase()}`;
+}
+
+function userPrefix(pubky: Pubky): string {
+  return `${VIEWER_TAG_MARKER_STORAGE_PREFIX}${pubky}:`;
+}
+
+function isStorageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
+}
+
+function safeRemove(key: string): void {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    /* sessionStorage best-effort */
+  }
+}
+
+// Parses + structurally validates a marker. Returns null for anything that
+// isn't a recognizable marker (bad JSON, wrong shape, unknown `op`, etc.).
+function parseMarker(raw: string): ViewerTagMarker | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const candidate = parsed as { op?: unknown; ts?: unknown; expiresAt?: unknown };
+
+  if (candidate.op !== HttpMethod.PUT && candidate.op !== HttpMethod.DELETE) return null;
+  if (typeof candidate.ts !== 'number') return null;
+  if (typeof candidate.expiresAt !== 'number') return null;
+
+  return { op: candidate.op, ts: candidate.ts, expiresAt: candidate.expiresAt };
+}
+
+// Reads one marker, validates it, and lazy-deletes the entry if it's invalid
+// (corrupted/unknown op/missing fields) or expired. Returns null in those cases.
+function readMarkerOrNull(key: string, now: number): ViewerTagMarker | null {
+  let raw: string | null;
+  try {
+    raw = window.sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+
+  const marker = parseMarker(raw);
+  if (!marker || marker.expiresAt <= now) {
+    // remove the marker because it's invalid or expired
+    safeRemove(key);
+    return null;
+  }
+  return marker;
+}
+
+// Iterates sessionStorage keys and removes the ones that match `predicate`.
+// Collects matching keys first so removals don't shift indices mid-iteration.
+function removeKeysMatching(predicate: (key: string) => boolean): void {
+  if (!isStorageAvailable()) return;
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < window.sessionStorage.length; i++) {
+      const key = window.sessionStorage.key(i);
+      if (key !== null && predicate(key)) keysToRemove.push(key);
+    }
+    for (const key of keysToRemove) {
+      window.sessionStorage.removeItem(key);
+    }
+  } catch {
+    /* sessionStorage best-effort */
+  }
+}
+
+export class ViewerTagMarkerStorage {
+  private constructor() {}
+
+  static set({
+    pubky,
+    postId,
+    label,
+    op,
+  }: {
+    pubky: Pubky;
+    postId: string;
+    label: string;
+    op: ViewerTagMarkerOp;
+  }): void {
+    if (!isStorageAvailable()) return;
+
+    const ts = Date.now();
+    const marker: ViewerTagMarker = { op, ts, expiresAt: ts + MARKER_TTL_MS };
+
+    try {
+      window.sessionStorage.setItem(buildKey(pubky, postId, label), JSON.stringify(marker));
+    } catch {
+      /* sessionStorage best-effort */
+    }
+  }
+
+  static get({ pubky, postId, label }: { pubky: Pubky; postId: string; label: string }): ViewerTagMarker | null {
+    if (!isStorageAvailable()) return null;
+    return readMarkerOrNull(buildKey(pubky, postId, label), Date.now());
+  }
+
+  /**
+   * Sweeps all expired or invalid marker entries across sessionStorage. Called
+   * from mergeTags as a side-effect GC so stale markers don't accumulate.
+   */
+  static sweepExpired(): void {
+    if (!isStorageAvailable()) return;
+    const now = Date.now();
+
+    // Collect prefix-matching keys first so removals (inside readMarkerOrNull)
+    // don't shift indices mid-iteration.
+    const keys: string[] = [];
+    try {
+      for (let i = 0; i < window.sessionStorage.length; i++) {
+        const key = window.sessionStorage.key(i);
+        if (key !== null && key.startsWith(VIEWER_TAG_MARKER_STORAGE_PREFIX)) keys.push(key);
+      }
+    } catch {
+      /* sessionStorage best-effort */
+      return;
+    }
+
+    // readMarkerOrNull lazy-deletes invalid/expired entries as a side effect,
+    // so we only need to call it — no separate removal pass.
+    for (const key of keys) {
+      readMarkerOrNull(key, now);
+    }
+  }
+
+  static clearForUser(pubky: Pubky): void {
+    const prefix = userPrefix(pubky);
+    removeKeysMatching((key) => key.startsWith(prefix));
+  }
+}


### PR DESCRIPTION
## Summary
  Fixes a tagging bug where a user's freshly added or removed tag could "snap back" after a Nexus refresh,
  because Nexus's indexer is several minutes behind the homeserver write. Closes #1781.

  ## Root cause
  - After a user toggles a tag, the next Nexus response for that post is often still serving pre-toggle stale data
   (indexer lag, ~minutes).
  - The old merge step blindly took the union of local + Nexus and used `max(local, nexus)` for the count,
  so a stale Nexus response could resurrect a just-deleted tag or undercount a just-added one.
  - Separately, a delete that returned 404 from the homeserver was treated as a failure and rolled back
  locally, leaving the user with a "ghost" tag they couldn't remove (the homeserver kept 404-ing on every
  retry).

  ## Fix
  - **Viewer-mutation marker** — when the viewer tags or untags a post, drop a short-lived (~5 min) marker
  in sessionStorage; the merge step trusts the marker over Nexus for that one viewer slot.
  - **Per-field merge policy** — count comes from Nexus (with ±1 correction when a marker disagrees), the
  viewer's slot in the tagger list follows the marker, other taggers stay as a union (Nexus only ships a
  truncated top-N), labels not in the Nexus response are left alone (they may be on a later page).
  - **Treat homeserver 404 on delete as success** — the tag is already gone, no rollback, no ghost.
  - **Logout sweep** — clear the current user's markers before the next user signs in on the same tab.

  ## Notes
  - Scope is post tags only — user tags and other entity tags are unchanged.
  - Marker TTL (`MARKER_TTL_MS`, 5 min) is a tunable in `src/config/viewerTagMarker.ts`; pick the indexer
  lag ceiling, not a "freshness" budget.
  - Markers live in sessionStorage, so they're per-tab and naturally gone on tab close; the logout sweep
  covers same-tab user switches.
  
  ## Result
  
### 1.

https://github.com/user-attachments/assets/87215b95-d99b-4e3c-9c5a-2b8f9e1267df





### 2.

https://github.com/user-attachments/assets/53fc7af9-8819-45b2-b81d-36f43704e3f1

