### PR TITLE
Update Header.tsx to fix alignment issues for smaller breakpoints

### DIFF
--- a/src/components/molecules/Header/Header.test.tsx.snap
+++ b/src/components/molecules/Header/Header.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Header Components - Snapshots > matches snapshot for HeaderButtonSignIn
 
 exports[`Header Components - Snapshots > matches snapshot for HeaderContainer 1`] = `
 <header
-  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-6"
+  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6"
   data-testid="container"
 >
   <nav

--- a/src/components/molecules/Header/Header.tsx
+++ b/src/components/molecules/Header/Header.tsx
@@ -28,7 +28,7 @@ export const HeaderContainer = ({ children, className, classNameNav }: HeaderCon
       overrideDefaults
       as="header"
       className={cn(
-        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-6',
+        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6',
         className,
       )}
     >


### PR DESCRIPTION
This PR fixes alignment issues for the header for smaller breakpoints.

Fixed homepage header/content alignment by removing duplicate horizontal padding from the outer header wrapper. The nav keeps the shared container padding, so the Pubky logo now aligns with the landing heading across smaller and wide desktop breakpoints.

Incorrect (currently live on pubky.app):
<img width="2044" height="1416" alt="image" src="https://github.com/user-attachments/assets/c3277de8-5674-43c5-bd42-43f03305c7f9" />

<img width="778" height="748" alt="image" src="https://github.com/user-attachments/assets/ec100aa7-547a-41d3-bab7-6b8a2c714712" />


Correct:

<img width="2042" height="950" alt="image" src="https://github.com/user-attachments/assets/a4523646-aeb4-400d-95ad-18eb79d15237" />

<img width="771" height="710" alt="image" src="https://github.com/user-attachments/assets/f3e11730-954b-4350-81f8-616d3e33b8b5" />
