### PR TITLE
Update Header.tsx to remove excess vertical padding for mobile

### DIFF
--- a/src/components/molecules/Header/Header.test.tsx.snap
+++ b/src/components/molecules/Header/Header.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Header Components - Snapshots > matches snapshot for HeaderButtonSignIn
 
 exports[`Header Components - Snapshots > matches snapshot for HeaderContainer 1`] = `
 <header
-  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-6"
+  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6"
   data-testid="container"
 >
   <nav

--- a/src/components/molecules/Header/Header.test.tsx.snap
+++ b/src/components/molecules/Header/Header.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Header Components - Snapshots > matches snapshot for HeaderButtonSignIn
 
 exports[`Header Components - Snapshots > matches snapshot for HeaderContainer 1`] = `
 <header
-  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6"
+  class="pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-0 sm:py-6"
   data-testid="container"
 >
   <nav

--- a/src/components/molecules/Header/Header.tsx
+++ b/src/components/molecules/Header/Header.tsx
@@ -28,7 +28,7 @@ export const HeaderContainer = ({ children, className, classNameNav }: HeaderCon
       overrideDefaults
       as="header"
       className={cn(
-        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6',
+        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-0 sm:py-6',
         className,
       )}
     >

--- a/src/components/molecules/Header/Header.tsx
+++ b/src/components/molecules/Header/Header.tsx
@@ -28,7 +28,7 @@ export const HeaderContainer = ({ children, className, classNameNav }: HeaderCon
       overrideDefaults
       as="header"
       className={cn(
-        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent p-6',
+        'pointer-events-none sticky top-0 z-(--z-sticky-header) w-full bg-linear-to-b from-(--background) from-50% to-transparent py-6',
         className,
       )}
     >


### PR DESCRIPTION
A further improvement upon [PR 1813](https://github.com/pubky/pubky-app/pull/1813/ ) 

This fixes mobile homepage header spacing by removing the current excess header/nav padding below the `sm` breakpoint while preserving the existing desktop alignment and spacing.