### PR TITLE
fix(ui): disable automatic hyphenation in post text (#1834)

### DIFF
--- a/src/components/molecules/PostText/PostText.test.tsx.snap
+++ b/src/components/molecules/PostText/PostText.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostText - Snapshots > matches snapshot for article showing full content on post page 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -33,7 +33,7 @@ exports[`PostText - Snapshots > matches snapshot for article showing full conten
 
 exports[`PostText - Snapshots > matches snapshot for article showing only first paragraph in feed 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -45,7 +45,7 @@ exports[`PostText - Snapshots > matches snapshot for article showing only first 
 
 exports[`PostText - Snapshots > matches snapshot for article with h1 heading 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -59,7 +59,7 @@ exports[`PostText - Snapshots > matches snapshot for article with h1 heading 1`]
 
 exports[`PostText - Snapshots > matches snapshot for article with long content (first paragraph extracted and truncated in feed) 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -71,7 +71,7 @@ exports[`PostText - Snapshots > matches snapshot for article with long content (
 
 exports[`PostText - Snapshots > matches snapshot for article with multiple headings (first paragraph extracted in feed) 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -83,7 +83,7 @@ exports[`PostText - Snapshots > matches snapshot for article with multiple headi
 
 exports[`PostText - Snapshots > matches snapshot for autolinked URL 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -104,7 +104,7 @@ exports[`PostText - Snapshots > matches snapshot for autolinked URL 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for autolinked URL with path and query 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -124,7 +124,7 @@ exports[`PostText - Snapshots > matches snapshot for autolinked URL with path an
 
 exports[`PostText - Snapshots > matches snapshot for blockquote 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -144,7 +144,7 @@ exports[`PostText - Snapshots > matches snapshot for blockquote 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for bold and italic combination 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -162,7 +162,7 @@ exports[`PostText - Snapshots > matches snapshot for bold and italic combination
 
 exports[`PostText - Snapshots > matches snapshot for bold and italic text 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -182,7 +182,7 @@ exports[`PostText - Snapshots > matches snapshot for bold and italic text 1`] = 
 
 exports[`PostText - Snapshots > matches snapshot for code block 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -201,7 +201,7 @@ console.log(greeting);
 
 exports[`PostText - Snapshots > matches snapshot for code block without language 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -219,7 +219,7 @@ exports[`PostText - Snapshots > matches snapshot for code block without language
 
 exports[`PostText - Snapshots > matches snapshot for combined markdown elements 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -304,7 +304,7 @@ exports[`PostText - Snapshots > matches snapshot for combined markdown elements 
 
 exports[`PostText - Snapshots > matches snapshot for content with special characters 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -316,7 +316,7 @@ exports[`PostText - Snapshots > matches snapshot for content with special charac
 
 exports[`PostText - Snapshots > matches snapshot for deceptive link converted to plaintext 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -330,7 +330,7 @@ exports[`PostText - Snapshots > matches snapshot for deceptive link converted to
 
 exports[`PostText - Snapshots > matches snapshot for email autolink 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -351,7 +351,7 @@ exports[`PostText - Snapshots > matches snapshot for email autolink 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for empty content 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 />
@@ -359,7 +359,7 @@ exports[`PostText - Snapshots > matches snapshot for empty content 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for hashtag alongside autolink 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -386,7 +386,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag alongside autolink 
 
 exports[`PostText - Snapshots > matches snapshot for hashtag with hyphens 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -405,7 +405,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag with hyphens 1`] = 
 
 exports[`PostText - Snapshots > matches snapshot for hashtag with markdown formatting 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -432,7 +432,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag with markdown forma
 
 exports[`PostText - Snapshots > matches snapshot for hashtag with mixed hyphens and underscores 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -451,7 +451,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag with mixed hyphens 
 
 exports[`PostText - Snapshots > matches snapshot for hashtag with text 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -477,7 +477,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag with text 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for hashtag with underscores 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -496,7 +496,7 @@ exports[`PostText - Snapshots > matches snapshot for hashtag with underscores 1`
 
 exports[`PostText - Snapshots > matches snapshot for horizontal rule 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -516,7 +516,7 @@ exports[`PostText - Snapshots > matches snapshot for horizontal rule 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for inline code 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -534,7 +534,7 @@ exports[`PostText - Snapshots > matches snapshot for inline code 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for italic and bold combination 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -552,7 +552,7 @@ exports[`PostText - Snapshots > matches snapshot for italic and bold combination
 
 exports[`PostText - Snapshots > matches snapshot for italic and strikethrough combination 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -570,7 +570,7 @@ exports[`PostText - Snapshots > matches snapshot for italic and strikethrough co
 
 exports[`PostText - Snapshots > matches snapshot for long hashtag 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -583,7 +583,7 @@ exports[`PostText - Snapshots > matches snapshot for long hashtag 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for markdown link converted to plaintext 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -597,7 +597,7 @@ exports[`PostText - Snapshots > matches snapshot for markdown link converted to 
 
 exports[`PostText - Snapshots > matches snapshot for mention alongside autolink 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -617,7 +617,7 @@ exports[`PostText - Snapshots > matches snapshot for mention alongside autolink 
 
 exports[`PostText - Snapshots > matches snapshot for mention alongside hashtag 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -641,7 +641,7 @@ exports[`PostText - Snapshots > matches snapshot for mention alongside hashtag 1
 
 exports[`PostText - Snapshots > matches snapshot for mention with markdown formatting 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -668,7 +668,7 @@ exports[`PostText - Snapshots > matches snapshot for mention with markdown forma
 
 exports[`PostText - Snapshots > matches snapshot for mention with text 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -687,7 +687,7 @@ exports[`PostText - Snapshots > matches snapshot for mention with text 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for multiline content with line breaks 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -701,7 +701,7 @@ Third line
 
 exports[`PostText - Snapshots > matches snapshot for multiple hashtags 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -732,7 +732,7 @@ exports[`PostText - Snapshots > matches snapshot for multiple hashtags 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for multiple mentions 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -756,7 +756,7 @@ exports[`PostText - Snapshots > matches snapshot for multiple mentions 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for nested blockquote 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -789,7 +789,7 @@ exports[`PostText - Snapshots > matches snapshot for nested blockquote 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for non-truncated long content on post page 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -801,7 +801,7 @@ exports[`PostText - Snapshots > matches snapshot for non-truncated long content 
 
 exports[`PostText - Snapshots > matches snapshot for ordered list 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -831,7 +831,7 @@ exports[`PostText - Snapshots > matches snapshot for ordered list 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for plain text 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -843,7 +843,7 @@ exports[`PostText - Snapshots > matches snapshot for plain text 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for single hashtag 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -861,7 +861,7 @@ exports[`PostText - Snapshots > matches snapshot for single hashtag 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for single mention with pk: prefix 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -879,7 +879,7 @@ exports[`PostText - Snapshots > matches snapshot for single mention with pk: pre
 
 exports[`PostText - Snapshots > matches snapshot for single mention with pubky prefix 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -897,7 +897,7 @@ exports[`PostText - Snapshots > matches snapshot for single mention with pubky p
 
 exports[`PostText - Snapshots > matches snapshot for strikethrough and inline code combination 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -917,7 +917,7 @@ exports[`PostText - Snapshots > matches snapshot for strikethrough and inline co
 
 exports[`PostText - Snapshots > matches snapshot for strikethrough and italic combination 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -935,7 +935,7 @@ exports[`PostText - Snapshots > matches snapshot for strikethrough and italic co
 
 exports[`PostText - Snapshots > matches snapshot for strikethrough text 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -951,7 +951,7 @@ exports[`PostText - Snapshots > matches snapshot for strikethrough text 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for truncated content with Show more button 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -971,7 +971,7 @@ exports[`PostText - Snapshots > matches snapshot for truncated content with Show
 
 exports[`PostText - Snapshots > matches snapshot for unordered list 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -1001,7 +1001,7 @@ exports[`PostText - Snapshots > matches snapshot for unordered list 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot for www autolink 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -1022,7 +1022,7 @@ exports[`PostText - Snapshots > matches snapshot for www autolink 1`] = `
 
 exports[`PostText - Snapshots > matches snapshot with custom className 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground my-custom-class"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground my-custom-class"
   data-override-defaults="true"
   data-testid="container"
 >

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -82,7 +82,7 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
       data-cy="post-text"
       overrideDefaults
       className={cn(
-        'text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground',
+        'text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground',
         className,
       )}
     >

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >
@@ -60,7 +60,7 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >
@@ -109,7 +109,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >
@@ -158,7 +158,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >
@@ -207,7 +207,7 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >
@@ -256,7 +256,7 @@ exports[`PostArticle > Snapshots > matches snapshot without cover image 1`] = `
       data-testid="container"
     >
       <span
-        class="wrap-anywhere hyphens-auto"
+        class="wrap-anywhere"
         data-size="lg"
         data-testid="typography"
       >

--- a/src/components/organisms/PostArticle/PostArticle.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.tsx
@@ -38,7 +38,7 @@ export const PostArticle = ({ content, attachments, localAttachments, className 
     <>
       <Container className={cn('justify-between gap-6 lg:flex-row', className)}>
         <Container className="gap-y-1">
-          <Typography size="lg" className="wrap-anywhere hyphens-auto">
+          <Typography size="lg" className="wrap-anywhere">
             {title}
           </Typography>
 

--- a/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx.snap
+++ b/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`PostArticleDetail > matches snapshot when blurred 1`] = `
     data-testid="container"
   >
     <h1
-      class="mb-6 wrap-anywhere hyphens-auto"
+      class="mb-6 wrap-anywhere"
       data-testid="typography"
     >
       Test Article Title
@@ -70,7 +70,7 @@ exports[`PostArticleDetail > matches snapshot with cover image 1`] = `
     data-testid="container"
   >
     <h1
-      class="mb-6 wrap-anywhere hyphens-auto"
+      class="mb-6 wrap-anywhere"
       data-testid="typography"
     >
       Article With Cover
@@ -137,7 +137,7 @@ exports[`PostArticleDetail > matches snapshot with default props 1`] = `
     data-testid="container"
   >
     <h1
-      class="mb-6 wrap-anywhere hyphens-auto"
+      class="mb-6 wrap-anywhere"
       data-testid="typography"
     >
       Test Article Title

--- a/src/components/organisms/PostArticleDetail/PostArticleDetail.tsx
+++ b/src/components/organisms/PostArticleDetail/PostArticleDetail.tsx
@@ -58,7 +58,7 @@ export const PostArticleDetail = ({ postId, content, attachments, isBlurred }: P
     <>
       <Container className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
         <Container className="lg:col-span-2">
-          <Typography as="h1" size="2xl" className="mb-6 wrap-anywhere hyphens-auto">
+          <Typography as="h1" size="2xl" className="mb-6 wrap-anywhere">
             {title}
           </Typography>
 

--- a/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
+++ b/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`PostContentBase - Snapshots > matches snapshot with multiline content (
   data-testid="container"
 >
   <div
-    class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+    class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
     data-testid="container"
   >
     <p>
@@ -53,7 +53,7 @@ exports[`PostContentBase - Snapshots > matches snapshot with single-line content
   data-testid="container"
 >
   <div
-    class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+    class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
     data-testid="container"
   >
     <p>
@@ -72,7 +72,7 @@ exports[`PostContentBase - Snapshots > matches snapshot with special characters 
   data-testid="container"
 >
   <div
-    class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+    class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
     data-testid="container"
   >
     <p>
@@ -93,7 +93,7 @@ exports[`PostContentBase - Snapshots > matches snapshot with very long content 1
   data-testid="container"
 >
   <div
-    class="text-base leading-6 font-medium wrap-anywhere hyphens-auto whitespace-pre-line text-secondary-foreground"
+    class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
     data-testid="container"
   >
     <p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#1834](https://github.com/pubky/pubky-app/issues/1834) by removing `hyphens-auto` from post text rendering. Automatic hyphenation was introduced as part of PR #651 (`wrap-anywhere hyphens-auto` replacing `break-all`), which caused words like "revisit" to break across lines with inserted hyphens.

## Changes

- **`PostText`**: Removed `hyphens-auto`; kept `wrap-anywhere` so long URLs, pubkeys, and hashtags still wrap without the old `break-all` behavior.
- **`PostArticle` / `PostArticleDetail`**: Removed `hyphens-auto` from article title `Typography`.
- Updated snapshots for affected components.

All consumers of `PostText` inherit the fix (feeds, post pages, repost previews, article bodies, visual timeline overlay, profile bio popover).


