### PR TITLE
fix(ui): wrap long toast text beside OK button (#1873)

### DIFF
--- a/src/components/atoms/Toast/Toast.tsx
+++ b/src/components/atoms/Toast/Toast.tsx
@@ -84,7 +84,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
-    className={cn('text-sm leading-normal font-bold text-popover-foreground', className)}
+    className={cn('min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground', className)}
     {...props}
   />
 ));
@@ -93,7 +93,11 @@ const ToastDescription = React.forwardRef<
   React.ComponentRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('min-w-0 text-sm wrap-anywhere text-muted-foreground', className)}
+    {...props}
+  />
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 export {

--- a/src/components/molecules/Toaster/Toaster.test.tsx
+++ b/src/components/molecules/Toaster/Toaster.test.tsx
@@ -40,7 +40,7 @@ describe('Toaster', () => {
     expect(screen.getByText('Just a description')).toBeInTheDocument();
   });
 
-  it('should not truncate long description text', () => {
+  it('should wrap long description text instead of truncating', () => {
     const longDescription =
       'The file you are trying to upload exceeds the maximum allowed size of 100MB. Please reduce the file size and try again.';
 
@@ -58,7 +58,30 @@ describe('Toaster', () => {
     render(<Toaster />);
 
     const descriptionElement = screen.getByText(longDescription);
+    expect(descriptionElement).toHaveClass('wrap-anywhere');
     expect(descriptionElement).not.toHaveClass('truncate');
+  });
+
+  it('should wrap long URL description when dismiss button is shown', () => {
+    const longUrl = `https://pubky-ring-signer.example.com/auth?redirect=${'a'.repeat(120)}`;
+
+    mockUseToast.mockReturnValue({
+      toasts: [
+        {
+          id: 'copy-link',
+          title: 'Link copied to clipboard',
+          description: longUrl,
+          dismissButton: true,
+          open: true,
+        },
+      ],
+      dismiss: vi.fn(),
+    });
+
+    render(<Toaster />);
+
+    expect(screen.getByText(longUrl)).toHaveClass('wrap-anywhere');
+    expect(screen.getByRole('button', { name: 'OK' })).toBeInTheDocument();
   });
 
   it('should render dismiss button when dismissButton is true', () => {

--- a/src/components/molecules/Toaster/Toaster.test.tsx.snap
+++ b/src/components/molecules/Toaster/Toaster.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with multiple toasts
     tabindex="-1"
   >
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -25,15 +25,15 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with multiple toasts
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           First Toast
         </div>
         <div
-          class="text-sm text-muted-foreground"
+          class="min-w-0 text-sm wrap-anywhere text-muted-foreground"
         >
           First description
         </div>
@@ -43,7 +43,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with multiple toasts
       />
     </li>
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -52,15 +52,15 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with multiple toasts
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           Second Toast
         </div>
         <div
-          class="text-sm text-muted-foreground"
+          class="min-w-0 text-sm wrap-anywhere text-muted-foreground"
         >
           Second description
         </div>
@@ -93,7 +93,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with single toast 1`
     tabindex="-1"
   >
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -102,15 +102,15 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with single toast 1`
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           Test Toast
         </div>
         <div
-          class="text-sm text-muted-foreground"
+          class="min-w-0 text-sm wrap-anywhere text-muted-foreground"
         >
           This is a test toast message
         </div>
@@ -143,7 +143,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with title-only toas
     tabindex="-1"
   >
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -152,10 +152,10 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with title-only toas
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           Simple Toast
         </div>
@@ -188,7 +188,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with toast action 1`
     tabindex="-1"
   >
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -197,15 +197,15 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with toast action 1`
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           Toast with Action
         </div>
         <div
-          class="text-sm text-muted-foreground"
+          class="min-w-0 text-sm wrap-anywhere text-muted-foreground"
         >
           This toast has an action button
         </div>
@@ -242,7 +242,7 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with toast with acti
     tabindex="-1"
   >
     <li
-      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+      class="group pointer-events-auto relative w-full space-x-4 overflow-hidden transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full data-[state=open]:sm:slide-in-from-bottom-full flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
       data-cy="toast"
       data-radix-collection-item=""
       data-state="open"
@@ -251,15 +251,15 @@ exports[`Toaster - Snapshots > matches snapshot for Toaster with toast with acti
       tabindex="0"
     >
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain"
       >
         <div
-          class="text-sm leading-normal font-bold text-popover-foreground"
+          class="min-w-0 text-sm leading-normal font-bold break-words text-popover-foreground"
         >
           Toast with Action
         </div>
         <div
-          class="text-sm text-muted-foreground"
+          class="min-w-0 text-sm wrap-anywhere text-muted-foreground"
         >
           This toast has an action button
         </div>

--- a/src/components/molecules/Toaster/Toaster.tsx
+++ b/src/components/molecules/Toaster/Toaster.tsx
@@ -15,10 +15,10 @@ export function Toaster() {
           <Toast
             key={id}
             data-cy="toast"
-            className="flex items-center justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
+            className="flex items-start justify-between gap-2 rounded-lg border border-brand/32 bg-brand/8 p-6 shadow-lg backdrop-blur-[10px]"
             {...props}
           >
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex max-h-32 min-w-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && <ToastDescription>{description}</ToastDescription>}
             </div>


### PR DESCRIPTION
Long copy-link descriptions no longer overflow under the dismiss action; text wraps with scroll when content exceeds the toast height.


https://github.com/user-attachments/assets/ec43aff3-b90a-479e-bf75-4dfd61a197bb



Resolves #1873 