### PR TITLE
fix: [Bug]: UI: Filterbar and sidebar don't utilize all vertical space #1729

### DIFF
--- a/src/components/organisms/ContentLayout/ContentLayout.test.tsx.snap
+++ b/src/components/organisms/ContentLayout/ContentLayout.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ContentLayout - Custom Feed Layout Override > matches snapshot when cus
       <div
         class="hidden flex-col items-start justify-start gap-6 self-start lg:flex w-(--filter-bar-width) max-w-(--filter-bar-width) min-w-(--filter-bar-width) shrink-0 sticky overflow-x-hidden overflow-y-auto overscroll-contain"
         data-testid="container"
-        style="top: 144px; max-height: calc(100svh - 48px + 144px);"
+        style="top: 144px; max-height: calc(100svh - 144px);"
       >
         <div>
           Left Sidebar
@@ -40,7 +40,7 @@ exports[`ContentLayout - Custom Feed Layout Override > matches snapshot when cus
       <div
         class="hidden flex-col items-start justify-start gap-6 self-start lg:flex w-(--filter-bar-width) max-w-(--filter-bar-width) min-w-(--filter-bar-width) shrink-0 sticky overflow-x-hidden overflow-y-auto overscroll-contain"
         data-testid="container"
-        style="top: 144px; max-height: calc(100svh - 48px + 144px);"
+        style="top: 144px; max-height: calc(100svh - 144px);"
       >
         <div>
           Right Sidebar

--- a/src/components/organisms/ContentLayout/ContentLayout.tsx
+++ b/src/components/organisms/ContentLayout/ContentLayout.tsx
@@ -31,7 +31,7 @@ import type { ContentLayoutProps, StickySidebarProps } from './ContentLayout.typ
  */
 function StickySidebar({ children }: StickySidebarProps) {
   const stickyTop = LAYOUT_DIMENSIONS.HEADER_OFFSET_MAIN;
-  const sidebarMaxHeight = `calc(100svh - ${stickyTop}px - ${LAYOUT_DIMENSIONS.SIDEBAR_BOTTOM_OFFSET}px)`;
+  const sidebarMaxHeight = `calc(100svh - ${stickyTop}px)`;
 
   return (
     <Container


### PR DESCRIPTION
Fixes #1729

<img width="1241" height="681" alt="Screenshot 2026-05-22 at 10 26 56" src="https://github.com/user-attachments/assets/6b509d75-5d1d-48cd-a252-76caec1b8124" />
