### PR TITLE
fix(1499): show auth expired dialog as soon as relay polling fails

### DIFF
--- a/src/core/services/homeserver/error.utils.ts
+++ b/src/core/services/homeserver/error.utils.ts
@@ -20,18 +20,6 @@ const PUBKY_ERROR_NAMES = {
   AUTHENTICATION_ERROR: 'AuthenticationError',
 } as const;
 
-const RETRYABLE_STATUS_CODES = [
-  HttpStatusCode.NOT_FOUND,
-  HttpStatusCode.REQUEST_TIMEOUT,
-  HttpStatusCode.TOO_MANY_REQUESTS,
-  HttpStatusCode.INTERNAL_SERVER_ERROR,
-  HttpStatusCode.BAD_GATEWAY,
-  HttpStatusCode.SERVICE_UNAVAILABLE,
-  HttpStatusCode.GATEWAY_TIMEOUT,
-] as const;
-
-type RetryableStatusCode = (typeof RETRYABLE_STATUS_CODES)[number];
-
 /**
  * Extracts status code from error objects (checks error directly first, then nested data)
  * @param error - The error to extract status code from
@@ -50,34 +38,6 @@ export const extractStatusCode = (error: unknown): number | undefined => {
   if (!('statusCode' in data)) return undefined;
   const statusCode = (data as { statusCode?: unknown }).statusCode;
   return typeof statusCode === 'number' ? statusCode : undefined;
-};
-
-/**
- * Checks if a relay poll error is retryable based on status code or error message
- * @param error - The error to check
- * @returns True if the error is retryable, false otherwise
- */
-export const isRetryableRelayPollError = (error: unknown): boolean => {
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'name' in error &&
-    (error as { name?: unknown }).name === 'RequestError'
-  ) {
-    const statusCode = extractStatusCode(error);
-    // No status code typically means a network-level failure (DNS, connection refused, etc.)
-    // These are transient issues worth retrying during auth polling
-    if (!statusCode) return true;
-    return RETRYABLE_STATUS_CODES.includes(statusCode as RetryableStatusCode);
-  }
-
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
-    if (message.includes('timed out') || message.includes('timeout')) return true;
-    if (message.includes(HttpStatusCode.GATEWAY_TIMEOUT.toString()) || message.includes('gateway')) return true;
-  }
-
-  return false;
 };
 
 /**

--- a/src/core/services/homeserver/homeserver.test.ts
+++ b/src/core/services/homeserver/homeserver.test.ts
@@ -406,14 +406,11 @@ describe('HomeserverService', () => {
         }
       });
 
-      it('should retry polling on retryable relay errors (e.g. 504) and eventually resolve', async () => {
+      it('should reject with SESSION_EXPIRED when tryPollOnce throws (SDK exhausted its retry budget)', async () => {
         vi.useFakeTimers();
         try {
-          const session = createMockSession();
-          const tryPollOnce = vi
-            .fn()
-            .mockRejectedValueOnce({ name: 'RequestError', message: 'Gateway Timeout', data: { statusCode: 504 } })
-            .mockResolvedValueOnce(session);
+          const relayError = { name: 'RequestError', message: 'Gateway Timeout', data: { statusCode: 504 } };
+          const tryPollOnce = vi.fn().mockRejectedValue(relayError);
           const free = vi.fn();
           mockState.startAuthFlow.mockReturnValue({
             authorizationUrl: 'https://auth.example.com/authorize',
@@ -423,40 +420,15 @@ describe('HomeserverService', () => {
 
           const result = await HomeserverService.generateAuthUrl();
           const approvalPromise = result.awaitApproval;
-
-          await vi.advanceTimersByTimeAsync(0);
-          await vi.advanceTimersByTimeAsync(2_000);
-
-          await expect(approvalPromise).resolves.toBe(session);
-          expect(tryPollOnce).toHaveBeenCalledTimes(2);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('should retry polling on 404 Not Found (relay may not have registered flow yet)', async () => {
-        vi.useFakeTimers();
-        try {
-          const session = createMockSession();
-          const tryPollOnce = vi
-            .fn()
-            .mockRejectedValueOnce({ name: 'RequestError', message: '404 Not Found', data: { statusCode: 404 } })
-            .mockResolvedValueOnce(session);
-          const free = vi.fn();
-          mockState.startAuthFlow.mockReturnValue({
-            authorizationUrl: 'https://auth.example.com/authorize',
-            tryPollOnce,
-            free,
+          const rejection = expect(approvalPromise).rejects.toMatchObject({
+            code: AuthErrorCode.SESSION_EXPIRED,
           });
 
-          const result = await HomeserverService.generateAuthUrl();
-          const approvalPromise = result.awaitApproval;
-
           await vi.advanceTimersByTimeAsync(0);
-          await vi.advanceTimersByTimeAsync(2_000);
+          await rejection;
 
-          await expect(approvalPromise).resolves.toBe(session);
-          expect(tryPollOnce).toHaveBeenCalledTimes(2);
+          // Loop must not retry on a dead flow; one throw is terminal.
+          expect(tryPollOnce).toHaveBeenCalledTimes(1);
         } finally {
           vi.useRealTimers();
         }

--- a/src/core/services/homeserver/homeserver.utils.ts
+++ b/src/core/services/homeserver/homeserver.utils.ts
@@ -192,8 +192,10 @@ export const createCancelableAuthApproval = (
         if (maybeSession) return maybeSession;
       } catch (error) {
         if (canceled) throw createCanceledError();
-        // tryPollOnce throws only when the SDK has given up retrying.
-        // The flow is dead, so fail fast with SESSION_EXPIRED instead of retrying our loop.
+        // From the caller's view, tryPollOnce is one-shot: one call, one outcome
+        // (pubky SDK 0.8 — it doesn't loop or retry on our behalf). If it throws,
+        // we treat the flow as dead and fail fast — showing "session expired" now
+        // is better UX than letting the user wait minutes on a flow that may already be dead.
         throw Err.auth(AuthErrorCode.SESSION_EXPIRED, 'Auth flow polling failed', {
           service: ErrorService.Homeserver,
           operation: 'awaitApproval',

--- a/src/core/services/homeserver/homeserver.utils.ts
+++ b/src/core/services/homeserver/homeserver.utils.ts
@@ -8,7 +8,7 @@ import { HttpMethod, HttpStatusCode } from '@/libs/http/http.types';
 import { parseResponseOrThrow } from '@/libs/http/response.utils';
 import { Logger } from '@/libs/logger/logger';
 import { sleep } from '@/libs/utils/utils';
-import { createCanceledError, handleError, isRetryableRelayPollError } from './error.utils';
+import { createCanceledError, extractStatusCode, handleError } from './error.utils';
 import type {
   CancelableAuthApproval,
   PubPath,
@@ -192,11 +192,17 @@ export const createCancelableAuthApproval = (
         if (maybeSession) return maybeSession;
       } catch (error) {
         if (canceled) throw createCanceledError();
-        if (isRetryableRelayPollError(error)) {
-          await sleep(pollIntervalMs);
-          continue;
-        }
-        throw error;
+        // tryPollOnce throws only when the SDK has given up retrying.
+        // The flow is dead, so fail fast with SESSION_EXPIRED instead of retrying our loop.
+        throw Err.auth(AuthErrorCode.SESSION_EXPIRED, 'Auth flow polling failed', {
+          service: ErrorService.Homeserver,
+          operation: 'awaitApproval',
+          context: {
+            originalError: error instanceof Error ? error.message : String(error),
+            statusCode: extractStatusCode(error),
+          },
+          cause: error,
+        });
       }
 
       await sleep(pollIntervalMs);


### PR DESCRIPTION
## Summary
Fixes #1499. The "QR code expired" dialog on the sign-in / sign-up QR screen now appears   as soon as the relay polling actually fails, instead of after an extra silent wait of several minutes.

## Root cause
- The SDK's relay polling already retries internally and only throws once it's actually failed.
- On top of that, our polling loop had its own retry layer that kept polling after the SDK gave up.       
- Result: the dialog was effectively gated on a separate ~5-minute timer, not the real failure, so users
sat on a dead flow for minutes before seeing anything.

## Fix
- **Fail fast on relay error** — when the SDK reports a polling failure, surface it as a session-expired
error immediately instead of retrying.
- **Drop duplicate retry layer** — remove the status-code retry helper that's no longer reachable, since
the SDK is the single source of truth for retry.
- **Comment fix** — clarify in code that we're intentionally choosing the fast "expired + refresh" UX
over a silent wait on a possibly-dead flow.
## Testing
- Updated unit tests to verify that one relay throw is terminal (no extra polling attempts) and produces   the session-expired error.
- Manual smoke: opened the sign-in QR page, let relay requests time out — dialog now appears right after
the SDK gives up rather than minutes later.

## Notes
- No change to other session-expired paths (regular API calls / `requiresLogin` checks).
- Behavior change is scoped to the QR auth flow polling loop only.

## Reulst
<img width="1331" height="876" alt="Screenshot 2026-05-27 at 08 52 28" src="https://github.com/user-attachments/assets/7a6b0be0-0f7e-4f9b-b994-3b377ba045c5" />

## Test
From ephemeral deployment:
https://github.com/user-attachments/assets/24c0fe1b-7596-4924-a712-6e37e0e619d9

From local test: Change the value of `NEXT_PUBLIC_DEFAULT_HTTP_RELAY`.



## Follow-up
- #1910 — revisit "QR code expired" wording vs. relay-failure cause.
