### PR TITLE
fix(ui): scope custom feed layout to feed routes

### DIFF
--- a/src/components/organisms/ContentLayout/ContentLayout.test.tsx
+++ b/src/components/organisms/ContentLayout/ContentLayout.test.tsx
@@ -326,13 +326,15 @@ describe('ContentLayout', () => {
 describe('ContentLayout - Custom Feed Layout Override', () => {
   beforeEach(() => {
     mockUseCustomFeed.mockReturnValue(undefined);
+    mockHomeLayout = 'columns';
   });
 
-  it('hides sidebars when custom feed layout is wide', () => {
+  it('hides sidebars when custom feed route layout is wide', () => {
     mockUseCustomFeed.mockReturnValue({ layout: 'wide' });
 
     render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftSidebarContent={<div data-testid="left-sidebar-content">Left Sidebar</div>}
         showRightSidebar={true}
@@ -347,11 +349,12 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
     expect(screen.queryByText('Right Sidebar')).not.toBeInTheDocument();
   });
 
-  it('shows ButtonFilters when custom feed layout is wide and drawer content exists', () => {
+  it('shows ButtonFilters when custom feed route layout is wide and drawer content exists', () => {
     mockUseCustomFeed.mockReturnValue({ layout: 'wide' });
 
     render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftDrawerContent={<div>Left Drawer</div>}
         showRightSidebar={true}
@@ -365,11 +368,12 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
     expect(screen.getByTestId('button-filters-right')).toBeInTheDocument();
   });
 
-  it('keeps sidebars visible when custom feed layout is columns', () => {
+  it('keeps sidebars visible when custom feed route layout is columns', () => {
     mockUseCustomFeed.mockReturnValue({ layout: 'columns' });
 
     render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftSidebarContent={<div data-testid="left-sidebar-content">Left Sidebar</div>}
         showRightSidebar={true}
@@ -385,12 +389,13 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
     expect(rightElements.length).toBeGreaterThan(0);
   });
 
-  it('custom feed wide layout overrides home store columns layout', () => {
+  it('custom feed route wide layout overrides home store columns layout', () => {
     // Home store is 'columns' by default in mock, custom feed overrides to 'wide'
     mockUseCustomFeed.mockReturnValue({ layout: 'wide' });
 
     render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftSidebarContent={<div data-testid="left-sidebar-content">Left Sidebar</div>}
         leftDrawerContent={<div>Left Drawer</div>}
@@ -405,11 +410,34 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
     expect(screen.getByTestId('button-filters-left')).toBeInTheDocument();
   });
 
-  it('does not show ButtonFilters when custom feed layout is wide but no drawer content', () => {
+  it('uses home store layout on home route even when a latched custom feed layout is wide', () => {
     mockUseCustomFeed.mockReturnValue({ layout: 'wide' });
 
     render(
-      <ContentLayout showLeftSidebar={true} showRightSidebar={true}>
+      <ContentLayout
+        feedVariant="home"
+        showLeftSidebar={true}
+        leftSidebarContent={<div data-testid="left-sidebar-content">Left Sidebar</div>}
+        leftDrawerContent={<div>Left Drawer</div>}
+        showRightSidebar={true}
+        rightSidebarContent={<div data-testid="right-sidebar-content">Right Sidebar</div>}
+        rightDrawerContent={<div>Right Drawer</div>}
+      >
+        <div>Test Content</div>
+      </ContentLayout>,
+    );
+
+    expect(screen.getByText('Left Sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Right Sidebar')).toBeInTheDocument();
+    expect(screen.queryByTestId('button-filters-left')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('button-filters-right')).not.toBeInTheDocument();
+  });
+
+  it('does not show ButtonFilters when custom feed route layout is wide but no drawer content', () => {
+    mockUseCustomFeed.mockReturnValue({ layout: 'wide' });
+
+    render(
+      <ContentLayout feedVariant="custom" showLeftSidebar={true} showRightSidebar={true}>
         <div>Test Content</div>
       </ContentLayout>,
     );
@@ -423,6 +451,7 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
 
     const { container } = render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftSidebarContent={<div>Left Sidebar</div>}
         leftDrawerContent={<div>Left Drawer</div>}
@@ -441,6 +470,7 @@ describe('ContentLayout - Custom Feed Layout Override', () => {
 
     const { container } = render(
       <ContentLayout
+        feedVariant="custom"
         showLeftSidebar={true}
         leftSidebarContent={<div>Left Sidebar</div>}
         showRightSidebar={true}

--- a/src/components/organisms/ContentLayout/ContentLayout.tsx
+++ b/src/components/organisms/ContentLayout/ContentLayout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Container } from '@/atoms/Container/Container';
+import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { LAYOUT_DIMENSIONS } from '@/config/layoutDimensions';
 import { useCustomFeed } from '@/hooks/useCustomFeed/useCustomFeed';
 import { resolveFeedLayout } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
@@ -68,7 +69,10 @@ export function ContentLayout({
 }: ContentLayoutProps) {
   const { layout: homeLayout } = useHomeStore();
   const customFeed = useCustomFeed();
-  const customFeedLayout = customFeed?.layout !== undefined ? pubkyLayoutToHomeLayout(customFeed.layout) : undefined;
+  const customFeedLayout =
+    feedVariant === TIMELINE_FEED_VARIANT.CUSTOM && customFeed?.layout !== undefined
+      ? pubkyLayoutToHomeLayout(customFeed.layout)
+      : undefined;
   const requestedLayout = customFeedLayout ?? homeLayout;
 
   const [drawerFilterOpen, setDrawerFilterOpen] = useState(false);


### PR DESCRIPTION
## Summary
- fix #1911
- Prevents wide/visual custom feed layout state from leaking into default feed routes after navigation.
- Restores the default feed shell immediately when returning to `/home`, `/bookmarks`, or other non-custom feed routes.

## Changes
- Scope `ContentLayout` custom feed layout overrides to `TIMELINE_FEED_VARIANT.CUSTOM`.
- Keep default feed routes driven by the persisted home layout even when `useCustomFeed` has a latched custom feed.
- Add regression coverage for home route layout behavior with a latched wide custom feed.

https://github.com/user-attachments/assets/756500a9-a2da-4ecf-b2d4-69de7be3b69b


## Notes
- `useCustomFeed` remains latched for intercepted post navigation; only the layout consumer is scoped by route variant.