### PR TITLE
feat(collections): dedicated bookmarks collection detail view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ Use `Err.*` factories (never raw `Error`). Factories log automatically — don't
 - App routes: import route enums, maps, and helpers from `@/app/routes` (`src/app/routes.ts`); prefer that over route-only imports through a re-export entrypoint.
 - Z-index scale: -z-10, z-10, z-30, z-40, z-50, z-60 (see `docs/z-index.md`)
 - **Icons**: stock Lucide from `lucide-react`; custom/brand SVG components from `@/icons` (`src/libs/icons/icons.tsx` via `tsconfig` path alias). URL→icon helpers (`getIconFromUrl`, `getLabelFromUrl`, …) live in `@/libs/utils/urlToIcon` — see `docs/components.md` — _Icons (Lucide and custom)_.
+- **Forms (standard)**: build new forms with `react-hook-form` + `zod` (via `@hookform/resolvers/zod`). Wrap field components with `Controller` (use the `ControlledInputField` / `ControlledTextareaField` molecules where applicable). Keep the schema + types + defaults in a sibling `*.types.ts` file next to the hook (see `src/hooks/useCreateCollection/useCreateCollection.types.ts` for the canonical layout). Components must not call controllers directly — wrap the mutation in a hook (`use{Action}Form` or `use{Verb}{Entity}`) that returns `{ form, submit, reset, ... }`, where `submit()` returns `Promise<boolean>` so the caller can decide what to do on success. Non-text inputs (file pickers, rich text, etc.) live in their own dedicated hooks (e.g. `useCoverImagePicker`) and the form hook composes them. Localize zod messages by passing `useTranslations(...)` into a schema factory.
+- **Memoization**: do not add `useCallback` / `useMemo` — the React Compiler (`reactCompiler: true` in `next.config.ts`) handles memoization. Reach for them only after profiling proves the compiler missed something.
 
 ## Learned User Preferences
 

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -446,11 +446,13 @@ describe('posts', () => {
     cy.findFirstPostInFeedFiltered(postContent1, CheckForNewPosts.No, WaitForNewPosts.Yes).within(() => {
       cy.get('[data-cy="post-bookmark-btn"]').click();
     });
+    cy.get('[data-cy="post-save-bookmarks-option"]').click();
 
     createQuickPost(postContent2);
     cy.findFirstPostInFeedFiltered(postContent2, CheckForNewPosts.No, WaitForNewPosts.Yes).within(() => {
       cy.get('[data-cy="post-bookmark-btn"]').click();
     });
+    cy.get('[data-cy="post-save-bookmarks-option"]').click();
 
     cy.get('a[href="/collections"]').first().click();
     cy.location('pathname').should('eq', '/collections');
@@ -467,6 +469,7 @@ describe('posts', () => {
       .then(($posts) => {
         $posts.each((_idx, element) => {
           cy.wrap(element).find('[data-cy="post-bookmark-btn"]').click();
+          cy.get('[data-cy="post-save-bookmarks-option"]').click();
         });
       });
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1228,10 +1228,45 @@
   },
   "collections": {
     "title": "مجموعاتي",
+    "new": {
+      "cta": "مجموعة جديدة",
+      "title": "مجموعة جديدة",
+      "nameLabel": "العنوان",
+      "namePlaceholder": "إثبات العمل",
+      "descriptionLabel": "الوصف",
+      "descriptionPlaceholder": "أفضل ما قدمه أكبر المساهمين في بيتكوين",
+      "backgroundLabel": "الخلفية",
+      "addImage": "إضافة صورة",
+      "removeImage": "إزالة الصورة",
+      "coverImageInvalid": "يجب أن تكون صورة الغلاف ملف صورة.",
+      "coverImageTooLarge": "صورة الغلاف كبيرة جداً.",
+      "nameRequired": "عنوان المجموعة مطلوب.",
+      "cancel": "إلغاء",
+      "save": "حفظ المجموعة",
+      "saving": "جارٍ الحفظ...",
+      "created": "تم إنشاء المجموعة {name}",
+      "createFailed": "فشل إنشاء المجموعة."
+    },
     "bookmarks": {
       "title": "الإشارات المرجعية",
       "description": "كل ما تريد حفظه لوقت لاحق."
     },
     "private": "خاص"
+  },
+  "postSave": {
+    "title": "حفظ المنشور",
+    "description": "اختر مكان حفظ هذا المنشور.",
+    "open": "حفظ المنشور",
+    "loading": "جارٍ تحميل خيارات الحفظ",
+    "bookmarks": "الإشارات المرجعية",
+    "newCollection": "مجموعة جديدة",
+    "collectionNamePlaceholder": "اسم المجموعة",
+    "createCollection": "إنشاء مجموعة",
+    "loadingCollections": "جارٍ تحميل المجموعات...",
+    "addedToCollection": "تمت إضافة المنشور إلى {name}.",
+    "removedFromCollection": "تمت إزالة المنشور من {name}.",
+    "updateCollectionFailed": "فشل تحديث المجموعة.",
+    "collectionCreated": "تم إنشاء المجموعة وحفظ المنشور.",
+    "createCollectionFailed": "فشل إنشاء المجموعة."
   }
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1249,7 +1249,12 @@
     },
     "bookmarks": {
       "title": "الإشارات المرجعية",
-      "description": "كل ما تريد حفظه لوقت لاحق."
+      "description": "كل ما تريد حفظه لوقت لاحق.",
+      "ownerLabel": "منسقة بواسطة {name}",
+      "postSingular": "منشور",
+      "postPlural": "منشورات",
+      "emptyTitle": "لا توجد إشارات مرجعية بعد",
+      "emptyDescription": "احفظ المنشورات في الإشارات المرجعية وستظهر هنا."
     },
     "private": "خاص"
   },

--- a/messages/de.json
+++ b/messages/de.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "Meine Sammlungen",
+    "new": {
+      "cta": "Neue Sammlung",
+      "title": "Neue Sammlung",
+      "nameLabel": "Titel",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Beschreibung",
+      "descriptionPlaceholder": "Das Beste von den größten Beitragenden in Bitcoin",
+      "backgroundLabel": "Hintergrund",
+      "addImage": "Bild hinzufügen",
+      "removeImage": "Bild entfernen",
+      "coverImageInvalid": "Das Coverbild muss eine Bilddatei sein.",
+      "coverImageTooLarge": "Das Coverbild ist zu groß.",
+      "nameRequired": "Sammlungstitel ist erforderlich.",
+      "cancel": "Abbrechen",
+      "save": "Sammlung speichern",
+      "saving": "Wird gespeichert...",
+      "created": "Sammlung {name} erstellt",
+      "createFailed": "Sammlung konnte nicht erstellt werden."
+    },
     "bookmarks": {
       "title": "Lesezeichen",
       "description": "Alles, was du für später speichern möchtest."
     },
     "private": "PRIVAT"
+  },
+  "postSave": {
+    "title": "Beitrag speichern",
+    "description": "Wähle, wo dieser Beitrag gespeichert werden soll.",
+    "open": "Beitrag speichern",
+    "loading": "Speicheroptionen werden geladen",
+    "bookmarks": "Lesezeichen",
+    "newCollection": "Neue Sammlung",
+    "collectionNamePlaceholder": "Name der Sammlung",
+    "createCollection": "Sammlung erstellen",
+    "loadingCollections": "Sammlungen werden geladen...",
+    "addedToCollection": "Beitrag zu {name} hinzugefügt.",
+    "removedFromCollection": "Beitrag aus {name} entfernt.",
+    "updateCollectionFailed": "Sammlung konnte nicht aktualisiert werden.",
+    "collectionCreated": "Sammlung erstellt und Beitrag gespeichert.",
+    "createCollectionFailed": "Sammlung konnte nicht erstellt werden."
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1255,7 +1255,9 @@
     },
     "bookmarks": {
       "title": "Lesezeichen",
-      "description": "Alles, was du für später speichern möchtest."
+      "description": "Alles, was du für später gespeichert hast",
+      "emptyTitle": "Noch keine Lesezeichen",
+      "emptyDescription": "Speichere Beiträge in den Lesezeichen, dann erscheinen sie hier."
     },
     "private": "PRIVAT"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -1255,7 +1255,9 @@
     },
     "bookmarks": {
       "title": "Bookmarks",
-      "description": "Everything you want to save for later."
+      "description": "Everything you saved for later",
+      "emptyTitle": "No bookmarks yet",
+      "emptyDescription": "Save posts to Bookmarks and they will appear here."
     },
     "private": "PRIVATE"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "My Collections",
+    "new": {
+      "cta": "New Collection",
+      "title": "New Collection",
+      "nameLabel": "Title",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "The best from the biggest contributors in Bitcoin",
+      "backgroundLabel": "Background",
+      "addImage": "Add image",
+      "removeImage": "Remove image",
+      "coverImageInvalid": "Cover image must be an image file.",
+      "coverImageTooLarge": "Cover image is too large.",
+      "nameRequired": "Collection title is required.",
+      "cancel": "Cancel",
+      "save": "Save collection",
+      "saving": "Saving...",
+      "created": "Collection {name} created",
+      "createFailed": "Failed to create collection."
+    },
     "bookmarks": {
       "title": "Bookmarks",
       "description": "Everything you want to save for later."
     },
     "private": "PRIVATE"
+  },
+  "postSave": {
+    "title": "Save post",
+    "description": "Choose where this post should be saved.",
+    "open": "Save post",
+    "loading": "Loading save options",
+    "bookmarks": "Bookmarks",
+    "newCollection": "New Collection",
+    "collectionNamePlaceholder": "Collection name",
+    "createCollection": "Create collection",
+    "loadingCollections": "Loading collections...",
+    "addedToCollection": "Post added to {name}.",
+    "removedFromCollection": "Post removed from {name}.",
+    "updateCollectionFailed": "Failed to update collection.",
+    "collectionCreated": "Collection created and post saved.",
+    "createCollectionFailed": "Failed to create collection."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "Mis colecciones",
+    "new": {
+      "cta": "Nueva colección",
+      "title": "Nueva colección",
+      "nameLabel": "Título",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "Lo mejor de los mayores contribuyentes de Bitcoin",
+      "backgroundLabel": "Fondo",
+      "addImage": "Añadir imagen",
+      "removeImage": "Quitar imagen",
+      "coverImageInvalid": "La imagen de portada debe ser un archivo de imagen.",
+      "coverImageTooLarge": "La imagen de portada es demasiado grande.",
+      "nameRequired": "El título de la colección es obligatorio.",
+      "cancel": "Cancelar",
+      "save": "Guardar colección",
+      "saving": "Guardando...",
+      "created": "Colección {name} creada",
+      "createFailed": "No se pudo crear la colección."
+    },
     "bookmarks": {
       "title": "Marcadores",
       "description": "Todo lo que quieres guardar para más tarde."
     },
     "private": "PRIVADO"
+  },
+  "postSave": {
+    "title": "Guardar publicación",
+    "description": "Elige dónde guardar esta publicación.",
+    "open": "Guardar publicación",
+    "loading": "Cargando opciones de guardado",
+    "bookmarks": "Marcadores",
+    "newCollection": "Nueva colección",
+    "collectionNamePlaceholder": "Nombre de la colección",
+    "createCollection": "Crear colección",
+    "loadingCollections": "Cargando colecciones...",
+    "addedToCollection": "Publicación añadida a {name}.",
+    "removedFromCollection": "Publicación eliminada de {name}.",
+    "updateCollectionFailed": "No se pudo actualizar la colección.",
+    "collectionCreated": "Colección creada y publicación guardada.",
+    "createCollectionFailed": "No se pudo crear la colección."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1255,7 +1255,9 @@
     },
     "bookmarks": {
       "title": "Marcadores",
-      "description": "Todo lo que quieres guardar para más tarde."
+      "description": "Todo lo que guardaste para más tarde",
+      "emptyTitle": "Aún no hay marcadores",
+      "emptyDescription": "Guarda publicaciones en Marcadores y aparecerán aquí."
     },
     "private": "PRIVADO"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1255,7 +1255,9 @@
     },
     "bookmarks": {
       "title": "Signets",
-      "description": "Tout ce que vous souhaitez enregistrer pour plus tard."
+      "description": "Tout ce que vous avez enregistré pour plus tard",
+      "emptyTitle": "Aucun signet pour le moment",
+      "emptyDescription": "Enregistrez des publications dans les signets et elles apparaîtront ici."
     },
     "private": "PRIVÉ"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "Mes collections",
+    "new": {
+      "cta": "Nouvelle collection",
+      "title": "Nouvelle collection",
+      "nameLabel": "Titre",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Le meilleur des plus grands contributeurs Bitcoin",
+      "backgroundLabel": "Arrière-plan",
+      "addImage": "Ajouter une image",
+      "removeImage": "Supprimer l'image",
+      "coverImageInvalid": "L'image de couverture doit être un fichier image.",
+      "coverImageTooLarge": "L'image de couverture est trop grande.",
+      "nameRequired": "Le titre de la collection est requis.",
+      "cancel": "Annuler",
+      "save": "Enregistrer la collection",
+      "saving": "Enregistrement...",
+      "created": "Collection {name} créée",
+      "createFailed": "Échec de la création de la collection."
+    },
     "bookmarks": {
       "title": "Signets",
       "description": "Tout ce que vous souhaitez enregistrer pour plus tard."
     },
     "private": "PRIVÉ"
+  },
+  "postSave": {
+    "title": "Enregistrer la publication",
+    "description": "Choisissez où enregistrer cette publication.",
+    "open": "Enregistrer la publication",
+    "loading": "Chargement des options d'enregistrement",
+    "bookmarks": "Signets",
+    "newCollection": "Nouvelle collection",
+    "collectionNamePlaceholder": "Nom de la collection",
+    "createCollection": "Créer une collection",
+    "loadingCollections": "Chargement des collections...",
+    "addedToCollection": "Publication ajoutée à {name}.",
+    "removedFromCollection": "Publication retirée de {name}.",
+    "updateCollectionFailed": "Échec de la mise à jour de la collection.",
+    "collectionCreated": "Collection créée et publication enregistrée.",
+    "createCollectionFailed": "Échec de la création de la collection."
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "Le mie collezioni",
+    "new": {
+      "cta": "Nuova collezione",
+      "title": "Nuova collezione",
+      "nameLabel": "Titolo",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Descrizione",
+      "descriptionPlaceholder": "Il meglio dai maggiori contributori di Bitcoin",
+      "backgroundLabel": "Sfondo",
+      "addImage": "Aggiungi immagine",
+      "removeImage": "Rimuovi immagine",
+      "coverImageInvalid": "L'immagine di copertina deve essere un file immagine.",
+      "coverImageTooLarge": "L'immagine di copertina è troppo grande.",
+      "nameRequired": "Il titolo della collezione è obbligatorio.",
+      "cancel": "Annulla",
+      "save": "Salva collezione",
+      "saving": "Salvataggio...",
+      "created": "Collezione {name} creata",
+      "createFailed": "Impossibile creare la collezione."
+    },
     "bookmarks": {
       "title": "Segnalibri",
       "description": "Tutto ciò che vuoi salvare per dopo."
     },
     "private": "PRIVATO"
+  },
+  "postSave": {
+    "title": "Salva post",
+    "description": "Scegli dove salvare questo post.",
+    "open": "Salva post",
+    "loading": "Caricamento opzioni di salvataggio",
+    "bookmarks": "Segnalibri",
+    "newCollection": "Nuova collezione",
+    "collectionNamePlaceholder": "Nome della collezione",
+    "createCollection": "Crea collezione",
+    "loadingCollections": "Caricamento collezioni...",
+    "addedToCollection": "Post aggiunto a {name}.",
+    "removedFromCollection": "Post rimosso da {name}.",
+    "updateCollectionFailed": "Impossibile aggiornare la collezione.",
+    "collectionCreated": "Collezione creata e post salvato.",
+    "createCollectionFailed": "Impossibile creare la collezione."
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1255,7 +1255,9 @@
     },
     "bookmarks": {
       "title": "Segnalibri",
-      "description": "Tutto ciò che vuoi salvare per dopo."
+      "description": "Tutto ciò che hai salvato per dopo",
+      "emptyTitle": "Ancora nessun segnalibro",
+      "emptyDescription": "Salva i post nei Segnalibri e appariranno qui."
     },
     "private": "PRIVATO"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "マイコレクション",
+    "new": {
+      "cta": "新しいコレクション",
+      "title": "新しいコレクション",
+      "nameLabel": "タイトル",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "説明",
+      "descriptionPlaceholder": "ビットコインの主要な貢献者のベスト",
+      "backgroundLabel": "背景",
+      "addImage": "画像を追加",
+      "removeImage": "画像を削除",
+      "coverImageInvalid": "カバー画像は画像ファイルである必要があります。",
+      "coverImageTooLarge": "カバー画像が大きすぎます。",
+      "nameRequired": "コレクションのタイトルは必須です。",
+      "cancel": "キャンセル",
+      "save": "コレクションを保存",
+      "saving": "保存中...",
+      "created": "コレクション「{name}」を作成しました",
+      "createFailed": "コレクションの作成に失敗しました。"
+    },
     "bookmarks": {
       "title": "ブックマーク",
       "description": "あとで見たいものをすべて保存できます。"
     },
     "private": "非公開"
+  },
+  "postSave": {
+    "title": "投稿を保存",
+    "description": "この投稿を保存する場所を選択してください。",
+    "open": "投稿を保存",
+    "loading": "保存オプションを読み込み中",
+    "bookmarks": "ブックマーク",
+    "newCollection": "新しいコレクション",
+    "collectionNamePlaceholder": "コレクション名",
+    "createCollection": "コレクションを作成",
+    "loadingCollections": "コレクションを読み込み中...",
+    "addedToCollection": "投稿を「{name}」に追加しました。",
+    "removedFromCollection": "投稿を「{name}」から削除しました。",
+    "updateCollectionFailed": "コレクションの更新に失敗しました。",
+    "collectionCreated": "コレクションを作成し、投稿を保存しました。",
+    "createCollectionFailed": "コレクションの作成に失敗しました。"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1255,7 +1255,12 @@
     },
     "bookmarks": {
       "title": "ブックマーク",
-      "description": "あとで見たいものをすべて保存できます。"
+      "description": "あとで見たいものをすべて保存できます。",
+      "ownerLabel": "{name} が整理",
+      "postSingular": "件の投稿",
+      "postPlural": "件の投稿",
+      "emptyTitle": "ブックマークはまだありません",
+      "emptyDescription": "投稿をブックマークに保存すると、ここに表示されます。"
     },
     "private": "非公開"
   },

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1234,10 +1234,45 @@
   },
   "collections": {
     "title": "Minhas coleções",
+    "new": {
+      "cta": "Nova coleção",
+      "title": "Nova coleção",
+      "nameLabel": "Título",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "Descrição",
+      "descriptionPlaceholder": "O melhor dos maiores contribuidores do Bitcoin",
+      "backgroundLabel": "Plano de fundo",
+      "addImage": "Adicionar imagem",
+      "removeImage": "Remover imagem",
+      "coverImageInvalid": "A imagem de capa deve ser um arquivo de imagem.",
+      "coverImageTooLarge": "A imagem de capa é muito grande.",
+      "nameRequired": "O título da coleção é obrigatório.",
+      "cancel": "Cancelar",
+      "save": "Salvar coleção",
+      "saving": "Salvando...",
+      "created": "Coleção {name} criada",
+      "createFailed": "Falha ao criar a coleção."
+    },
     "bookmarks": {
       "title": "Favoritos",
       "description": "Tudo o que você quer salvar para mais tarde."
     },
     "private": "PRIVADO"
+  },
+  "postSave": {
+    "title": "Salvar publicação",
+    "description": "Escolha onde esta publicação deve ser salva.",
+    "open": "Salvar publicação",
+    "loading": "Carregando opções de salvamento",
+    "bookmarks": "Favoritos",
+    "newCollection": "Nova coleção",
+    "collectionNamePlaceholder": "Nome da coleção",
+    "createCollection": "Criar coleção",
+    "loadingCollections": "Carregando coleções...",
+    "addedToCollection": "Publicação adicionada a {name}.",
+    "removedFromCollection": "Publicação removida de {name}.",
+    "updateCollectionFailed": "Falha ao atualizar a coleção.",
+    "collectionCreated": "Coleção criada e publicação salva.",
+    "createCollectionFailed": "Falha ao criar a coleção."
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1255,7 +1255,12 @@
     },
     "bookmarks": {
       "title": "Favoritos",
-      "description": "Tudo o que você quer salvar para mais tarde."
+      "description": "Tudo o que você quer salvar para mais tarde.",
+      "ownerLabel": "Organizado por {name}",
+      "postSingular": "publicação",
+      "postPlural": "publicações",
+      "emptyTitle": "Ainda não há favoritos",
+      "emptyDescription": "Salve publicações nos Favoritos e elas aparecerão aqui."
     },
     "private": "PRIVADO"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1228,10 +1228,45 @@
   },
   "collections": {
     "title": "我的收藏集",
+    "new": {
+      "cta": "新建收藏集",
+      "title": "新建收藏集",
+      "nameLabel": "标题",
+      "namePlaceholder": "Proof of Work",
+      "descriptionLabel": "描述",
+      "descriptionPlaceholder": "来自比特币最大贡献者的精选",
+      "backgroundLabel": "背景",
+      "addImage": "添加图片",
+      "removeImage": "移除图片",
+      "coverImageInvalid": "封面图片必须是图片文件。",
+      "coverImageTooLarge": "封面图片太大。",
+      "nameRequired": "收藏集标题为必填项。",
+      "cancel": "取消",
+      "save": "保存收藏集",
+      "saving": "保存中...",
+      "created": "收藏集 {name} 已创建",
+      "createFailed": "创建收藏集失败。"
+    },
     "bookmarks": {
       "title": "书签",
       "description": "保存你想稍后查看的所有内容。"
     },
     "private": "私密"
+  },
+  "postSave": {
+    "title": "保存帖子",
+    "description": "选择将此帖子保存到哪里。",
+    "open": "保存帖子",
+    "loading": "正在加载保存选项",
+    "bookmarks": "书签",
+    "newCollection": "新建收藏集",
+    "collectionNamePlaceholder": "收藏集名称",
+    "createCollection": "创建收藏集",
+    "loadingCollections": "正在加载收藏集...",
+    "addedToCollection": "帖子已添加到 {name}。",
+    "removedFromCollection": "帖子已从 {name} 移除。",
+    "updateCollectionFailed": "更新收藏集失败。",
+    "collectionCreated": "收藏集已创建并保存帖子。",
+    "createCollectionFailed": "创建收藏集失败。"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1249,7 +1249,12 @@
     },
     "bookmarks": {
       "title": "书签",
-      "description": "保存你想稍后查看的所有内容。"
+      "description": "保存你想稍后查看的所有内容。",
+      "ownerLabel": "由 {name} 整理",
+      "postSingular": "篇帖子",
+      "postPlural": "篇帖子",
+      "emptyTitle": "还没有书签",
+      "emptyDescription": "将帖子保存到书签后，它们会显示在这里。"
     },
     "private": "私密"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "franky",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "franky",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@codemirror/theme-one-dark": "6.1.3",
         "@emoji-mart/data": "1.2.1",
@@ -36,7 +36,7 @@
         "next": "16.2.6",
         "next-intl": "4.12.0",
         "next-themes": "0.4.6",
-        "pubky-app-specs": "0.4.4",
+        "pubky-app-specs": "0.5.2-rc2",
         "qrcode.react": "4.2.0",
         "radix-ui": "1.4.3",
         "react": "19.2.6",
@@ -16580,9 +16580,9 @@
       "license": "MIT"
     },
     "node_modules/pubky-app-specs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/pubky-app-specs/-/pubky-app-specs-0.4.4.tgz",
-      "integrity": "sha512-+TzW46KuHhIusOm23iJejrMcVeydPmvErQFPrkHtU2zlUUqXudEK3r3x1urpEcaVcCRZRnTjWfpvuSHA9iqFqQ==",
+      "version": "0.5.2-rc2",
+      "resolved": "https://registry.npmjs.org/pubky-app-specs/-/pubky-app-specs-0.5.2-rc2.tgz",
+      "integrity": "sha512-sgj6YWfUddaWEC1LHo9pn7vZw8xLwDKlM/gkLMtQXnKZBiqXTH9tiL8qUugF/86smdKXXAtXYYTqNdjFMwHKlQ==",
       "license": "MIT"
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "next": "16.2.6",
     "next-intl": "4.12.0",
     "next-themes": "0.4.6",
-    "pubky-app-specs": "0.4.4",
+    "pubky-app-specs": "0.5.2-rc2",
     "qrcode.react": "4.2.0",
     "radix-ui": "1.4.3",
     "react": "19.2.6",

--- a/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx
+++ b/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BookmarksCollectionHeader } from './BookmarksCollectionHeader';
+
+vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
+  AvatarWithFallback: ({
+    avatarUrl,
+    name,
+    fallbackSeed,
+    size,
+    alt,
+  }: {
+    avatarUrl?: string;
+    name: string;
+    fallbackSeed?: string;
+    size?: string;
+    alt?: string;
+  }) => (
+    <div
+      data-testid="avatar-with-fallback"
+      data-avatar-url={avatarUrl}
+      data-name={name}
+      data-fallback-seed={fallbackSeed}
+      data-size={size}
+      data-alt={alt}
+    >
+      {name}
+    </div>
+  ),
+}));
+
+const defaultProps = {
+  title: 'Bookmarks',
+  description: 'Everything you saved for later',
+  ownerName: 'Test User',
+  visibilityLabel: 'PRIVATE',
+  postCount: 29,
+  ownerAvatarUrl: 'https://example.com/avatar.png',
+  ownerSeed: 'test-pubky',
+};
+
+describe('BookmarksCollectionHeader', () => {
+  it('renders the collection title, owner, count, visibility, and description', () => {
+    render(<BookmarksCollectionHeader {...defaultProps} />);
+
+    const header = screen.getByTestId('bookmarks-collection-header');
+    expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeInTheDocument();
+    expect(screen.getByText('Everything you saved for later')).toBeInTheDocument();
+    expect(header).toHaveTextContent('Test User');
+    expect(header).toHaveTextContent('29');
+    expect(header).toHaveTextContent('PRIVATE');
+    expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute(
+      'data-avatar-url',
+      'https://example.com/avatar.png',
+    );
+    expect(document.querySelector('.lucide-sticky-note')).toBeInTheDocument();
+    expect(document.querySelector('.lucide-circle-user-round')).toBeInTheDocument();
+  });
+
+  it('does not render collection management actions', () => {
+    render(<BookmarksCollectionHeader {...defaultProps} />);
+
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reorder/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('BookmarksCollectionHeader - Snapshots', () => {
+  it('matches snapshot with default props', () => {
+    const { container } = render(<BookmarksCollectionHeader {...defaultProps} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx.snap
+++ b/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx.snap
@@ -1,0 +1,121 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BookmarksCollectionHeader - Snapshots > matches snapshot with default props 1`] = `
+<div
+  class="flex w-full flex-col gap-4 rounded-md bg-card p-6 lg:p-12"
+  data-testid="bookmarks-collection-header"
+>
+  <h1
+    class="w-full break-words text-5xl leading-none font-bold text-white lg:text-6xl"
+    data-testid="typography"
+  >
+    Bookmarks
+  </h1>
+  <div
+    class="flex w-full flex-wrap items-center gap-6"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-3 lg:flex-none"
+      data-testid="container"
+    >
+      <div
+        data-alt="Test User"
+        data-avatar-url="https://example.com/avatar.png"
+        data-fallback-seed="test-pubky"
+        data-name="Test User"
+        data-size="md"
+        data-testid="avatar-with-fallback"
+      >
+        Test User
+      </div>
+      <span
+        class="min-w-0 flex-1 truncate text-xl leading-7 font-bold text-white"
+        data-testid="typography"
+      >
+        Test User
+      </span>
+    </div>
+    <div
+      class="flex shrink-0 items-center gap-3 text-muted-foreground"
+      data-testid="container"
+    >
+      <div
+        class="flex items-center gap-1"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sticky-note size-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+          />
+          <path
+            d="M15 3v5a1 1 0 0 0 1 1h5"
+          />
+        </svg>
+        <span
+          class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+          data-testid="typography"
+        >
+          29
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-1"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-user-round size-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M17.925 20.056a6 6 0 0 0-11.851.001"
+          />
+          <circle
+            cx="12"
+            cy="11"
+            r="4"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+        </svg>
+        <span
+          class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+          data-testid="typography"
+        >
+          PRIVATE
+        </span>
+      </div>
+    </div>
+  </div>
+  <p
+    class="w-full text-xl leading-7 font-light text-muted-foreground lg:text-2xl lg:leading-8"
+    data-testid="typography"
+  >
+    Everything you saved for later
+  </p>
+</div>
+`;

--- a/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx.snap
+++ b/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`BookmarksCollectionHeader - Snapshots > matches snapshot with default p
   data-testid="bookmarks-collection-header"
 >
   <h1
-    class="w-full break-words text-5xl leading-none font-bold text-white lg:text-6xl"
+    class="w-full text-5xl leading-none font-bold break-words text-white lg:text-6xl"
     data-testid="typography"
   >
     Bookmarks

--- a/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.tsx
+++ b/src/components/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader.tsx
@@ -1,0 +1,84 @@
+import { CircleUserRound, StickyNote } from 'lucide-react';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
+
+interface BookmarksCollectionHeaderProps {
+  title: string;
+  description: string;
+  ownerName: string;
+  visibilityLabel: string;
+  postCount: number;
+  ownerAvatarUrl?: string;
+  ownerSeed?: string;
+}
+
+export function BookmarksCollectionHeader({
+  title,
+  description,
+  ownerName,
+  visibilityLabel,
+  postCount,
+  ownerAvatarUrl,
+  ownerSeed,
+}: BookmarksCollectionHeaderProps) {
+  const postCountLabel = String(postCount);
+
+  return (
+    <Container
+      data-testid="bookmarks-collection-header"
+      overrideDefaults
+      className="flex w-full flex-col gap-4 rounded-md bg-card p-6 lg:p-12"
+    >
+      <Typography
+        as="h1"
+        overrideDefaults
+        className="w-full text-5xl leading-none font-bold break-words text-white lg:text-6xl"
+      >
+        {title}
+      </Typography>
+
+      <Container overrideDefaults className="flex w-full flex-wrap items-center gap-6">
+        <Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-3 lg:flex-none">
+          <AvatarWithFallback
+            avatarUrl={ownerAvatarUrl}
+            name={ownerName}
+            fallbackSeed={ownerSeed ?? ownerName}
+            size="md"
+            alt={ownerName}
+          />
+          <Typography
+            as="span"
+            overrideDefaults
+            className="min-w-0 flex-1 truncate text-xl leading-7 font-bold text-white"
+          >
+            {ownerName}
+          </Typography>
+        </Container>
+
+        <Container overrideDefaults className="flex shrink-0 items-center gap-3 text-muted-foreground">
+          <Container overrideDefaults className="flex items-center gap-1">
+            <StickyNote className="size-3" strokeWidth={2} />
+            <Typography as="span" overrideDefaults className="text-xs leading-4 font-medium tracking-[1.2px] uppercase">
+              {postCountLabel}
+            </Typography>
+          </Container>
+          <Container overrideDefaults className="flex items-center gap-1">
+            <CircleUserRound className="size-4" strokeWidth={2} />
+            <Typography as="span" overrideDefaults className="text-xs leading-4 font-medium tracking-[1.2px] uppercase">
+              {visibilityLabel}
+            </Typography>
+          </Container>
+        </Container>
+      </Container>
+
+      <Typography
+        as="p"
+        overrideDefaults
+        className="w-full text-xl leading-7 font-light text-muted-foreground lg:text-2xl lg:leading-8"
+      >
+        {description}
+      </Typography>
+    </Container>
+  );
+}

--- a/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.test.tsx
+++ b/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BookmarksEmptyState } from './BookmarksEmptyState';
+
+const defaultProps = {
+  title: 'No bookmarks yet',
+  description: 'Save posts to Bookmarks and they will appear here.',
+};
+
+describe('BookmarksEmptyState', () => {
+  it('renders the empty state title and description', () => {
+    render(<BookmarksEmptyState {...defaultProps} />);
+
+    expect(screen.getByTestId('bookmarks-empty-state')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No bookmarks yet' })).toBeInTheDocument();
+    expect(screen.getByText('Save posts to Bookmarks and they will appear here.')).toBeInTheDocument();
+  });
+});
+
+describe('BookmarksEmptyState - Snapshots', () => {
+  it('matches snapshot with default props', () => {
+    const { container } = render(<BookmarksEmptyState {...defaultProps} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.test.tsx.snap
+++ b/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.test.tsx.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BookmarksEmptyState - Snapshots > matches snapshot with default props 1`] = `
+<div
+  class="flex min-h-48 w-full flex-col items-center justify-center gap-2 rounded-md px-6 py-12 text-center"
+  data-testid="bookmarks-empty-state"
+>
+  <h2
+    class="text-xl leading-7 font-bold text-foreground"
+    data-testid="typography"
+  >
+    No bookmarks yet
+  </h2>
+  <p
+    class="max-w-md text-base leading-6 font-medium text-muted-foreground"
+    data-testid="typography"
+  >
+    Save posts to Bookmarks and they will appear here.
+  </p>
+</div>
+`;

--- a/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.tsx
+++ b/src/components/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState.tsx
@@ -1,0 +1,24 @@
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+
+interface BookmarksEmptyStateProps {
+  title: string;
+  description: string;
+}
+
+export function BookmarksEmptyState({ title, description }: BookmarksEmptyStateProps) {
+  return (
+    <Container
+      data-testid="bookmarks-empty-state"
+      overrideDefaults
+      className="flex min-h-48 w-full flex-col items-center justify-center gap-2 rounded-md px-6 py-12 text-center"
+    >
+      <Typography as="h2" overrideDefaults className="text-xl leading-7 font-bold text-foreground">
+        {title}
+      </Typography>
+      <Typography overrideDefaults className="max-w-md text-base leading-6 font-medium text-muted-foreground">
+        {description}
+      </Typography>
+    </Container>
+  );
+}

--- a/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx
+++ b/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx
@@ -36,7 +36,7 @@ describe('CollectionCard', () => {
       <CollectionCard
         href="/collections/bookmarks"
         title="Bookmarks"
-        description="Everything you want to save for later."
+        description="Everything you saved for later"
         icon={Bookmark}
         count={29}
         visibilityLabel="PRIVATE"
@@ -49,7 +49,7 @@ describe('CollectionCard', () => {
     const link = screen.getByRole('link', { name: 'Bookmarks' });
     expect(link).toHaveAttribute('href', '/collections/bookmarks');
     expect(screen.getByText('Bookmarks')).toBeInTheDocument();
-    expect(screen.getByText('Everything you want to save for later.')).toBeInTheDocument();
+    expect(screen.getByText('Everything you saved for later')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
     expect(screen.getByText('PRIVATE')).toBeInTheDocument();
     expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute(
@@ -68,7 +68,7 @@ describe('CollectionCard - Snapshots', () => {
       <CollectionCard
         href="/collections/bookmarks"
         title="Bookmarks"
-        description="Everything you want to save for later."
+        description="Everything you saved for later"
         icon={Bookmark}
         count={29}
         visibilityLabel="PRIVATE"

--- a/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CollectionCard - Snapshots > matches snapshot with default props 1`] = `
 <a
   aria-label="Bookmarks"
-  class="block w-full lg:max-w-[588px]"
+  class="block w-full lg:max-w-xl"
   data-cy="collection-card"
   href="/collections/bookmarks"
 >
@@ -77,7 +77,7 @@ exports[`CollectionCard - Snapshots > matches snapshot with default props 1`] = 
               />
             </svg>
             <span
-              class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+              class="text-xs leading-4 font-medium tracking-widest uppercase"
               data-testid="typography"
             >
               29
@@ -101,11 +101,11 @@ exports[`CollectionCard - Snapshots > matches snapshot with default props 1`] = 
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M18 20a6 6 0 0 0-12 0"
+                d="M17.925 20.056a6 6 0 0 0-11.851.001"
               />
               <circle
                 cx="12"
-                cy="10"
+                cy="11"
                 r="4"
               />
               <circle
@@ -115,7 +115,7 @@ exports[`CollectionCard - Snapshots > matches snapshot with default props 1`] = 
               />
             </svg>
             <span
-              class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+              class="text-xs leading-4 font-medium tracking-widest uppercase"
               data-testid="typography"
             >
               PRIVATE

--- a/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/molecules/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`CollectionCard - Snapshots > matches snapshot with default props 1`] = 
         class="w-full min-w-0 text-base leading-6 font-medium text-muted-foreground"
         data-testid="typography"
       >
-        Everything you want to save for later.
+        Everything you saved for later
       </p>
     </div>
   </div>

--- a/src/components/molecules/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/molecules/Collections/CollectionCard/CollectionCard.tsx
@@ -35,7 +35,7 @@ export function CollectionCard({
       href={href}
       aria-label={title}
       data-cy="collection-card"
-      className="block w-full lg:max-w-[588px]"
+      className="block w-full lg:max-w-xl"
     >
       <Card className="gap-3 rounded-md py-0">
         <CardContent className="flex flex-col gap-3 p-6">
@@ -58,7 +58,7 @@ export function CollectionCard({
                   <Typography
                     as="span"
                     overrideDefaults
-                    className="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                    className="text-xs leading-4 font-medium tracking-widest uppercase"
                   >
                     {count}
                   </Typography>
@@ -69,7 +69,7 @@ export function CollectionCard({
                 <Typography
                   as="span"
                   overrideDefaults
-                  className="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                  className="text-xs leading-4 font-medium tracking-widest uppercase"
                 >
                   {visibilityLabel}
                 </Typography>

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with GIF 
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -46,6 +47,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -59,7 +61,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/mixed-video.mp4"
@@ -215,6 +217,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -232,6 +235,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -249,6 +253,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -428,6 +433,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -554,7 +560,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/single-carousel-video.mp4"
@@ -671,13 +677,13 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/carousel-video1.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/carousel-video2.mp4"
@@ -844,6 +850,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -861,6 +868,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -878,6 +886,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -895,6 +904,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -926,6 +936,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -939,7 +950,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       </button>
     </div>
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/mixed-video.mp4"
@@ -949,6 +960,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -980,6 +992,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -997,6 +1010,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -1014,6 +1028,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -1041,19 +1056,19 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video1.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video2.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video3.mp4"
@@ -1077,6 +1092,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
       data-testid="dialog-trigger"
     >
       <button
+        class=""
         data-override-defaults="true"
         data-testid="button"
       >
@@ -1104,7 +1120,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/snapshot-video.mp4"

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with GIF 
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -15,13 +15,13 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with GIF 
       data-testid="dialog-trigger"
     >
       <button
-        class=""
+        class="only:relative only:h-full only:w-full"
         data-override-defaults="true"
         data-testid="button"
       >
         <img
           alt="animated.gif"
-          class="rounded-md max-h-96 w-fit object-contain"
+          class="rounded-md object-cover object-center only:h-full only:w-full only:object-cover @md/post:only:static @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit @md/post:only:object-contain"
           data-fill="false"
           data-testid="image"
           src="https://example.com/animated.gif"
@@ -38,7 +38,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -61,7 +61,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/mixed-video.mp4"
@@ -208,7 +208,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -424,7 +424,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -433,13 +433,13 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-testid="dialog-trigger"
     >
       <button
-        class=""
+        class="only:relative only:h-full only:w-full"
         data-override-defaults="true"
         data-testid="button"
       >
         <img
           alt="dialog-image.jpg"
-          class="rounded-md max-h-96 w-fit object-contain"
+          class="rounded-md object-cover object-center only:h-full only:w-full only:object-cover @md/post:only:static @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit @md/post:only:object-contain"
           data-fill="false"
           data-testid="image"
           src="https://example.com/dialog-feed.jpg"
@@ -555,12 +555,12 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2 only:aspect-video only:h-auto only:w-full only:max-w-full @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/single-carousel-video.mp4"
@@ -672,18 +672,18 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/carousel-video1.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/carousel-video2.mp4"
@@ -828,7 +828,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with empt
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   />
@@ -841,7 +841,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -927,7 +927,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -950,7 +950,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       </button>
     </div>
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/mixed-video.mp4"
@@ -983,7 +983,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -1051,24 +1051,24 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video1.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video2.mp4"
     />
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/video3.mp4"
@@ -1083,7 +1083,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
@@ -1092,13 +1092,13 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
       data-testid="dialog-trigger"
     >
       <button
-        class=""
+        class="only:relative only:h-full only:w-full"
         data-override-defaults="true"
         data-testid="button"
       >
         <img
           alt="snapshot-image.jpg"
-          class="rounded-md max-h-96 w-fit object-contain"
+          class="rounded-md object-cover object-center only:h-full only:w-full only:object-cover @md/post:only:static @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit @md/post:only:object-contain"
           data-fill="false"
           data-testid="image"
           src="https://example.com/snapshot-feed.jpg"
@@ -1115,12 +1115,12 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
   data-testid="dialog"
 >
   <div
-    class="gap-3 sm:grid-cols-2"
+    class="min-w-0 gap-3 @sm/post:grid-cols-2"
     data-display="grid"
     data-testid="container"
   >
     <video
-      class="h-52 w-full cursor-auto sm:last:odd:col-span-2 only:h-auto only:max-h-96 only:w-fit"
+      class="h-52 w-full cursor-auto @sm/post:last:odd:col-span-2 only:aspect-video only:h-auto only:w-full only:max-w-full @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit"
       data-pause-video="false"
       data-testid="video"
       src="https://example.com/snapshot-video.mp4"

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -18,6 +18,7 @@ import { Typography } from '@/atoms/Typography/Typography';
 import { Video } from '@/atoms/Video/Video';
 import { cn } from '@/libs/utils/utils';
 import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
+import { usePostMainLayout } from '@/organisms/PostMain/PostMainLayoutContext';
 import { PostAttachmentsCarouselImage } from '../PostAttachmentsCarouselImage/PostAttachmentsCarouselImage';
 import { useToast } from '../Toaster/use-toast';
 
@@ -63,16 +64,22 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
     };
   }, []);
   const isOnlyMedia = imagesAndVideos.length === 1;
+  const isCollectionSurface = usePostMainLayout()?.surface === 'collection';
+  const singleMediaCollectionClass = isCollectionSurface && isOnlyMedia;
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       {/* Grid layout */}
-      <Container display="grid" className="gap-3 sm:grid-cols-2">
+      <Container display="grid" className={cn('gap-3 sm:grid-cols-2', singleMediaCollectionClass && 'grid-cols-1')}>
         {imagesAndVideos.map((media, i) =>
           media.type.startsWith('image') ? (
             <DialogTrigger
               key={i}
               asChild
-              className="relative h-52 w-full cursor-pointer only:static only:h-auto only:w-fit sm:last:odd:col-span-2"
+              className={cn(
+                'relative h-52 w-full cursor-pointer sm:last:odd:col-span-2',
+                singleMediaCollectionClass ? 'aspect-video h-auto' : 'only:static only:h-auto only:w-fit',
+              )}
             >
               <Button
                 overrideDefaults
@@ -80,14 +87,19 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
                   e.stopPropagation();
                   setCurrentIndex(i);
                 }}
+                className={cn(singleMediaCollectionClass && 'h-full w-full')}
               >
                 <Image
                   src={media.type === 'image/gif' ? media.urls.main : (media.urls.feed as string)}
                   alt={media.name}
-                  fill={!isOnlyMedia}
+                  fill={!isOnlyMedia || singleMediaCollectionClass}
                   className={cn(
                     'rounded-md',
-                    isOnlyMedia ? 'max-h-96 w-fit object-contain' : 'object-cover object-center',
+                    singleMediaCollectionClass
+                      ? 'object-cover object-center'
+                      : isOnlyMedia
+                        ? 'max-h-96 w-fit object-contain'
+                        : 'object-cover object-center',
                   )}
                 />
               </Button>
@@ -100,7 +112,12 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
               }}
               src={media.urls.main}
               pauseVideo={open}
-              className="h-52 w-full cursor-auto only:h-auto only:max-h-96 only:w-fit sm:last:odd:col-span-2"
+              className={cn(
+                'h-52 w-full cursor-auto sm:last:odd:col-span-2',
+                singleMediaCollectionClass
+                  ? 'aspect-video h-auto max-h-none w-full'
+                  : 'only:h-auto only:max-h-96 only:w-fit',
+              )}
             />
           ),
         )}

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -18,7 +18,6 @@ import { Typography } from '@/atoms/Typography/Typography';
 import { Video } from '@/atoms/Video/Video';
 import { cn } from '@/libs/utils/utils';
 import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
-import { usePostMainLayout } from '@/organisms/PostMain/PostMainLayoutContext';
 import { PostAttachmentsCarouselImage } from '../PostAttachmentsCarouselImage/PostAttachmentsCarouselImage';
 import { useToast } from '../Toaster/use-toast';
 
@@ -64,21 +63,20 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
     };
   }, []);
   const isOnlyMedia = imagesAndVideos.length === 1;
-  const isCollectionSurface = usePostMainLayout()?.surface === 'collection';
-  const singleMediaCollectionClass = isCollectionSurface && isOnlyMedia;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      {/* Grid layout */}
-      <Container display="grid" className={cn('gap-3 sm:grid-cols-2', singleMediaCollectionClass && 'grid-cols-1')}>
+      {/* Grid layout — breakpoints follow the post card (@container/post on PostMain), not the viewport */}
+      <Container display="grid" className="min-w-0 gap-3 @sm/post:grid-cols-2">
         {imagesAndVideos.map((media, i) =>
           media.type.startsWith('image') ? (
             <DialogTrigger
               key={i}
               asChild
               className={cn(
-                'relative h-52 w-full cursor-pointer sm:last:odd:col-span-2',
-                singleMediaCollectionClass ? 'aspect-video h-auto' : 'only:static only:h-auto only:w-fit',
+                'relative h-52 w-full cursor-pointer @sm/post:last:odd:col-span-2',
+                isOnlyMedia &&
+                  'only:aspect-video only:h-auto only:w-full only:max-w-full @md/post:only:static @md/post:only:w-fit',
               )}
             >
               <Button
@@ -87,19 +85,16 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
                   e.stopPropagation();
                   setCurrentIndex(i);
                 }}
-                className={cn(singleMediaCollectionClass && 'h-full w-full')}
+                className={cn(isOnlyMedia && 'only:relative only:h-full only:w-full')}
               >
                 <Image
                   src={media.type === 'image/gif' ? media.urls.main : (media.urls.feed as string)}
                   alt={media.name}
-                  fill={!isOnlyMedia || singleMediaCollectionClass}
+                  fill={!isOnlyMedia}
                   className={cn(
-                    'rounded-md',
-                    singleMediaCollectionClass
-                      ? 'object-cover object-center'
-                      : isOnlyMedia
-                        ? 'max-h-96 w-fit object-contain'
-                        : 'object-cover object-center',
+                    'rounded-md object-cover object-center',
+                    isOnlyMedia &&
+                      'only:h-full only:w-full only:object-cover @md/post:only:static @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit @md/post:only:object-contain',
                   )}
                 />
               </Button>
@@ -113,10 +108,10 @@ export const PostAttachmentsImagesAndVideos = ({ imagesAndVideos }: PostAttachme
               src={media.urls.main}
               pauseVideo={open}
               className={cn(
-                'h-52 w-full cursor-auto sm:last:odd:col-span-2',
-                singleMediaCollectionClass
-                  ? 'aspect-video h-auto max-h-none w-full'
-                  : 'only:h-auto only:max-h-96 only:w-fit',
+                'h-52 w-full cursor-auto @sm/post:last:odd:col-span-2',
+                isOnlyMedia
+                  ? 'only:aspect-video only:h-auto only:w-full only:max-w-full @md/post:only:h-auto @md/post:only:max-h-96 @md/post:only:w-fit'
+                  : undefined,
               )}
             />
           ),

--- a/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.test.tsx
+++ b/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBookmarksStreamId } from '@/hooks/useBookmarksStreamId/useBookmarksStreamId';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
+import { usePostListKeyboard } from '@/hooks/usePostListKeyboard/usePostListKeyboard';
+import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
+import { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import { CONTENT } from '@/stores/home/home.types';
+import { BookmarksCollectionPosts } from './BookmarksCollectionPosts';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/hooks/useBookmarksStreamId/useBookmarksStreamId', () => ({
+  useBookmarksStreamId: vi.fn(),
+}));
+
+vi.mock('@/hooks/useStreamPagination/useStreamPagination', () => ({
+  useStreamPagination: vi.fn(),
+}));
+
+vi.mock('@/hooks/useInfiniteScroll/useInfiniteScroll', () => ({
+  useInfiniteScroll: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePostNavigation/usePostNavigation', () => ({
+  usePostNavigation: vi.fn(() => ({
+    handlePostKeyDown: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/usePostListKeyboard/usePostListKeyboard', () => ({
+  usePostListKeyboard: vi.fn(),
+}));
+
+vi.mock('@/organisms/PostMain/PostMain', () => ({
+  PostMain: ({ postId }: { postId: string }) => <div data-testid={`post-main-${postId}`}>{postId}</div>,
+}));
+
+const mockLoadMore = vi.fn();
+const mockPrependPosts = vi.fn();
+const mockRemovePosts = vi.fn();
+
+const defaultPaginationResult = {
+  postIds: ['author1:post1', 'author2:post2'],
+  loading: false,
+  loadingMore: false,
+  error: null,
+  hasMore: true,
+  loadMore: mockLoadMore,
+  refresh: vi.fn(),
+  prependPosts: mockPrependPosts,
+  removePosts: mockRemovePosts,
+};
+
+describe('BookmarksCollectionPosts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useBookmarksStreamId).mockReturnValue(PostStreamTypes.TIMELINE_BOOKMARKS_ALL);
+    vi.mocked(useStreamPagination).mockReturnValue(defaultPaginationResult);
+    vi.mocked(useInfiniteScroll).mockReturnValue({ sentinelRef: vi.fn() });
+    vi.mocked(usePostListKeyboard).mockReturnValue({
+      setCardRef: vi.fn(() => vi.fn()),
+      onListKeyDown: vi.fn(),
+    });
+  });
+
+  it('loads the all-content bookmarks stream', () => {
+    render(<BookmarksCollectionPosts emptyComponent={<div>No bookmarks</div>} />);
+
+    expect(useBookmarksStreamId).toHaveBeenCalledWith(CONTENT.ALL);
+    expect(useStreamPagination).toHaveBeenCalledWith({
+      streamId: PostStreamTypes.TIMELINE_BOOKMARKS_ALL,
+    });
+  });
+
+  it('renders bookmarked posts in a three-column grid without reply threads', () => {
+    render(<BookmarksCollectionPosts emptyComponent={<div>No bookmarks</div>} />);
+
+    const feed = screen.getByRole('feed');
+    expect(feed).toHaveClass('grid', 'lg:grid-cols-3');
+    expect(screen.getAllByRole('article')).toHaveLength(2);
+    expect(screen.getByTestId('post-main-author1:post1')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-replies-author1:post1')).not.toBeInTheDocument();
+  });
+
+  it('renders the provided empty state when the bookmarks stream is empty', () => {
+    vi.mocked(useStreamPagination).mockReturnValue({
+      ...defaultPaginationResult,
+      postIds: [],
+      hasMore: false,
+    });
+
+    render(<BookmarksCollectionPosts emptyComponent={<div data-testid="bookmarks-empty">No bookmarks</div>} />);
+
+    expect(screen.getByTestId('bookmarks-empty')).toBeInTheDocument();
+    expect(screen.queryByRole('feed')).not.toBeInTheDocument();
+  });
+
+  it('does not render the timeline end message', () => {
+    render(<BookmarksCollectionPosts emptyComponent={<div>No bookmarks</div>} />);
+
+    expect(screen.queryByText(/you've reached the end/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('BookmarksCollectionPosts - Snapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useBookmarksStreamId).mockReturnValue(PostStreamTypes.TIMELINE_BOOKMARKS_ALL);
+    vi.mocked(useStreamPagination).mockReturnValue(defaultPaginationResult);
+    vi.mocked(useInfiniteScroll).mockReturnValue({ sentinelRef: vi.fn() });
+    vi.mocked(usePostListKeyboard).mockReturnValue({
+      setCardRef: vi.fn(() => vi.fn()),
+      onListKeyDown: vi.fn(),
+    });
+  });
+
+  it('matches snapshot with bookmarked posts', () => {
+    const { container } = render(<BookmarksCollectionPosts emptyComponent={<div>No bookmarks</div>} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.test.tsx.snap
+++ b/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.test.tsx.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BookmarksCollectionPosts - Snapshots > matches snapshot with bookmarked posts 1`] = `
+<div
+  class="mx-auto w-full flex-col flex"
+  data-cy="bookmarks-collection-posts-container"
+  data-testid="container"
+>
+  <div
+    class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+    data-cy="bookmarks-collection-posts"
+    data-testid="container"
+    role="feed"
+  >
+    <div
+      aria-posinset="1"
+      aria-setsize="2"
+      class="mx-auto w-full flex-col flex min-w-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-cy="post-card"
+      data-testid="container"
+      role="article"
+      tabindex="0"
+    >
+      <div
+        data-testid="post-main-author1:post1"
+      >
+        author1:post1
+      </div>
+    </div>
+    <div
+      aria-posinset="2"
+      aria-setsize="2"
+      class="mx-auto w-full flex-col flex min-w-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-cy="post-card"
+      data-testid="container"
+      role="article"
+      tabindex="0"
+    >
+      <div
+        data-testid="post-main-author2:post2"
+      >
+        author2:post2
+      </div>
+    </div>
+    <div
+      class="col-span-full h-5"
+      data-testid="container"
+    />
+  </div>
+</div>
+`;

--- a/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.tsx
+++ b/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.tsx
@@ -46,7 +46,7 @@ export function BookmarksCollectionPosts({ emptyComponent }: BookmarksCollection
 
   return (
     <TimelineFeedContext.Provider value={{ prependPosts, removePosts }}>
-      <PostMainLayoutProvider tagsLayout={tagsLayout} surface="collection">
+      <PostMainLayoutProvider tagsLayout={tagsLayout}>
         <TimelineStateWrapper
           loading={loading}
           error={error}

--- a/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.tsx
+++ b/src/components/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Container } from '@/atoms/Container/Container';
+import { useBookmarksStreamId } from '@/hooks/useBookmarksStreamId/useBookmarksStreamId';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
+import { usePostListKeyboard } from '@/hooks/usePostListKeyboard/usePostListKeyboard';
+import { usePostNavigation } from '@/hooks/usePostNavigation/usePostNavigation';
+import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
+import { TimelineError } from '@/molecules/Timeline/TimelineError';
+import { TimelineLoadingMore } from '@/molecules/Timeline/TimelineLoadingMore';
+import { TimelineStateWrapper } from '@/molecules/Timeline/TimelineStateWrapper/TimelineStateWrapper';
+import { PostMain } from '@/organisms/PostMain/PostMain';
+import { PostMainLayoutProvider } from '@/organisms/PostMain/PostMainLayoutContext';
+import { getTagsLayoutForSurfaceLayout } from '@/organisms/PostMain/PostMainLayoutRules';
+import { TimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext';
+import { CONTENT, LAYOUT } from '@/stores/home/home.types';
+
+interface BookmarksCollectionPostsProps {
+  emptyComponent: ReactNode;
+}
+
+export function BookmarksCollectionPosts({ emptyComponent }: BookmarksCollectionPostsProps) {
+  const streamId = useBookmarksStreamId(CONTENT.ALL);
+  const {
+    postIds: rawPostIds,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+    prependPosts,
+    removePosts,
+  } = useStreamPagination({ streamId });
+  const postIds = [...new Set(rawPostIds)];
+  const tagsLayout = getTagsLayoutForSurfaceLayout(LAYOUT.COLUMNS);
+  const { sentinelRef } = useInfiniteScroll({
+    onLoadMore: loadMore,
+    hasMore,
+    isLoading: loadingMore,
+    threshold: 3000,
+    debounceMs: 20,
+  });
+  const { handlePostKeyDown } = usePostNavigation();
+  const { setCardRef, onListKeyDown } = usePostListKeyboard();
+
+  return (
+    <TimelineFeedContext.Provider value={{ prependPosts, removePosts }}>
+      <PostMainLayoutProvider tagsLayout={tagsLayout} surface="collection">
+        <TimelineStateWrapper
+          loading={loading}
+          error={error}
+          hasItems={postIds.length > 0}
+          emptyComponent={emptyComponent}
+        >
+          <Container data-cy="bookmarks-collection-posts-container">
+            <Container
+              overrideDefaults
+              role="feed"
+              data-cy="bookmarks-collection-posts"
+              className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+              onKeyDown={onListKeyDown}
+            >
+              {postIds.map((postId, index) => (
+                <Container
+                  key={`bookmark_${postId}`}
+                  data-cy="post-card"
+                  ref={setCardRef(index)}
+                  role="article"
+                  aria-posinset={index + 1}
+                  aria-setsize={postIds.length}
+                  tabIndex={0}
+                  onKeyDown={(event) => handlePostKeyDown(postId, event)}
+                  className="min-w-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <PostMain postId={postId} isReply={false} className="h-full" />
+                </Container>
+              ))}
+
+              {loadingMore && (
+                <Container overrideDefaults className="col-span-full">
+                  <TimelineLoadingMore />
+                </Container>
+              )}
+
+              {error && postIds.length > 0 && (
+                <Container overrideDefaults className="col-span-full">
+                  <TimelineError message={error} />
+                </Container>
+              )}
+
+              <Container overrideDefaults className="col-span-full h-5" ref={sentinelRef} />
+            </Container>
+          </Container>
+        </TimelineStateWrapper>
+      </PostMainLayoutProvider>
+    </TimelineFeedContext.Provider>
+  );
+}

--- a/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx
+++ b/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx
@@ -1,0 +1,238 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Button } from '@/atoms/Button/Button';
+import { NewCollectionDialog } from './NewCollectionDialog';
+
+const mocks = vi.hoisted(() => ({
+  commitCreateCollection: vi.fn(),
+  toast: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+  'collections.new.title': 'New Collection',
+  'collections.new.nameLabel': 'Title',
+  'collections.new.namePlaceholder': 'Proof of Work',
+  'collections.new.descriptionLabel': 'Description',
+  'collections.new.descriptionPlaceholder': 'The best from the biggest contributors in Bitcoin',
+  'collections.new.backgroundLabel': 'Background',
+  'collections.new.addImage': 'Add image',
+  'collections.new.removeImage': 'Remove image',
+  'collections.new.coverImageInvalid': 'Cover image must be an image file.',
+  'collections.new.coverImageTooLarge': 'Cover image is too large.',
+  'collections.new.nameRequired': 'Collection title is required.',
+  'collections.new.cancel': 'Cancel',
+  'collections.new.save': 'Save collection',
+  'collections.new.saving': 'Saving...',
+  'collections.new.created': 'Collection {name} created',
+  'collections.new.createFailed': 'Failed to create collection.',
+  'toast.success': 'Success',
+  'toast.error': 'Error',
+};
+
+vi.mock('@/controllers/post/post', () => ({
+  PostController: {
+    commitCreateCollection: (...args: unknown[]) => mocks.commitCreateCollection(...args),
+  },
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string }) => unknown) =>
+    selector({ currentUserPubky: 'current-user' }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace: string) =>
+    (key: string, values?: Record<string, string>): string => {
+      const translation = translations[`${namespace}.${key}`] ?? key;
+      return Object.entries(values ?? {}).reduce(
+        (message, [name, value]) => message.replace(`{${name}}`, value),
+        translation,
+      );
+    },
+}));
+
+describe('NewCollectionDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens from the trigger and renders collection fields', () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'New Collection' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toHaveAttribute('placeholder', 'Proof of Work');
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
+      'placeholder',
+      'The best from the biggest contributors in Bitcoin',
+    );
+  });
+
+  it('disables save until a title is entered', () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(screen.getByRole('button', { name: 'Save collection' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Proof of Work' } });
+
+    expect(screen.getByRole('button', { name: 'Save collection' })).toBeEnabled();
+  });
+
+  it('shows required title feedback after blurring an empty title field', async () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    expect(screen.queryByText('Collection title is required.')).not.toBeInTheDocument();
+
+    fireEvent.blur(screen.getByLabelText('Title'));
+
+    expect(await screen.findByText('Collection title is required.')).toBeInTheDocument();
+  });
+
+  it('clears required title feedback when a valid title is entered', async () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    fireEvent.blur(screen.getByLabelText('Title'));
+
+    expect(await screen.findByText('Collection title is required.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Proof of Work' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Collection title is required.')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows required title feedback for whitespace-only titles', async () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: '   ' } });
+    fireEvent.blur(screen.getByLabelText('Title'));
+
+    expect(await screen.findByText('Collection title is required.')).toBeInTheDocument();
+  });
+
+  it('creates a collection with title and description', async () => {
+    mocks.commitCreateCollection.mockResolvedValue('current-user:collection1');
+
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Proof of Work' } });
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Bitcoin writing' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save collection' }));
+
+    await waitFor(() => {
+      expect(mocks.commitCreateCollection).toHaveBeenCalledWith({
+        authorId: 'current-user',
+        name: 'Proof of Work',
+        description: 'Bitcoin writing',
+        coverImage: null,
+      });
+    });
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Success',
+      description: 'Collection Proof of Work created',
+    });
+  });
+
+  it('forwards a chosen cover image file to commitCreateCollection', async () => {
+    mocks.commitCreateCollection.mockResolvedValue('current-user:collection1');
+    // jsdom doesn't implement URL.createObjectURL/revokeObjectURL out of the box.
+    const createObjectURL = vi.fn(() => 'blob:mock-cover');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Cover collection' } });
+
+    const file = new File(['cover'], 'cover.png', { type: 'image/png' });
+    const fileInput = document.getElementById('new-collection-cover-image') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(screen.getByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save collection' }));
+
+    await waitFor(() => {
+      expect(mocks.commitCreateCollection).toHaveBeenCalledWith({
+        authorId: 'current-user',
+        name: 'Cover collection',
+        description: '',
+        coverImage: file,
+      });
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects non-image files for the cover image picker', () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const file = new File(['notes'], 'notes.txt', { type: 'text/plain' });
+    const fileInput = document.getElementById('new-collection-cover-image') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(screen.getByText('Cover image must be an image file.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add image' })).toBeInTheDocument();
+  });
+
+  it('matches snapshot when open', () => {
+    render(
+      <NewCollectionDialog>
+        <Button>Open dialog</Button>
+      </NewCollectionDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(document.body).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx.snap
+++ b/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx.snap
@@ -1,0 +1,261 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NewCollectionDialog > matches snapshot when open 1`] = `
+<body
+  data-scroll-locked="1"
+  style="pointer-events: none;"
+>
+  <span
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-radix-focus-guard=""
+    style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+    tabindex="0"
+  />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <button
+      aria-controls="radix-normalized"
+      aria-expanded="true"
+      aria-haspopup="dialog"
+      class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-brand/16 text-brand hover:!bg-brand/30 border-brand h-10 gap-1 px-4 py-2 has-[>svg]:px-4"
+      data-as-child="true"
+      data-slot="dialog-trigger"
+      data-state="open"
+      data-testid="dialog-trigger"
+      type="button"
+    >
+      Open dialog
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    class="fixed inset-0 z-40 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0"
+    data-aria-hidden="true"
+    data-slot="dialog-overlay"
+    data-state="open"
+    style="pointer-events: auto;"
+  />
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center"
+  >
+    <div
+      aria-labelledby="radix-normalized"
+      class="relative z-50 grid duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 m-4 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] gap-6 overflow-y-auto rounded-lg border p-6 shadow-lg sm:rounded-xl sm:p-8 w-full max-w-xl border-border bg-popover"
+      data-cy="dialog-content"
+      data-slot="dialog-content"
+      data-state="open"
+      data-testid="dialog-content"
+      id="radix-normalized"
+      role="dialog"
+      style="pointer-events: auto;"
+      tabindex="-1"
+    >
+      <div
+        class="flex flex-col gap-1.5 pr-6"
+        data-slot="dialog-header"
+        data-testid="dialog-header"
+      >
+        <h2
+          class="text-xl/[1.4] font-bold text-foreground sm:text-2xl/[1.333]"
+          data-slot="dialog-title"
+          data-testid="dialog-title"
+          id="radix-normalized"
+        >
+          New Collection
+        </h2>
+      </div>
+      <div
+        class="flex flex-col gap-4"
+        data-testid="container"
+      >
+        <div
+          class="mx-auto w-full flex-col flex gap-2"
+          data-testid="container"
+        >
+          <label
+            class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-xs font-medium tracking-wide text-muted-foreground uppercase"
+            data-slot="label"
+            for="name"
+          >
+            Title
+          </label>
+          <div
+            class="flex !bg-alpha-90/10 mx-0 w-full cursor-pointer flex-row items-center gap-0 rounded-md border bg-transparent pl-2 border-dashed h-14 text-lg mb-0"
+            data-testid="container"
+          >
+            <input
+              aria-invalid="false"
+              class="flex h-9 min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 w-full border-none !bg-transparent"
+              data-testid="input"
+              id="name"
+              maxlength="100"
+              name="name"
+              placeholder="Proof of Work"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="mx-auto w-full flex-col flex gap-2"
+          data-testid="container"
+        >
+          <label
+            class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-xs font-medium tracking-wide text-muted-foreground uppercase"
+            data-slot="label"
+            for="description"
+          >
+            Description
+          </label>
+          <div
+            class="flex !bg-alpha-90/10 mx-0 w-full cursor-pointer flex-row items-center gap-0 rounded-md border bg-transparent pl-2 border-dashed h-14 text-lg mb-0"
+            data-testid="container"
+          >
+            <input
+              aria-invalid="false"
+              class="flex h-9 min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 w-full border-none !bg-transparent"
+              data-testid="input"
+              id="description"
+              maxlength="500"
+              name="description"
+              placeholder="The best from the biggest contributors in Bitcoin"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flex flex-col gap-2"
+          data-testid="container"
+        >
+          <label
+            class="flex items-center gap-2 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-xs font-medium tracking-wide text-muted-foreground uppercase"
+            data-slot="label"
+            for="new-collection-cover-image"
+          >
+            Background
+          </label>
+          <div
+            class="relative flex h-32 w-full items-center justify-center overflow-hidden rounded-md bg-card bg-cover bg-center"
+            data-testid="new-collection-cover-image"
+          >
+            <button
+              aria-label="Add image"
+              class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 rounded-full"
+              data-size="sm"
+              data-slot="button"
+              data-variant="secondary"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-image size-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="18"
+                  rx="2"
+                  ry="2"
+                  width="18"
+                  x="3"
+                  y="3"
+                />
+                <circle
+                  cx="9"
+                  cy="9"
+                  r="2"
+                />
+                <path
+                  d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
+                />
+              </svg>
+              <span
+                data-testid="typography"
+              >
+                Add image
+              </span>
+            </button>
+            <input
+              accept="image/*"
+              class="hidden"
+              id="new-collection-cover-image"
+              type="file"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 md:justify-between [&>*]:w-full sm:[&>*]:flex-1"
+        data-slot="dialog-footer"
+      >
+        <button
+          class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs hover:text-accent-foreground bg-input/30 border-input hover:bg-input/50 h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal"
+          data-size="lg"
+          data-slot="button"
+          data-variant="outline"
+        >
+          Cancel
+        </button>
+        <button
+          class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand/16 text-brand hover:!bg-brand/30 border-brand h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal"
+          data-size="lg"
+          data-slot="button"
+          disabled=""
+        >
+          Save collection
+        </button>
+      </div>
+      <button
+        class="absolute top-4 right-4 cursor-pointer rounded-full bg-secondary p-2 transition-all duration-300 ease-in-out outline-none hover:bg-secondary/80 focus:outline-none disabled:pointer-events-none disabled:opacity-50"
+        data-slot="dialog-close"
+        data-testid="dialog-close"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-x h-4 w-4 text-secondary-foreground opacity-70"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 6 6 18"
+          />
+          <path
+            d="m6 6 12 12"
+          />
+        </svg>
+        <span
+          class="sr-only"
+        >
+          Close
+        </span>
+      </button>
+    </div>
+  </div>
+  <span
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-radix-focus-guard=""
+    style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+    tabindex="0"
+  />
+</body>
+`;

--- a/src/components/organisms/NewCollectionDialog/NewCollectionDialog.tsx
+++ b/src/components/organisms/NewCollectionDialog/NewCollectionDialog.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { type ReactNode, useState } from 'react';
+import { Image as ImageIcon, Trash2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useWatch } from 'react-hook-form';
+import { Button } from '@/atoms/Button/Button';
+import { Container } from '@/atoms/Container/Container';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/atoms/Dialog/Dialog';
+import { Label } from '@/atoms/Label/Label';
+import { Typography } from '@/atoms/Typography/Typography';
+import { FORM_LABEL_CLASSES } from '@/config/forms';
+import { COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH, COLLECTION_NAME_MAX_CHARACTER_LENGTH } from '@/config/posts';
+import { useCreateCollection } from '@/hooks/useCreateCollection/useCreateCollection';
+import { CREATE_COLLECTION_FORM_FIELDS } from '@/hooks/useCreateCollection/useCreateCollection.types';
+import { ControlledInputField } from '@/molecules/ControlledInputField/ControlledInputField';
+
+type NewCollectionDialogProps = {
+  children: ReactNode;
+};
+
+export function NewCollectionDialog({ children }: NewCollectionDialogProps) {
+  const t = useTranslations('collections.new');
+  const [open, setOpen] = useState(false);
+
+  const { form, cover, submit, reset } = useCreateCollection();
+  const {
+    previewUrl: coverPreviewUrl,
+    error: coverError,
+    inputRef: coverInputRef,
+    onInputChange: onCoverInputChange,
+    choose: chooseCover,
+    remove: removeCover,
+  } = cover;
+
+  const isSaving = form.formState.isSubmitting;
+  const watchedName = useWatch({ control: form.control, name: CREATE_COLLECTION_FORM_FIELDS.NAME });
+  const canSubmit = !!watchedName.trim() && !isSaving;
+
+  const coverErrorMessage =
+    coverError === 'invalid-type'
+      ? t('coverImageInvalid')
+      : coverError === 'too-large'
+        ? t('coverImageTooLarge')
+        : null;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) reset();
+  };
+
+  const handleSave = async () => {
+    const ok = await submit();
+    if (ok) handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="w-full max-w-xl border-border bg-popover">
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+        </DialogHeader>
+
+        <Container overrideDefaults className="flex flex-col gap-4">
+          <ControlledInputField
+            name={CREATE_COLLECTION_FORM_FIELDS.NAME}
+            control={form.control}
+            label={t('nameLabel')}
+            placeholder={t('namePlaceholder')}
+            maxLength={COLLECTION_NAME_MAX_CHARACTER_LENGTH}
+            variant="dashed"
+            size="lg"
+            disabled={isSaving}
+          />
+
+          <ControlledInputField
+            name={CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION}
+            control={form.control}
+            label={t('descriptionLabel')}
+            placeholder={t('descriptionPlaceholder')}
+            maxLength={COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH}
+            variant="dashed"
+            size="lg"
+            disabled={isSaving}
+          />
+
+          <Container overrideDefaults className="flex flex-col gap-2">
+            <Label htmlFor="new-collection-cover-image" className={FORM_LABEL_CLASSES}>
+              {t('backgroundLabel')}
+            </Label>
+            <Container
+              overrideDefaults
+              className="relative flex h-32 w-full items-center justify-center overflow-hidden rounded-md bg-card bg-cover bg-center"
+              style={coverPreviewUrl ? { backgroundImage: `url(${coverPreviewUrl})` } : undefined}
+              data-testid="new-collection-cover-image"
+            >
+              {coverPreviewUrl ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="rounded-full"
+                  onClick={removeCover}
+                  disabled={isSaving}
+                  aria-label={t('removeImage')}
+                >
+                  <Trash2 className="size-4" />
+                  <Typography as="span" overrideDefaults>
+                    {t('removeImage')}
+                  </Typography>
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="rounded-full"
+                  onClick={chooseCover}
+                  disabled={isSaving}
+                  aria-label={t('addImage')}
+                >
+                  <ImageIcon className="size-4" />
+                  <Typography as="span" overrideDefaults>
+                    {t('addImage')}
+                  </Typography>
+                </Button>
+              )}
+              <input
+                ref={coverInputRef}
+                id="new-collection-cover-image"
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={onCoverInputChange}
+                disabled={isSaving}
+              />
+            </Container>
+            {coverErrorMessage && (
+              <Typography overrideDefaults className="text-sm font-medium text-destructive">
+                {coverErrorMessage}
+              </Typography>
+            )}
+          </Container>
+        </Container>
+
+        <DialogFooter>
+          <Button variant="outline" size="lg" onClick={() => handleOpenChange(false)} disabled={isSaving}>
+            {t('cancel')}
+          </Button>
+          <Button size="lg" onClick={handleSave} disabled={!canSubmit}>
+            {isSaving ? t('saving') : t('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx
@@ -34,6 +34,16 @@ vi.mock('@/organisms/PostMenuActions/PostMenuActions', () => {
   };
 });
 
+vi.mock('../PostSavePicker/PostSavePicker', () => {
+  return {
+    PostSavePicker: ({ postId }: { postId: string }) => (
+      <button aria-label="Save post" data-testid="post-save-picker" data-post-id={postId}>
+        Save
+      </button>
+    ),
+  };
+});
+
 // Minimal atoms used by PostActionsBar
 vi.mock('@/atoms/Button/Button', () => {
   return {
@@ -133,7 +143,7 @@ describe('PostActionsBar', () => {
     expect(screen.getByRole('button', { name: 'Tag post (3)' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reply to post (5)' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Repost (2)' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /bookmark/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save post' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument();
   });
 
@@ -165,23 +175,14 @@ describe('PostActionsBar', () => {
     expect(onRepostClick).toHaveBeenCalledTimes(1);
   });
 
-  it('calls toggle when bookmark button is clicked', () => {
+  it('renders the save picker for bookmark and collection saves', () => {
     mockUsePostCounts.mockReturnValue({
       postCounts: { tags: 1, unique_tags: 1, replies: 1, reposts: 1 },
       isLoading: false,
     });
-    const mockToggle = vi.fn();
-    mockUseBookmark.mockReturnValue({
-      isBookmarked: false,
-      isLoading: false,
-      isToggling: false,
-      toggle: mockToggle,
-    });
-
     render(<PostActionsBar postId="post-bookmark" />);
 
-    fireEvent.click(screen.getByRole('button', { name: /bookmark/i }));
-    expect(mockToggle).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('post-save-picker')).toHaveAttribute('data-post-id', 'post-bookmark');
   });
 
   it('applies the visual variant classes to the action buttons', () => {

--- a/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx.snap
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx.snap
@@ -148,28 +148,11 @@ exports[`PostActionsBar - Snapshots > matches snapshot with counts 1`] = `
     </span>
   </button>
   <button
-    aria-label="Add bookmark"
-    class="border-none shadow-xs w-10"
-    data-size="sm"
-    data-variant="secondary"
+    aria-label="Save post"
+    data-post-id="post-4"
+    data-testid="post-save-picker"
   >
-    <svg
-      aria-hidden="true"
-      class="lucide lucide-bookmark"
-      fill="none"
-      height="24"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z"
-      />
-    </svg>
+    Save
   </button>
   <div
     data-post-id="post-4"

--- a/src/components/organisms/PostActionsBar/PostActionsBar.tsx
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { cva } from 'class-variance-authority';
-import { Bookmark, Ellipsis, Loader2, MessageCircle, Repeat, Tag } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { Ellipsis, MessageCircle, Repeat, Tag } from 'lucide-react';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
-import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { usePostCounts } from '@/hooks/usePostCounts/usePostCounts';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { cn } from '@/libs/utils/utils';
 import { PostMenuActions } from '../PostMenuActions/PostMenuActions';
+import { PostSavePicker } from '../PostSavePicker/PostSavePicker';
 import { PostActionsBarSkeleton } from './PostActionsBar.skeleton';
 import type { ActionButtonConfig, PostActionsBarProps } from './PostActionsBar.types';
 
@@ -44,16 +43,8 @@ export function PostActionsBar({
   className,
   variant = 'default',
 }: PostActionsBarProps) {
-  const t = useTranslations('common');
   const { postCounts, isLoading: isCountsLoading } = usePostCounts(postId);
-  const {
-    isBookmarked,
-    isLoading: isBookmarkLoading,
-    isToggling: isBookmarkToggling,
-    toggle: toggleBookmark,
-  } = useBookmark(postId);
   const { requireAuth } = useRequireAuth();
-  const isBookmarkBusy = isBookmarkLoading || isBookmarkToggling;
   const buttonClassName = postActionsButtonVariants({
     variant,
   });
@@ -91,18 +82,6 @@ export function PostActionsBar({
       onClick: () => requireAuth(() => onRepostClick?.()),
       ariaLabel: `Repost (${postCounts.reposts})`,
     },
-    {
-      id: 'bookmark',
-      icon: isBookmarkBusy ? Loader2 : Bookmark,
-      onClick: () => requireAuth(() => toggleBookmark()),
-      ariaLabel: isBookmarkBusy ? t('loadingBookmark') : isBookmarked ? t('removeBookmark') : t('addBookmark'),
-      className: 'w-10',
-      iconProps: {
-        fill: isBookmarked && !isBookmarkBusy ? 'currentColor' : 'none',
-        className: isBookmarkBusy ? 'animate-spin' : undefined,
-      },
-      disabled: isBookmarkBusy,
-    },
   ];
   const moreButton = (
     <Button {...commonButtonProps} aria-label="More options" data-cy="post-more-btn">
@@ -131,6 +110,7 @@ export function PostActionsBar({
           </Button>
         ),
       )}
+      <PostSavePicker postId={postId} buttonClassName={buttonClassName} />
       <PostMenuActions postId={postId} trigger={moreButton} />
     </Container>
   );

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row"
     data-testid="container"
   >
     <div
@@ -52,7 +52,7 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
 exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row custom-article-class"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row custom-article-class"
     data-testid="container"
   >
     <div
@@ -101,7 +101,7 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
 exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row"
     data-testid="container"
   >
     <div
@@ -150,7 +150,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
 exports[`PostArticle > Snapshots > matches snapshot with local video attachment falling back to hook image 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row"
     data-testid="container"
   >
     <div
@@ -199,7 +199,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
 exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row"
     data-testid="container"
   >
     <div
@@ -248,7 +248,7 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
 exports[`PostArticle > Snapshots > matches snapshot without cover image 1`] = `
 <div>
   <div
-    class="justify-between gap-6 lg:flex-row"
+    class="flex flex-col justify-between gap-6 @lg/post:flex-row"
     data-testid="container"
   >
     <div

--- a/src/components/organisms/PostArticle/PostArticle.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.tsx
@@ -36,7 +36,7 @@ export const PostArticle = ({ content, attachments, localAttachments, className 
 
   return (
     <>
-      <Container className={cn('justify-between gap-6 lg:flex-row', className)}>
+      <Container className={cn('flex flex-col justify-between gap-6 @lg/post:flex-row', className)}>
         <Container className="gap-y-1">
           <Typography size="lg" className="wrap-anywhere">
             {title}

--- a/src/components/organisms/PostContentBase/PostContentBase.tsx
+++ b/src/components/organisms/PostContentBase/PostContentBase.tsx
@@ -10,7 +10,6 @@ import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 import { PostArticle } from '../PostArticle/PostArticle';
 import { PostAttachments } from '../PostAttachments/PostAttachments';
 import { PostContentBlurred } from '../PostContentBlurred/PostContentBlurred';
-import { usePostMainLayout } from '../PostMain/PostMainLayoutContext';
 import { PostContentBaseSkeleton } from './PostContentBase.skeleton';
 import type { PostContentBaseProps } from './PostContentBase.types';
 
@@ -21,7 +20,6 @@ import type { PostContentBaseProps } from './PostContentBase.types';
  */
 export function PostContentBase({ postId, className, textClassName }: PostContentBaseProps) {
   const localAttachments = useLocalFilesStore((s) => s.posts[postId]);
-  const isCollectionSurface = usePostMainLayout()?.surface === 'collection';
 
   // Fetch post details for content
   const { postDetails } = usePostDetails(postId);
@@ -45,7 +43,7 @@ export function PostContentBase({ postId, className, textClassName }: PostConten
         content={postDetails.content}
         attachments={postDetails.attachments}
         localAttachments={localAttachments}
-        className={cn(isCollectionSurface && 'flex-col lg:flex-col', className)}
+        className={className}
       />
     );
 

--- a/src/components/organisms/PostContentBase/PostContentBase.tsx
+++ b/src/components/organisms/PostContentBase/PostContentBase.tsx
@@ -10,6 +10,7 @@ import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 import { PostArticle } from '../PostArticle/PostArticle';
 import { PostAttachments } from '../PostAttachments/PostAttachments';
 import { PostContentBlurred } from '../PostContentBlurred/PostContentBlurred';
+import { usePostMainLayout } from '../PostMain/PostMainLayoutContext';
 import { PostContentBaseSkeleton } from './PostContentBase.skeleton';
 import type { PostContentBaseProps } from './PostContentBase.types';
 
@@ -20,6 +21,7 @@ import type { PostContentBaseProps } from './PostContentBase.types';
  */
 export function PostContentBase({ postId, className, textClassName }: PostContentBaseProps) {
   const localAttachments = useLocalFilesStore((s) => s.posts[postId]);
+  const isCollectionSurface = usePostMainLayout()?.surface === 'collection';
 
   // Fetch post details for content
   const { postDetails } = usePostDetails(postId);
@@ -43,7 +45,7 @@ export function PostContentBase({ postId, className, textClassName }: PostConten
         content={postDetails.content}
         attachments={postDetails.attachments}
         localAttachments={localAttachments}
-        className={className}
+        className={cn(isCollectionSurface && 'flex-col lg:flex-col', className)}
       />
     );
 

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx.snap
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostInlineTagsActions - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+  class="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
   data-testid="container"
 >
   <div
@@ -14,6 +14,7 @@ exports[`PostInlineTagsActions - Snapshots > matches snapshot with default props
     data-testid="clickable-tags-list"
   />
   <div
+    class="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
     data-post-id="snapshot-author:post-1"
     data-testid="post-actions-bar"
   >

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.tsx
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.tsx
@@ -30,8 +30,8 @@ export function PostInlineTagsActions({
     <Container
       onClick={(event) => event.stopPropagation()}
       className={cn(
-        'flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4',
-        tagsExpanded ? 'md:items-end' : 'md:items-start',
+        'flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:items-center @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4',
+        tagsExpanded ? '@md/post:items-end' : '@md/post:items-start',
         className,
       )}
     >
@@ -41,7 +41,7 @@ export function PostInlineTagsActions({
           widthMode="fit"
           autoFocusInput
           enableLoadingSkeleton={false}
-          className="flex-1"
+          className="min-w-0 flex-1"
         />
       ) : (
         <ClickableTagsList
@@ -53,6 +53,7 @@ export function PostInlineTagsActions({
           showInput={false}
           showAddButton={true}
           addMode={true}
+          className="min-w-0 flex-1"
         />
       )}
       <PostActionsBar
@@ -60,7 +61,7 @@ export function PostInlineTagsActions({
         onTagClick={() => setTagsExpanded((prev) => !prev)}
         onReplyClick={onReplyClick}
         onRepostClick={onRepostClick}
-        className={actionsClassName}
+        className={cn('w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end', actionsClassName)}
       />
     </Container>
   );

--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -165,7 +165,7 @@ export function PostInput({
   const characterLimit = isArticle ? undefined : { count: getCharacterCount(content), max: POST_MAX_CHARACTER_LENGTH };
 
   const isMobile = useIsMobile();
-  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
+  const inheritedTagsLayout = usePostMainLayout()?.tagsLayout ?? 'inline';
   const isWideLayout = !isMobile && inheritedTagsLayout === 'side';
 
   return (

--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -165,7 +165,7 @@ export function PostInput({
   const characterLimit = isArticle ? undefined : { count: getCharacterCount(content), max: POST_MAX_CHARACTER_LENGTH };
 
   const isMobile = useIsMobile();
-  const inheritedTagsLayout = usePostMainLayout()?.tagsLayout ?? 'inline';
+  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
   const isWideLayout = !isMobile && inheritedTagsLayout === 'side';
 
   return (

--- a/src/components/organisms/PostMain/PostMain.test.tsx.snap
+++ b/src/components/organisms/PostMain/PostMain.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`PostMain - Snapshots > matches snapshot for quote repost by current use
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -32,7 +32,7 @@ exports[`PostMain - Snapshots > matches snapshot for quote repost by current use
         me:quote-repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -45,7 +45,7 @@ exports[`PostMain - Snapshots > matches snapshot for quote repost by current use
           me:quote-repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -75,7 +75,7 @@ exports[`PostMain - Snapshots > matches snapshot for repost by another user 1`] 
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -95,7 +95,7 @@ exports[`PostMain - Snapshots > matches snapshot for repost by another user 1`] 
         other-user:repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -108,7 +108,7 @@ exports[`PostMain - Snapshots > matches snapshot for repost by another user 1`] 
           other-user:repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -138,7 +138,7 @@ exports[`PostMain - Snapshots > matches snapshot for simple repost by current us
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -157,7 +157,7 @@ exports[`PostMain - Snapshots > matches snapshot for simple repost by current us
         me:simple-repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -170,7 +170,7 @@ exports[`PostMain - Snapshots > matches snapshot for simple repost by current us
           me:simple-repost-1
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -200,7 +200,7 @@ exports[`PostMain - Snapshots > matches snapshot with default state 1`] = `
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -220,7 +220,7 @@ exports[`PostMain - Snapshots > matches snapshot with default state 1`] = `
         post-123
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -233,7 +233,7 @@ exports[`PostMain - Snapshots > matches snapshot with default state 1`] = `
           post-123
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -263,7 +263,7 @@ exports[`PostMain - Snapshots > matches snapshot with deleted post 1`] = `
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -282,7 +282,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
   data-testid="container"
 >
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -302,7 +302,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
         post-no-reply-456
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -315,7 +315,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
           post-no-reply-456
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 
@@ -358,7 +358,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply true 1`] = `
     </div>
   </div>
   <div
-    data-class-name="min-w-0 flex-1 gap-0 rounded-md py-0"
+    data-class-name="@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0"
     data-testid="card"
   >
     <div
@@ -378,7 +378,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply true 1`] = `
         post-reply-123
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 md:items-start"
+        data-class-name="flex flex-col items-start gap-2 @md/post:flex-row @md/post:flex-wrap @md/post:justify-between @md/post:gap-x-2 @md/post:gap-y-4 @md/post:items-start"
         data-testid="container"
       >
         <div
@@ -391,7 +391,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply true 1`] = `
           post-reply-123
         </div>
         <div
-          data-class-name="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+          data-class-name="w-full shrink-0 justify-start @md/post:w-auto @md/post:justify-end"
           data-testid="post-actions"
         >
           Actions 

--- a/src/components/organisms/PostMain/PostMain.tsx
+++ b/src/components/organisms/PostMain/PostMain.tsx
@@ -38,7 +38,9 @@ export function PostMain({
   isNavigable = true,
 }: PostMainProps) {
   const isMobile = useIsMobile();
-  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
+  const layoutConfig = usePostMainLayout();
+  const inheritedTagsLayout = layoutConfig?.tagsLayout ?? 'inline';
+  const isCollectionSurface = layoutConfig?.surface === 'collection';
   const effectiveTagsLayout = inheritedTagsLayout === 'side' && isMobile ? 'inline' : inheritedTagsLayout;
   const isWideLayout = effectiveTagsLayout === 'side';
   const { postDetails } = usePostDetails(postId);
@@ -133,7 +135,14 @@ export function PostMain({
                       postId={postId}
                       onReplyClick={openReplyDialog}
                       onRepostClick={openRepostDialog}
-                      actionsClassName="w-full shrink-0 justify-start sm:w-auto md:justify-end"
+                      className={
+                        isCollectionSurface ? 'flex flex-wrap items-center justify-between gap-x-2 gap-y-4' : undefined
+                      }
+                      actionsClassName={
+                        isCollectionSurface
+                          ? 'shrink-0 justify-end'
+                          : 'w-full shrink-0 justify-start sm:w-auto md:justify-end'
+                      }
                     />
                   </>
                 )}

--- a/src/components/organisms/PostMain/PostMain.tsx
+++ b/src/components/organisms/PostMain/PostMain.tsx
@@ -38,9 +38,7 @@ export function PostMain({
   isNavigable = true,
 }: PostMainProps) {
   const isMobile = useIsMobile();
-  const layoutConfig = usePostMainLayout();
-  const inheritedTagsLayout = layoutConfig?.tagsLayout ?? 'inline';
-  const isCollectionSurface = layoutConfig?.surface === 'collection';
+  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
   const effectiveTagsLayout = inheritedTagsLayout === 'side' && isMobile ? 'inline' : inheritedTagsLayout;
   const isWideLayout = effectiveTagsLayout === 'side';
   const { postDetails } = usePostDetails(postId);
@@ -80,7 +78,10 @@ export function PostMain({
             <PostThreadConnector height={postHeight} variant={connectorVariant} />
           </Container>
         )}
-        <Card ref={cardRef} className={cn('min-w-0 flex-1 gap-0 rounded-md py-0', className)}>
+        <Card
+          ref={cardRef}
+          className={cn('@container/post min-w-0 flex-1 gap-0 overflow-hidden rounded-md py-0', className)}
+        >
           {isDeleted ? (
             <PostDeleted />
           ) : (
@@ -135,14 +136,6 @@ export function PostMain({
                       postId={postId}
                       onReplyClick={openReplyDialog}
                       onRepostClick={openRepostDialog}
-                      className={
-                        isCollectionSurface ? 'flex flex-wrap items-center justify-between gap-x-2 gap-y-4' : undefined
-                      }
-                      actionsClassName={
-                        isCollectionSurface
-                          ? 'shrink-0 justify-end'
-                          : 'w-full shrink-0 justify-start sm:w-auto md:justify-end'
-                      }
                     />
                   </>
                 )}

--- a/src/components/organisms/PostMain/PostMain.types.ts
+++ b/src/components/organisms/PostMain/PostMain.types.ts
@@ -1,7 +1,5 @@
 export type TagsLayout = 'inline' | 'side';
 
-export type PostMainSurface = 'default' | 'collection';
-
 export interface PostMainProps {
   postId: string;
   className?: string;

--- a/src/components/organisms/PostMain/PostMain.types.ts
+++ b/src/components/organisms/PostMain/PostMain.types.ts
@@ -1,5 +1,7 @@
 export type TagsLayout = 'inline' | 'side';
 
+export type PostMainSurface = 'default' | 'collection';
+
 export interface PostMainProps {
   postId: string;
   className?: string;

--- a/src/components/organisms/PostMain/PostMainLayoutContext.tsx
+++ b/src/components/organisms/PostMain/PostMainLayoutContext.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import * as React from 'react';
-import type { TagsLayout } from './PostMain.types';
+import type { PostMainSurface, TagsLayout } from './PostMain.types';
 
-const PostMainLayoutContext = React.createContext<TagsLayout | undefined>(undefined);
+export interface PostMainLayoutConfig {
+  tagsLayout: TagsLayout;
+  surface?: PostMainSurface;
+}
+
+const PostMainLayoutContext = React.createContext<PostMainLayoutConfig | undefined>(undefined);
 
 interface PostMainLayoutProviderProps {
   tagsLayout: TagsLayout;
+  surface?: PostMainSurface;
   children: React.ReactNode;
 }
 
@@ -14,8 +20,8 @@ interface PostMainLayoutProviderProps {
  * Provides the surface-level tags layout to every PostMain rendered beneath it,
  * including those reached via the recursive ThreadTree -> ReplyWithNested chain.
  */
-export function PostMainLayoutProvider({ tagsLayout, children }: PostMainLayoutProviderProps) {
-  return <PostMainLayoutContext.Provider value={tagsLayout}>{children}</PostMainLayoutContext.Provider>;
+export function PostMainLayoutProvider({ tagsLayout, surface = 'default', children }: PostMainLayoutProviderProps) {
+  return <PostMainLayoutContext.Provider value={{ tagsLayout, surface }}>{children}</PostMainLayoutContext.Provider>;
 }
 
 export function usePostMainLayout() {

--- a/src/components/organisms/PostMain/PostMainLayoutContext.tsx
+++ b/src/components/organisms/PostMain/PostMainLayoutContext.tsx
@@ -1,18 +1,12 @@
 'use client';
 
 import * as React from 'react';
-import type { PostMainSurface, TagsLayout } from './PostMain.types';
+import type { TagsLayout } from './PostMain.types';
 
-export interface PostMainLayoutConfig {
-  tagsLayout: TagsLayout;
-  surface?: PostMainSurface;
-}
-
-const PostMainLayoutContext = React.createContext<PostMainLayoutConfig | undefined>(undefined);
+const PostMainLayoutContext = React.createContext<TagsLayout | undefined>(undefined);
 
 interface PostMainLayoutProviderProps {
   tagsLayout: TagsLayout;
-  surface?: PostMainSurface;
   children: React.ReactNode;
 }
 
@@ -20,8 +14,8 @@ interface PostMainLayoutProviderProps {
  * Provides the surface-level tags layout to every PostMain rendered beneath it,
  * including those reached via the recursive ThreadTree -> ReplyWithNested chain.
  */
-export function PostMainLayoutProvider({ tagsLayout, surface = 'default', children }: PostMainLayoutProviderProps) {
-  return <PostMainLayoutContext.Provider value={{ tagsLayout, surface }}>{children}</PostMainLayoutContext.Provider>;
+export function PostMainLayoutProvider({ tagsLayout, children }: PostMainLayoutProviderProps) {
+  return <PostMainLayoutContext.Provider value={tagsLayout}>{children}</PostMainLayoutContext.Provider>;
 }
 
 export function usePostMainLayout() {

--- a/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx
@@ -1,0 +1,174 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostSavePicker } from './PostSavePicker';
+
+const mockState = vi.hoisted(() => ({
+  isMobile: false,
+  toggleBookmark: vi.fn(),
+  toggleCollection: vi.fn(),
+  createCollectionWithPost: vi.fn(),
+  setShowSignInDialog: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+  'postSave.title': 'Save post',
+  'postSave.description': 'Choose where this post should be saved.',
+  'postSave.open': 'Save post',
+  'postSave.loading': 'Loading save options',
+  'postSave.bookmarks': 'Bookmarks',
+  'postSave.newCollection': 'New Collection',
+  'postSave.collectionNamePlaceholder': 'Collection name',
+  'postSave.createCollection': 'Create collection',
+  'postSave.loadingCollections': 'Loading collections...',
+};
+
+vi.mock('@/hooks/usePostSaveTargets/usePostSaveTargets', () => ({
+  usePostSaveTargets: () => ({
+    isBookmarked: true,
+    isBookmarkLoading: false,
+    isBookmarkToggling: false,
+    collections: [
+      {
+        id: 'author:collection1',
+        name: 'Proof of Work',
+        description: 'Bitcoin writing',
+        isSaved: true,
+        isUpdating: false,
+      },
+      {
+        id: 'author:collection2',
+        name: 'AI Papers',
+        description: '',
+        isSaved: false,
+        isUpdating: false,
+      },
+    ],
+    isCollectionsLoading: false,
+    isCreatingCollection: false,
+    toggleBookmark: mockState.toggleBookmark,
+    toggleCollection: mockState.toggleCollection,
+    createCollectionWithPost: mockState.createCollectionWithPost,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile/useIsMobile', () => ({
+  useIsMobile: () => mockState.isMobile,
+}));
+
+vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
+  useRequireAuth: () => ({
+    isAuthenticated: true,
+    requireAuth: <T,>(action: () => T) => action(),
+  }),
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: {
+    getState: () => ({
+      currentUserPubky: 'current-user',
+      setShowSignInDialog: mockState.setShowSignInDialog,
+    }),
+  },
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace: string) =>
+    (key: string): string =>
+      translations[`${namespace}.${key}`] ?? key,
+}));
+
+describe('PostSavePicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.isMobile = false;
+  });
+
+  const renderPicker = () => render(<PostSavePicker postId="author:post1" buttonClassName="border-none shadow-xs" />);
+
+  const openPicker = () => {
+    const trigger = screen.getByRole('button', { name: 'Save post' });
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+  };
+
+  it('opens the desktop save menu with bookmarks and collections', async () => {
+    renderPicker();
+
+    openPicker();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bookmarks')).toBeInTheDocument();
+      expect(screen.getByText('Proof of Work')).toBeInTheDocument();
+      expect(screen.getByText('AI Papers')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles bookmark and collection targets from the desktop menu', async () => {
+    renderPicker();
+
+    openPicker();
+
+    fireEvent.click(await screen.findByText('Bookmarks'));
+    expect(mockState.toggleBookmark).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Proof of Work'));
+    expect(mockState.toggleCollection).toHaveBeenCalledWith('author:collection1');
+  });
+
+  it('creates a collection from the inline field', async () => {
+    renderPicker();
+
+    openPicker();
+    fireEvent.change(await screen.findByPlaceholderText('Collection name'), { target: { value: 'Reading list' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create collection' }));
+    });
+
+    expect(mockState.createCollectionWithPost).toHaveBeenCalledWith('Reading list');
+  });
+
+  it('keeps inline field keyboard events from bubbling to the menu', async () => {
+    const keyDownListener = vi.fn();
+
+    renderPicker();
+
+    openPicker();
+    const input = await screen.findByPlaceholderText('Collection name');
+
+    document.addEventListener('keydown', keyDownListener);
+
+    try {
+      fireEvent.keyDown(input, { key: 'V', code: 'KeyV', metaKey: true });
+      fireEvent.keyDown(input, { key: 'V', code: 'KeyV' });
+
+      expect(keyDownListener).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('keydown', keyDownListener);
+    }
+  });
+
+  it('uses a bottom sheet on mobile', async () => {
+    mockState.isMobile = true;
+
+    renderPicker();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save post' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Save post')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Choose where this post should be saved.')).not.toBeInTheDocument();
+  });
+
+  it('matches desktop picker snapshot when open', async () => {
+    renderPicker();
+
+    openPicker();
+
+    await screen.findByText('Bookmarks');
+
+    expect(document.body).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
@@ -1,0 +1,291 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PostSavePicker > matches desktop picker snapshot when open 1`] = `
+<body
+  data-scroll-locked="1"
+  style="pointer-events: none;"
+>
+  <span
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-radix-focus-guard=""
+    style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+    tabindex="0"
+  />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <button
+      aria-controls="radix-normalized"
+      aria-expanded="true"
+      aria-haspopup="menu"
+      aria-label="Save post"
+      class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 border-none shadow-xs w-10"
+      data-cy="post-bookmark-btn"
+      data-size="sm"
+      data-slot="button"
+      data-state="open"
+      data-variant="secondary"
+      id="radix-normalized"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-bookmark"
+        fill="currentColor"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    data-radix-popper-content-wrapper=""
+    dir="ltr"
+    style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px); min-width: max-content; --radix-popper-available-width: 0px; --radix-popper-available-height: -4px; --radix-popper-anchor-width: 0px; --radix-popper-anchor-height: 0px; --radix-popper-transform-origin: 100% 0px;"
+  >
+    <div
+      aria-labelledby="radix-normalized"
+      aria-orientation="vertical"
+      class="z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-background p-4 shadow-xl data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 w-70"
+      data-align="end"
+      data-orientation="vertical"
+      data-radix-menu-content=""
+      data-side="bottom"
+      data-state="open"
+      dir="ltr"
+      id="radix-normalized"
+      role="menu"
+      style="outline: none; --radix-dropdown-menu-content-transform-origin: var(--radix-popper-transform-origin); --radix-dropdown-menu-content-available-width: var(--radix-popper-available-width); --radix-dropdown-menu-content-available-height: var(--radix-popper-available-height); --radix-dropdown-menu-trigger-width: var(--radix-popper-anchor-width); --radix-dropdown-menu-trigger-height: var(--radix-popper-anchor-height); pointer-events: auto;"
+      tabindex="-1"
+    >
+      <div
+        class="flex w-full flex-col gap-3"
+        data-testid="container"
+      >
+        <div
+          class="relative cursor-pointer rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 flex w-full items-center gap-2 p-0 text-base font-medium text-muted-foreground"
+          data-cy="post-save-bookmarks-option"
+          data-orientation="vertical"
+          data-radix-collection-item=""
+          role="menuitem"
+          tabindex="-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-bookmark size-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z"
+            />
+          </svg>
+          <span
+            class="min-w-0 flex-1 truncate text-base font-medium"
+            data-testid="typography"
+          >
+            Bookmarks
+          </span>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-check size-4 text-brand"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 6 9 17l-5-5"
+            />
+          </svg>
+        </div>
+        <div
+          class="relative cursor-pointer rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 flex w-full items-center gap-2 p-0 text-base font-medium text-muted-foreground"
+          data-orientation="vertical"
+          data-radix-collection-item=""
+          role="menuitem"
+          tabindex="-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-library size-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m16 6 4 14"
+            />
+            <path
+              d="M12 6v14"
+            />
+            <path
+              d="M8 8v12"
+            />
+            <path
+              d="M4 4v16"
+            />
+          </svg>
+          <span
+            class="min-w-0 flex-1 truncate text-base font-medium"
+            data-testid="typography"
+          >
+            Proof of Work
+          </span>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-check size-4 text-brand"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 6 9 17l-5-5"
+            />
+          </svg>
+        </div>
+        <div
+          class="relative cursor-pointer rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 flex w-full items-center gap-2 p-0 text-base font-medium text-muted-foreground"
+          data-orientation="vertical"
+          data-radix-collection-item=""
+          role="menuitem"
+          tabindex="-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-library size-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m16 6 4 14"
+            />
+            <path
+              d="M12 6v14"
+            />
+            <path
+              d="M8 8v12"
+            />
+            <path
+              d="M4 4v16"
+            />
+          </svg>
+          <span
+            class="min-w-0 flex-1 truncate text-base font-medium"
+            data-testid="typography"
+          >
+            AI Papers
+          </span>
+        </div>
+        <div
+          aria-orientation="horizontal"
+          class="-mx-1 h-px bg-muted my-1"
+          role="separator"
+        />
+        <div
+          class="flex flex-col gap-2 pt-1"
+          data-testid="container"
+        >
+          <label
+            class="flex items-center gap-2 font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 text-xs tracking-widest text-muted-foreground uppercase"
+            data-slot="label"
+          >
+            New Collection
+          </label>
+          <div
+            class="flex items-center gap-2 rounded-md border border-dashed border-input px-4 py-3"
+            data-testid="container"
+          >
+            <input
+              class="flex w-full min-w-0 rounded-md border border-input bg-transparent text-base transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 hover:ring-0 hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none aria-invalid:border-destructive aria-invalid:ring-destructive/40 h-auto border-none p-0 shadow-none"
+              data-testid="input"
+              maxlength="100"
+              placeholder="Collection name"
+              value=""
+            />
+            <button
+              aria-label="Create collection"
+              class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent size-6"
+              data-size="icon"
+              data-slot="button"
+              data-variant="secondary"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-plus"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 12h14"
+                />
+                <path
+                  d="M12 5v14"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <span
+    aria-hidden="true"
+    data-aria-hidden="true"
+    data-radix-focus-guard=""
+    style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+    tabindex="0"
+  />
+</body>
+`;

--- a/src/components/organisms/PostSavePicker/PostSavePicker.tsx
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { type KeyboardEvent, type ReactNode, useState } from 'react';
+import { Bookmark, Check, Library, Loader2, Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/atoms/Button/Button';
+import { Container } from '@/atoms/Container/Container';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/atoms/DropdownMenu/DropdownMenu';
+import { Input } from '@/atoms/Input/Input';
+import { Label } from '@/atoms/Label/Label';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/atoms/Sheet/Sheet';
+import { Typography } from '@/atoms/Typography/Typography';
+import { COLLECTION_NAME_MAX_CHARACTER_LENGTH } from '@/config/posts';
+import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
+import { type PostSaveCollectionTarget, usePostSaveTargets } from '@/hooks/usePostSaveTargets/usePostSaveTargets';
+import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
+import { cn } from '@/libs/utils/utils';
+
+type PostSavePickerProps = {
+  postId: string;
+  /**
+   * Class merged into the trigger Button. `PostActionsBar` passes its variant
+   * styling (default vs. visual / overlay) so the save trigger stays visually
+   * consistent with sibling action buttons.
+   */
+  buttonClassName: string;
+};
+
+type SavePickerLayout = 'dropdown' | 'sheet';
+
+type SaveTargetIconProps = {
+  isSaved: boolean;
+  isBusy: boolean;
+};
+
+type SavePickerContentProps = {
+  layout: SavePickerLayout;
+  isBookmarked: boolean;
+  isBookmarkBusy: boolean;
+  collections: PostSaveCollectionTarget[];
+  isCollectionsLoading: boolean;
+  isCreatingCollection: boolean;
+  toggleBookmark: () => Promise<void>;
+  toggleCollection: (collectionId: string) => Promise<void>;
+  createCollectionWithPost: (name: string) => Promise<void>;
+};
+
+function SaveTargetIcon({ isSaved, isBusy }: SaveTargetIconProps) {
+  if (isBusy) {
+    return <Loader2 className="size-4 animate-spin" />;
+  }
+
+  if (isSaved) {
+    return <Check className="size-4 text-brand" />;
+  }
+
+  return null;
+}
+
+function SavePickerRow({
+  layout,
+  disabled,
+  dataCy,
+  onActivate,
+  children,
+}: {
+  layout: SavePickerLayout;
+  disabled?: boolean;
+  dataCy?: string;
+  onActivate: () => void;
+  children: ReactNode;
+}) {
+  if (layout === 'dropdown') {
+    return (
+      <DropdownMenuItem
+        disabled={disabled}
+        onSelect={(event) => {
+          event.preventDefault();
+          onActivate();
+        }}
+        className="flex w-full items-center gap-2 p-0 text-base font-medium text-muted-foreground"
+        data-cy={dataCy}
+      >
+        {children}
+      </DropdownMenuItem>
+    );
+  }
+
+  return (
+    <Button
+      overrideDefaults
+      disabled={disabled}
+      onClick={onActivate}
+      className="flex w-full cursor-pointer items-center gap-2 rounded-sm p-0 text-base font-medium text-muted-foreground disabled:opacity-50"
+      data-cy={dataCy}
+    >
+      {children}
+    </Button>
+  );
+}
+
+function CollectionRow({
+  layout,
+  collection,
+  onToggleCollection,
+}: {
+  layout: SavePickerLayout;
+  collection: PostSaveCollectionTarget;
+  onToggleCollection: (collectionId: string) => Promise<void>;
+}) {
+  return (
+    <SavePickerRow
+      layout={layout}
+      disabled={collection.isUpdating}
+      onActivate={() => void onToggleCollection(collection.id)}
+    >
+      <Library className="size-4" />
+      <Typography
+        as="span"
+        overrideDefaults
+        className={cn('min-w-0 flex-1 truncate text-base font-medium', layout === 'sheet' && 'text-left')}
+      >
+        {collection.name}
+      </Typography>
+      <SaveTargetIcon isSaved={collection.isSaved} isBusy={collection.isUpdating} />
+    </SavePickerRow>
+  );
+}
+
+function SavePickerContent({
+  layout,
+  isBookmarked,
+  isBookmarkBusy,
+  collections,
+  isCollectionsLoading,
+  isCreatingCollection,
+  toggleBookmark,
+  toggleCollection,
+  createCollectionWithPost,
+}: SavePickerContentProps) {
+  const t = useTranslations('postSave');
+  const [newCollectionName, setNewCollectionName] = useState('');
+  const canCreate = newCollectionName.trim().length > 0 && !isCreatingCollection;
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
+    await createCollectionWithPost(newCollectionName);
+    setNewCollectionName('');
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Stop the menu/sheet from intercepting typing (e.g. type-ahead in
+    // DropdownMenu, copy/paste shortcuts) so the inline name field behaves
+    // like a normal text input even when nested inside the menu.
+    event.stopPropagation();
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    void handleCreate();
+  };
+
+  return (
+    <Container overrideDefaults className={cn('flex w-full flex-col', layout === 'sheet' ? 'gap-4' : 'gap-3')}>
+      <SavePickerRow
+        layout={layout}
+        disabled={isBookmarkBusy}
+        dataCy="post-save-bookmarks-option"
+        onActivate={() => void toggleBookmark()}
+      >
+        {isBookmarkBusy ? <Loader2 className="size-4 animate-spin" /> : <Bookmark className="size-4" />}
+        <Typography
+          as="span"
+          overrideDefaults
+          className={cn('min-w-0 flex-1 truncate text-base font-medium', layout === 'sheet' && 'text-left')}
+        >
+          {t('bookmarks')}
+        </Typography>
+        <SaveTargetIcon isSaved={isBookmarked} isBusy={isBookmarkBusy} />
+      </SavePickerRow>
+
+      {isCollectionsLoading ? (
+        <Container overrideDefaults className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          <Typography overrideDefaults className="text-base font-medium">
+            {t('loadingCollections')}
+          </Typography>
+        </Container>
+      ) : (
+        collections.map((collection) => (
+          <CollectionRow
+            key={collection.id}
+            layout={layout}
+            collection={collection}
+            onToggleCollection={toggleCollection}
+          />
+        ))
+      )}
+
+      {layout === 'dropdown' ? (
+        <DropdownMenuSeparator className="my-1" />
+      ) : (
+        <Container overrideDefaults className="h-px bg-muted" />
+      )}
+
+      <Container overrideDefaults className={cn('flex flex-col gap-2', layout === 'dropdown' && 'pt-1')}>
+        <Label className="text-xs tracking-widest text-muted-foreground uppercase">{t('newCollection')}</Label>
+        <Container
+          overrideDefaults
+          className="flex items-center gap-2 rounded-md border border-dashed border-input px-4 py-3"
+        >
+          <Input
+            value={newCollectionName}
+            onChange={(event) => setNewCollectionName(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            maxLength={COLLECTION_NAME_MAX_CHARACTER_LENGTH}
+            placeholder={t('collectionNamePlaceholder')}
+            className="h-auto border-none p-0 shadow-none"
+            disabled={isCreatingCollection}
+          />
+          <Button
+            type="button"
+            size="icon"
+            variant="secondary"
+            className="size-6"
+            disabled={!canCreate}
+            onClick={() => void handleCreate()}
+            aria-label={t('createCollection')}
+          >
+            {isCreatingCollection ? <Loader2 className="animate-spin" /> : <Plus />}
+          </Button>
+        </Container>
+      </Container>
+    </Container>
+  );
+}
+
+export function PostSavePicker({ postId, buttonClassName }: PostSavePickerProps) {
+  const t = useTranslations('postSave');
+  const isMobile = useIsMobile();
+  const { requireAuth } = useRequireAuth();
+  const [open, setOpen] = useState(false);
+  const saveTargets = usePostSaveTargets(postId);
+  const isBusy = saveTargets.isBookmarkLoading || saveTargets.isBookmarkToggling;
+  const TriggerIcon = isBusy ? Loader2 : Bookmark;
+  const trigger = (
+    <Button
+      variant="secondary"
+      size="sm"
+      // `w-10` keeps the icon-only trigger the same width as sibling action
+      // buttons in `PostActionsBar` (which carry an icon + count and grow naturally).
+      className={cn(buttonClassName, 'w-10')}
+      aria-label={isBusy ? t('loading') : t('open')}
+      data-cy="post-bookmark-btn"
+    >
+      <TriggerIcon
+        fill={saveTargets.isBookmarked && !isBusy ? 'currentColor' : 'none'}
+        className={cn(isBusy && 'animate-spin')}
+      />
+    </Button>
+  );
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setOpen(false);
+      return;
+    }
+
+    requireAuth(() => setOpen(true));
+  };
+
+  const contentProps = { ...saveTargets, isBookmarkBusy: isBusy };
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetTrigger asChild>{trigger}</SheetTrigger>
+        <SheetContent side="bottom" aria-describedby={undefined} className="rounded-t-xl border-border bg-popover">
+          <SheetHeader>
+            <SheetTitle>{t('title')}</SheetTitle>
+          </SheetHeader>
+          <SavePickerContent layout="sheet" {...contentProps} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-70">
+        <SavePickerContent layout="dropdown" {...contentProps} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/organisms/QuickReply/QuickReply.tsx
+++ b/src/components/organisms/QuickReply/QuickReply.tsx
@@ -102,7 +102,7 @@ export function QuickReply({
   const connectorHeight = cardHeight ? cardHeight + QUICK_REPLY_CONNECTOR_SPACER_HEIGHT : undefined;
 
   const isMobile = useIsMobile();
-  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
+  const inheritedTagsLayout = usePostMainLayout()?.tagsLayout ?? 'inline';
   const isWideLayout = !isMobile && inheritedTagsLayout === 'side';
 
   return (

--- a/src/components/organisms/QuickReply/QuickReply.tsx
+++ b/src/components/organisms/QuickReply/QuickReply.tsx
@@ -102,7 +102,7 @@ export function QuickReply({
   const connectorHeight = cardHeight ? cardHeight + QUICK_REPLY_CONNECTOR_SPACER_HEIGHT : undefined;
 
   const isMobile = useIsMobile();
-  const inheritedTagsLayout = usePostMainLayout()?.tagsLayout ?? 'inline';
+  const inheritedTagsLayout = usePostMainLayout() ?? 'inline';
   const isWideLayout = !isMobile && inheritedTagsLayout === 'side';
 
   return (

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
@@ -68,7 +68,7 @@ vi.mock('@/atoms/PostThreadSpacer/PostThreadSpacer', () => {
 vi.mock('@/organisms/PostMain/PostMain', () => {
   return {
     PostMain: ({ postId, isLastReply }: { postId: string; isLastReply: boolean }) => {
-      const tagsLayout = usePostMainLayout()?.tagsLayout;
+      const tagsLayout = usePostMainLayout();
 
       return (
         <div

--- a/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
+++ b/src/components/organisms/ReplyWithNested/ReplyWithNested.test.tsx
@@ -68,7 +68,7 @@ vi.mock('@/atoms/PostThreadSpacer/PostThreadSpacer', () => {
 vi.mock('@/organisms/PostMain/PostMain', () => {
   return {
     PostMain: ({ postId, isLastReply }: { postId: string; isLastReply: boolean }) => {
-      const tagsLayout = usePostMainLayout();
+      const tagsLayout = usePostMainLayout()?.tagsLayout;
 
       return (
         <div

--- a/src/components/organisms/SinglePostContent/SinglePostContent.test.tsx
+++ b/src/components/organisms/SinglePostContent/SinglePostContent.test.tsx
@@ -205,7 +205,7 @@ vi.mock('@/organisms/PostMain/PostMain', async () => {
       pinActionsToBottom?: boolean;
       isNavigable?: boolean;
     }) => {
-      const inheritedTagsLayout = usePostMainLayout();
+      const inheritedTagsLayout = usePostMainLayout()?.tagsLayout;
       return (
         <div
           data-testid="post-main"

--- a/src/components/organisms/SinglePostContent/SinglePostContent.test.tsx
+++ b/src/components/organisms/SinglePostContent/SinglePostContent.test.tsx
@@ -205,7 +205,7 @@ vi.mock('@/organisms/PostMain/PostMain', async () => {
       pinActionsToBottom?: boolean;
       isNavigable?: boolean;
     }) => {
-      const inheritedTagsLayout = usePostMainLayout()?.tagsLayout;
+      const inheritedTagsLayout = usePostMainLayout();
       return (
         <div
           data-testid="post-main"

--- a/src/components/templates/Collections/Collections.test.tsx
+++ b/src/components/templates/Collections/Collections.test.tsx
@@ -1,43 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { FileController } from '@/controllers/file/file';
-import { useCurrentUserProfile } from '@/hooks/useCurrentUserProfile/useCurrentUserProfile';
-import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCollectionsOwner } from '@/hooks/useCollectionsOwner/useCollectionsOwner';
 import { Collections } from './Collections';
 
-vi.mock('@/controllers/file/file', () => ({
-  FileController: {
-    getAvatarUrl: vi.fn(
-      (pubky: string, version?: string | number) => `https://example.com/avatar/${pubky}?v=${version}`,
-    ),
-  },
-}));
-
-vi.mock('@/hooks/useCurrentUserProfile/useCurrentUserProfile', () => ({
-  useCurrentUserProfile: vi.fn(() => ({
-    currentUserPubky: 'test-pubky',
-    userDetails: {
-      id: 'test-pubky',
-      name: 'Test User',
-      image: 'avatar',
-      indexed_at: 123,
-      bio: '',
-      links: [],
-      status: '',
-    },
-  })),
-}));
-
-vi.mock('@/hooks/useLocalFirstQuery/useLocalFirstQuery', () => ({
-  useLocalFirstQuery: vi.fn(() => ({
-    data: { bookmarks: 29 },
-    isLoading: false,
-  })),
-}));
-
-vi.mock('@/stores/localFiles/localFiles.store', () => ({
-  useLocalFilesStore: vi.fn((selector: (state: { profile: string | null }) => unknown) => selector({ profile: null })),
+vi.mock('@/hooks/useCollectionsOwner/useCollectionsOwner', () => ({
+  useCollectionsOwner: vi.fn(),
 }));
 
 vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
@@ -87,25 +55,19 @@ vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
   ),
 }));
 
+const defaultOwner = {
+  currentUserPubky: 'test-pubky',
+  avatarUrl: 'https://example.com/avatar/test-pubky?v=123',
+  avatarName: 'Test User',
+  avatarSeed: 'test-pubky',
+  bookmarkCount: 29,
+  isCountsLoading: false,
+};
+
 describe('Collections', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useCurrentUserProfile).mockReturnValue({
-      currentUserPubky: 'test-pubky',
-      userDetails: {
-        id: 'test-pubky',
-        name: 'Test User',
-        image: 'avatar',
-        indexed_at: 123,
-        bio: '',
-        links: [],
-        status: '',
-      },
-    });
-    vi.mocked(useLocalFirstQuery).mockReturnValue({
-      data: { bookmarks: 29 },
-      isLoading: false,
-    });
+    vi.mocked(useCollectionsOwner).mockReturnValue(defaultOwner);
   });
 
   it('renders the Collections landing page with the default Bookmarks collection', () => {
@@ -114,7 +76,7 @@ describe('Collections', () => {
     expect(screen.getByRole('heading', { name: 'My Collections' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'New Collection' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Bookmarks' })).toHaveAttribute('href', '/collections/bookmarks');
-    expect(screen.getByText('Everything you want to save for later.')).toBeInTheDocument();
+    expect(screen.getByText('Everything you saved for later')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();
     expect(screen.getByText('PRIVATE')).toBeInTheDocument();
   });
@@ -122,7 +84,6 @@ describe('Collections', () => {
   it('renders current user avatar metadata on the Bookmarks card', () => {
     render(<Collections />);
 
-    expect(FileController.getAvatarUrl).toHaveBeenCalledWith('test-pubky', 123);
     const avatar = screen.getByTestId('avatar-with-fallback');
     expect(avatar).toHaveAttribute('data-avatar-url', 'https://example.com/avatar/test-pubky?v=123');
     expect(avatar).toHaveAttribute('data-name', 'Test User');

--- a/src/components/templates/Collections/Collections.test.tsx
+++ b/src/components/templates/Collections/Collections.test.tsx
@@ -112,6 +112,7 @@ describe('Collections', () => {
     render(<Collections />);
 
     expect(screen.getByRole('heading', { name: 'My Collections' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New Collection' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Bookmarks' })).toHaveAttribute('href', '/collections/bookmarks');
     expect(screen.getByText('Everything you want to save for later.')).toBeInTheDocument();
     expect(screen.getByText('29')).toBeInTheDocument();

--- a/src/components/templates/Collections/Collections.test.tsx.snap
+++ b/src/components/templates/Collections/Collections.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`Collections - Snapshots > matches snapshot 1`] = `
               class="w-full min-w-0 text-base leading-6 font-medium text-muted-foreground"
               data-testid="typography"
             >
-              Everything you want to save for later.
+              Everything you saved for later
             </p>
           </div>
         </div>

--- a/src/components/templates/Collections/Collections.test.tsx.snap
+++ b/src/components/templates/Collections/Collections.test.tsx.snap
@@ -11,19 +11,59 @@ exports[`Collections - Snapshots > matches snapshot 1`] = `
     class="flex w-full flex-col gap-6"
     data-testid="container"
   >
-    <h1
-      class="text-2xl font-light text-muted-foreground"
-      data-testid="heading-1"
+    <div
+      class="flex flex-wrap items-center gap-3"
+      data-testid="container"
     >
-      My Collections
-    </h1>
+      <h1
+        class="text-2xl font-light text-muted-foreground"
+        data-testid="heading-1"
+      >
+        My Collections
+      </h1>
+      <button
+        aria-controls="radix-normalized"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5"
+        data-as-child="true"
+        data-size="sm"
+        data-slot="dialog-trigger"
+        data-state="closed"
+        data-testid="dialog-trigger"
+        data-variant="secondary"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-plus"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5 12h14"
+          />
+          <path
+            d="M12 5v14"
+          />
+        </svg>
+        New Collection
+      </button>
+    </div>
     <div
       class="flex flex-wrap gap-6"
       data-testid="container"
     >
       <a
         aria-label="Bookmarks"
-        class="block w-full lg:max-w-[588px]"
+        class="block w-full lg:max-w-xl"
         data-cy="collection-card"
         href="/collections/bookmarks"
       >
@@ -97,7 +137,7 @@ exports[`Collections - Snapshots > matches snapshot 1`] = `
                     />
                   </svg>
                   <span
-                    class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                    class="text-xs leading-4 font-medium tracking-widest uppercase"
                     data-testid="typography"
                   >
                     29
@@ -121,11 +161,11 @@ exports[`Collections - Snapshots > matches snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M18 20a6 6 0 0 0-12 0"
+                      d="M17.925 20.056a6 6 0 0 0-11.851.001"
                     />
                     <circle
                       cx="12"
-                      cy="10"
+                      cy="11"
                       r="4"
                     />
                     <circle
@@ -135,7 +175,7 @@ exports[`Collections - Snapshots > matches snapshot 1`] = `
                     />
                   </svg>
                   <span
-                    class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                    class="text-xs leading-4 font-medium tracking-widest uppercase"
                     data-testid="typography"
                   >
                     PRIVATE

--- a/src/components/templates/Collections/Collections.tsx
+++ b/src/components/templates/Collections/Collections.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Bookmark } from 'lucide-react';
+import { Bookmark, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { COLLECTION_ROUTES } from '@/app/routes';
+import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Heading } from '@/atoms/Heading/Heading';
 import { FileController } from '@/controllers/file/file';
@@ -11,6 +12,7 @@ import { useCurrentUserProfile } from '@/hooks/useCurrentUserProfile/useCurrentU
 import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
 import { CollectionCard } from '@/molecules/Collections/CollectionCard/CollectionCard';
 import { ContentLayout } from '@/organisms/ContentLayout/ContentLayout';
+import { NewCollectionDialog } from '@/organisms/NewCollectionDialog/NewCollectionDialog';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 
 export function Collections() {
@@ -33,9 +35,17 @@ export function Collections() {
   return (
     <ContentLayout showLeftMobileButton={false} showRightMobileButton={false} className="pb-24 lg:pb-12 xl:!px-0">
       <Container overrideDefaults className="flex w-full flex-col gap-6">
-        <Heading level={1} size="lg" className="font-light text-muted-foreground">
-          {t('title')}
-        </Heading>
+        <Container overrideDefaults className="flex flex-wrap items-center gap-3">
+          <Heading level={1} size="lg" className="font-light text-muted-foreground">
+            {t('title')}
+          </Heading>
+          <NewCollectionDialog>
+            <Button variant="secondary" size="sm">
+              <Plus />
+              {t('new.cta')}
+            </Button>
+          </NewCollectionDialog>
+        </Container>
 
         <Container overrideDefaults className="flex flex-wrap gap-6">
           <CollectionCard

--- a/src/components/templates/Collections/Collections.tsx
+++ b/src/components/templates/Collections/Collections.tsx
@@ -6,31 +6,14 @@ import { COLLECTION_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Heading } from '@/atoms/Heading/Heading';
-import { FileController } from '@/controllers/file/file';
-import { UserController } from '@/controllers/user/user';
-import { useCurrentUserProfile } from '@/hooks/useCurrentUserProfile/useCurrentUserProfile';
-import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import { useCollectionsOwner } from '@/hooks/useCollectionsOwner/useCollectionsOwner';
 import { CollectionCard } from '@/molecules/Collections/CollectionCard/CollectionCard';
 import { ContentLayout } from '@/organisms/ContentLayout/ContentLayout';
 import { NewCollectionDialog } from '@/organisms/NewCollectionDialog/NewCollectionDialog';
-import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 
 export function Collections() {
   const t = useTranslations('collections');
-  const { userDetails, currentUserPubky } = useCurrentUserProfile();
-  const localAvatarUrl = useLocalFilesStore((state) => state.profile);
-  const { data: userCounts } = useLocalFirstQuery({
-    queryFn: () => UserController.getCounts({ userId: currentUserPubky! }),
-    fetchFn: () => UserController.fetchCounts({ userId: currentUserPubky! }),
-    deps: [currentUserPubky],
-    enabled: !!currentUserPubky,
-  });
-  const avatarUrl =
-    localAvatarUrl ??
-    (currentUserPubky && userDetails?.image
-      ? FileController.getAvatarUrl(currentUserPubky, userDetails.indexed_at)
-      : undefined);
-  const avatarName = userDetails?.name || 'U';
+  const { avatarUrl, avatarName, avatarSeed, bookmarkCount } = useCollectionsOwner();
 
   return (
     <ContentLayout showLeftMobileButton={false} showRightMobileButton={false} className="pb-24 lg:pb-12 xl:!px-0">
@@ -53,11 +36,11 @@ export function Collections() {
             title={t('bookmarks.title')}
             description={t('bookmarks.description')}
             icon={Bookmark}
-            count={userCounts?.bookmarks}
+            count={bookmarkCount}
             visibilityLabel={t('private')}
             avatarUrl={avatarUrl}
             avatarName={avatarName}
-            avatarSeed={currentUserPubky ?? avatarName}
+            avatarSeed={avatarSeed}
           />
         </Container>
       </Container>

--- a/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx
+++ b/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx
@@ -1,117 +1,125 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCollectionsOwner } from '@/hooks/useCollectionsOwner/useCollectionsOwner';
 import { Bookmarks } from './Bookmarks';
+
+vi.mock('@/hooks/useCollectionsOwner/useCollectionsOwner', () => ({
+  useCollectionsOwner: vi.fn(),
+}));
+
+vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
+  AvatarWithFallback: ({
+    avatarUrl,
+    name,
+    fallbackSeed,
+    size,
+  }: {
+    avatarUrl?: string;
+    name: string;
+    fallbackSeed?: string;
+    size?: string;
+  }) => (
+    <div
+      data-testid="avatar-with-fallback"
+      data-avatar-url={avatarUrl}
+      data-name={name}
+      data-fallback-seed={fallbackSeed}
+      data-size={size}
+    >
+      {name}
+    </div>
+  ),
+}));
 
 vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
   ContentLayout: ({
     children,
-    feedVariant,
+    showLeftSidebar,
+    showLeftMobileButton,
     showRightMobileButton,
-    leftSidebarContent,
-    rightSidebarContent,
-    leftDrawerContent,
-    rightDrawerContent,
-    leftDrawerContentMobile,
+    showRightSidebar,
+    className,
   }: {
     children: ReactNode;
-    feedVariant?: string;
+    showLeftSidebar?: boolean;
+    showLeftMobileButton?: boolean;
     showRightMobileButton?: boolean;
-    leftSidebarContent?: ReactNode;
-    rightSidebarContent?: ReactNode;
-    leftDrawerContent?: ReactNode;
-    rightDrawerContent?: ReactNode;
-    leftDrawerContentMobile?: ReactNode;
+    showRightSidebar?: boolean;
+    className?: string;
   }) => (
     <div
       data-testid="content-layout"
-      data-feed-variant={feedVariant}
+      data-show-left-sidebar={String(showLeftSidebar)}
+      data-show-left-mobile-button={String(showLeftMobileButton)}
+      data-show-right-sidebar={String(showRightSidebar)}
       data-show-right-mobile-button={String(showRightMobileButton)}
+      className={className}
     >
-      <div data-testid="left-sidebar">{leftSidebarContent}</div>
-      <div data-testid="right-sidebar">{rightSidebarContent}</div>
-      <div data-testid="left-drawer">{leftDrawerContent}</div>
-      <div data-testid="right-drawer">{rightDrawerContent}</div>
-      <div data-testid="left-drawer-mobile">{leftDrawerContentMobile}</div>
       {children}
     </div>
   ),
 }));
 
-vi.mock('@/organisms/FeedRightSidebar/FeedRightSidebar', () => ({
-  HomeFeedRightDrawer: () => <div data-testid="home-feed-right-drawer">HomeFeedRightDrawer</div>,
-  HomeFeedRightSidebar: () => <div data-testid="home-feed-right-sidebar">HomeFeedRightSidebar</div>,
-}));
-
-vi.mock('@/organisms/HomeFeedSidebar/HomeFeedSidebar', () => ({
-  HomeFeedDrawer: ({ feedVariant, hideReachFilter }: { feedVariant: string; hideReachFilter?: boolean }) => (
-    <div
-      data-testid="home-feed-drawer"
-      data-feed-variant={feedVariant}
-      data-hide-reach-filter={String(hideReachFilter)}
-    >
-      HomeFeedDrawer
-    </div>
-  ),
-  HomeFeedDrawerMobile: ({ feedVariant, hideReachFilter }: { feedVariant: string; hideReachFilter?: boolean }) => (
-    <div
-      data-testid="home-feed-drawer-mobile"
-      data-feed-variant={feedVariant}
-      data-hide-reach-filter={String(hideReachFilter)}
-    >
-      HomeFeedDrawerMobile
-    </div>
-  ),
-  HomeFeedSidebar: ({ feedVariant, hideReachFilter }: { feedVariant: string; hideReachFilter?: boolean }) => (
-    <div
-      data-testid="home-feed-sidebar"
-      data-feed-variant={feedVariant}
-      data-hide-reach-filter={String(hideReachFilter)}
-    >
-      HomeFeedSidebar
+vi.mock('@/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts', () => ({
+  BookmarksCollectionPosts: ({ emptyComponent }: { emptyComponent: ReactNode }) => (
+    <div data-testid="bookmarks-collection-posts">
+      <div data-testid="bookmarks-empty-prop">{emptyComponent}</div>
     </div>
   ),
 }));
 
-vi.mock('@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed', () => ({
-  TimelineFeed: ({ variant }: { variant: string }) => (
-    <div data-testid="timeline-feed" data-variant={variant}>
-      TimelineFeed
-    </div>
-  ),
-}));
-
-vi.mock('@/config/feed', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/config/feed')>();
-  return {
-    ...actual,
-    TIMELINE_FEED_VARIANT: {
-      ...actual.TIMELINE_FEED_VARIANT,
-      BOOKMARKS: 'bookmarks',
-    },
-  };
-});
+const defaultOwner = {
+  currentUserPubky: 'test-pubky',
+  avatarUrl: 'https://example.com/avatar/test-pubky?v=123',
+  avatarName: 'Test User',
+  avatarSeed: 'test-pubky',
+  bookmarkCount: 29,
+  isCountsLoading: false,
+};
 
 describe('Bookmarks', () => {
-  it('renders TimelineFeed with BOOKMARKS variant', () => {
-    render(<Bookmarks />);
-    const timelineFeed = screen.getByTestId('timeline-feed');
-    expect(timelineFeed).toBeInTheDocument();
-    expect(timelineFeed).toHaveAttribute('data-variant', 'bookmarks');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCollectionsOwner).mockReturnValue(defaultOwner);
   });
 
-  it('renders its own ContentLayout shell outside the feeds route group', () => {
+  it('renders the dedicated bookmarks collection posts list', () => {
+    render(<Bookmarks />);
+    expect(screen.getByTestId('bookmarks-collection-posts')).toBeInTheDocument();
+  });
+
+  it('renders its own collection detail shell outside the feeds route group', () => {
     render(<Bookmarks />);
     const contentLayout = screen.getByTestId('content-layout');
-    expect(contentLayout).toHaveAttribute('data-feed-variant', 'bookmarks');
+    expect(contentLayout).toHaveAttribute('data-show-left-sidebar', 'false');
+    expect(contentLayout).toHaveAttribute('data-show-left-mobile-button', 'false');
+    expect(contentLayout).toHaveAttribute('data-show-right-sidebar', 'false');
     expect(contentLayout).toHaveAttribute('data-show-right-mobile-button', 'false');
   });
 
-  it('renders bookmarks filters with reach filter hidden', () => {
+  it('renders the Bookmarks system collection header', () => {
     render(<Bookmarks />);
-    expect(screen.getByTestId('home-feed-sidebar')).toHaveAttribute('data-hide-reach-filter', 'true');
-    expect(screen.getByTestId('home-feed-drawer')).toHaveAttribute('data-hide-reach-filter', 'true');
-    expect(screen.getByTestId('home-feed-drawer-mobile')).toHaveAttribute('data-hide-reach-filter', 'true');
+    const header = screen.getByTestId('bookmarks-collection-header');
+    expect(header).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeInTheDocument();
+    expect(screen.getByText('Everything you saved for later')).toBeInTheDocument();
+    expect(header).toHaveTextContent('Test User');
+    expect(header).toHaveTextContent('29');
+    expect(header).toHaveTextContent('PRIVATE');
+  });
+
+  it('does not render system collection edit actions', () => {
+    render(<Bookmarks />);
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /rename/i })).not.toBeInTheDocument();
+  });
+
+  it('passes the Bookmarks empty state to the dedicated posts list', () => {
+    render(<Bookmarks />);
+    expect(screen.getByTestId('bookmarks-empty-state')).toBeInTheDocument();
+    expect(screen.getByText('No bookmarks yet')).toBeInTheDocument();
   });
 });
 

--- a/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx.snap
+++ b/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Bookmarks - Snapshots > matches snapshot 1`] = `
         data-testid="bookmarks-collection-header"
       >
         <h1
-          class="w-full break-words text-5xl leading-none font-bold text-white lg:text-6xl"
+          class="w-full text-5xl leading-none font-bold break-words text-white lg:text-6xl"
           data-testid="typography"
         >
           Bookmarks

--- a/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx.snap
+++ b/src/components/templates/Feed/Bookmarks/Bookmarks.test.tsx.snap
@@ -3,66 +3,158 @@
 exports[`Bookmarks - Snapshots > matches snapshot 1`] = `
 <div>
   <div
-    data-feed-variant="bookmarks"
+    class="pb-24 lg:pb-12 xl:!px-0"
+    data-show-left-mobile-button="false"
+    data-show-left-sidebar="false"
     data-show-right-mobile-button="false"
+    data-show-right-sidebar="false"
     data-testid="content-layout"
   >
     <div
-      data-testid="left-sidebar"
+      class="flex w-full flex-col gap-6"
+      data-testid="container"
     >
       <div
-        data-feed-variant="bookmarks"
-        data-hide-reach-filter="true"
-        data-testid="home-feed-sidebar"
+        class="flex w-full flex-col gap-4 rounded-md bg-card p-6 lg:p-12"
+        data-testid="bookmarks-collection-header"
       >
-        HomeFeedSidebar
+        <h1
+          class="w-full break-words text-5xl leading-none font-bold text-white lg:text-6xl"
+          data-testid="typography"
+        >
+          Bookmarks
+        </h1>
+        <div
+          class="flex w-full flex-wrap items-center gap-6"
+          data-testid="container"
+        >
+          <div
+            class="flex min-w-0 flex-1 items-center gap-3 lg:flex-none"
+            data-testid="container"
+          >
+            <div
+              data-avatar-url="https://example.com/avatar/test-pubky?v=123"
+              data-fallback-seed="test-pubky"
+              data-name="Test User"
+              data-size="md"
+              data-testid="avatar-with-fallback"
+            >
+              Test User
+            </div>
+            <span
+              class="min-w-0 flex-1 truncate text-xl leading-7 font-bold text-white"
+              data-testid="typography"
+            >
+              Test User
+            </span>
+          </div>
+          <div
+            class="flex shrink-0 items-center gap-3 text-muted-foreground"
+            data-testid="container"
+          >
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-sticky-note size-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+                />
+                <path
+                  d="M15 3v5a1 1 0 0 0 1 1h5"
+                />
+              </svg>
+              <span
+                class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                data-testid="typography"
+              >
+                29
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-1"
+              data-testid="container"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-circle-user-round size-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.925 20.056a6 6 0 0 0-11.851.001"
+                />
+                <circle
+                  cx="12"
+                  cy="11"
+                  r="4"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+              </svg>
+              <span
+                class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
+                data-testid="typography"
+              >
+                PRIVATE
+              </span>
+            </div>
+          </div>
+        </div>
+        <p
+          class="w-full text-xl leading-7 font-light text-muted-foreground lg:text-2xl lg:leading-8"
+          data-testid="typography"
+        >
+          Everything you saved for later
+        </p>
       </div>
-    </div>
-    <div
-      data-testid="right-sidebar"
-    >
       <div
-        data-testid="home-feed-right-sidebar"
+        data-testid="bookmarks-collection-posts"
       >
-        HomeFeedRightSidebar
+        <div
+          data-testid="bookmarks-empty-prop"
+        >
+          <div
+            class="flex min-h-48 w-full flex-col items-center justify-center gap-2 rounded-md px-6 py-12 text-center"
+            data-testid="bookmarks-empty-state"
+          >
+            <h2
+              class="text-xl leading-7 font-bold text-foreground"
+              data-testid="typography"
+            >
+              No bookmarks yet
+            </h2>
+            <p
+              class="max-w-md text-base leading-6 font-medium text-muted-foreground"
+              data-testid="typography"
+            >
+              Save posts to Bookmarks and they will appear here.
+            </p>
+          </div>
+        </div>
       </div>
-    </div>
-    <div
-      data-testid="left-drawer"
-    >
-      <div
-        data-feed-variant="bookmarks"
-        data-hide-reach-filter="true"
-        data-testid="home-feed-drawer"
-      >
-        HomeFeedDrawer
-      </div>
-    </div>
-    <div
-      data-testid="right-drawer"
-    >
-      <div
-        data-testid="home-feed-right-drawer"
-      >
-        HomeFeedRightDrawer
-      </div>
-    </div>
-    <div
-      data-testid="left-drawer-mobile"
-    >
-      <div
-        data-feed-variant="bookmarks"
-        data-hide-reach-filter="true"
-        data-testid="home-feed-drawer-mobile"
-      >
-        HomeFeedDrawerMobile
-      </div>
-    </div>
-    <div
-      data-testid="timeline-feed"
-      data-variant="bookmarks"
-    >
-      TimelineFeed
     </div>
   </div>
 </div>

--- a/src/components/templates/Feed/Bookmarks/Bookmarks.tsx
+++ b/src/components/templates/Feed/Bookmarks/Bookmarks.tsx
@@ -1,36 +1,48 @@
-import { TIMELINE_FEED_VARIANT } from '@/config/feed';
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Container } from '@/atoms/Container/Container';
+import { useCollectionsOwner } from '@/hooks/useCollectionsOwner/useCollectionsOwner';
+import { BookmarksCollectionHeader } from '@/molecules/Collections/BookmarksCollectionHeader/BookmarksCollectionHeader';
+import { BookmarksEmptyState } from '@/molecules/Collections/BookmarksEmptyState/BookmarksEmptyState';
+import { BookmarksCollectionPosts } from '@/organisms/Collections/BookmarksCollectionPosts/BookmarksCollectionPosts';
 import { ContentLayout } from '@/organisms/ContentLayout/ContentLayout';
-import { HomeFeedRightDrawer, HomeFeedRightSidebar } from '@/organisms/FeedRightSidebar/FeedRightSidebar';
-import { HomeFeedDrawer, HomeFeedDrawerMobile, HomeFeedSidebar } from '@/organisms/HomeFeedSidebar/HomeFeedSidebar';
-import { TimelineFeed } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed';
 
 /**
  * Bookmarks Page Template
  *
- * Displays the user's bookmarked posts with filtering capabilities.
- * Reuses the same sidebar components from Home page for UI consistency.
- *
- * Sort and Content filters affect the bookmarks stream.
- * Reach filter is hidden as it's not supported by the Nexus API for bookmarks.
+ * Displays the user's bookmarked posts as a system collection detail page.
+ * The post data still comes from the existing bookmarks stream.
  */
 export function Bookmarks() {
+  const t = useTranslations('collections');
+  const { avatarUrl, avatarName, avatarSeed, bookmarkCount } = useCollectionsOwner();
+
   return (
     <ContentLayout
-      feedVariant={TIMELINE_FEED_VARIANT.BOOKMARKS}
+      showLeftSidebar={false}
+      showRightSidebar={false}
+      showLeftMobileButton={false}
       showRightMobileButton={false}
-      leftSidebarContent={
-        <HomeFeedSidebar hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.BOOKMARKS} />
-      }
-      rightSidebarContent={<HomeFeedRightSidebar />}
-      leftDrawerContent={
-        <HomeFeedDrawer hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.BOOKMARKS} />
-      }
-      rightDrawerContent={<HomeFeedRightDrawer />}
-      leftDrawerContentMobile={
-        <HomeFeedDrawerMobile hideReachFilter allowVisualLayout feedVariant={TIMELINE_FEED_VARIANT.BOOKMARKS} />
-      }
+      className="pb-24 lg:pb-12 xl:!px-0"
+      classNameWrapperContent="gap-6"
     >
-      <TimelineFeed variant={TIMELINE_FEED_VARIANT.BOOKMARKS} />
+      <Container overrideDefaults className="flex w-full flex-col gap-6">
+        <BookmarksCollectionHeader
+          title={t('bookmarks.title')}
+          description={t('bookmarks.description')}
+          visibilityLabel={t('private')}
+          postCount={bookmarkCount}
+          ownerAvatarUrl={avatarUrl}
+          ownerName={avatarName}
+          ownerSeed={avatarSeed}
+        />
+        <BookmarksCollectionPosts
+          emptyComponent={
+            <BookmarksEmptyState title={t('bookmarks.emptyTitle')} description={t('bookmarks.emptyDescription')} />
+          }
+        />
+      </Container>
     </ContentLayout>
   );
 }

--- a/src/config/posts.ts
+++ b/src/config/posts.ts
@@ -27,6 +27,31 @@ export const TAG_MAX_LENGTH = validationLimits.tagLabelMaxLength;
 /** Maximum character length for feedback comments */
 export const FEEDBACK_MAX_CHARACTER_LENGTH = 1000;
 
+/** Maximum character length for collection names */
+export const COLLECTION_NAME_MAX_CHARACTER_LENGTH = validationLimits.collectionNameMaxLength;
+
+/** Maximum character length for collection descriptions */
+export const COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH = validationLimits.collectionDescriptionMaxLength;
+
+/** Maximum number of items allowed per collection */
+export const COLLECTION_ITEMS_MAX_COUNT = validationLimits.collectionItemsMaxCount;
+
+/** Maximum character length for serialized collection content */
+export const COLLECTION_CONTENT_MAX_LENGTH = validationLimits.collectionContentMaxLength;
+
+/** Maximum character length for a collection item URI (same limit as post attachment URLs in spec). */
+export const COLLECTION_ITEM_URI_MAX_LENGTH = validationLimits.postAttachmentUrlMaxLength;
+
+/**
+ * Maximum character length for a collection cover image URL.
+ * Reuses the spec's post attachment URL limit (cover_image is bound to the
+ * same `post_attachment_url_max_length` and protocol allowlist on the BE).
+ */
+export const COLLECTION_COVER_IMAGE_URL_MAX_LENGTH = validationLimits.postAttachmentUrlMaxLength;
+
+/** Allowed URL protocols for collection item URIs and cover images (spec post-attachment allowlist). */
+export const COLLECTION_COVER_IMAGE_ALLOWED_PROTOCOLS = validationLimits.postAllowedAttachmentProtocols;
+
 /**
  * Supported MIME types for file attachments.
  * Imported directly from pubky-app-specs to ensure consistency.

--- a/src/core/application/post/post.ts
+++ b/src/core/application/post/post.ts
@@ -10,19 +10,24 @@ import type {
   TFetchMorePostTagsParams,
   TFetchPostTaggersParams,
 } from '@/controllers/post/post.types';
+import { NOT_FOUND_CACHED_STREAM, SKIP_FETCH_NEW_POSTS } from '@/controllers/stream/posts/post.constants';
 import { ClientErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import { parseCompositeId } from '@/models/models.utils';
+import type { CollectionPost, TAuthoredCollectionsParams } from '@/models/post/collection/collectionPost.types';
 import type { PostCountsModelSchema } from '@/models/post/counts/postCounts.schema';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import type { TagCollectionModelSchema } from '@/models/shared/tag/tag.schema';
+import { buildAuthorCollectionStreamId } from '@/models/stream/post/postStream.types';
+import { CollectionPostContent } from '@/pipes/post/post.collection';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 import { LocalPostService } from '@/services/local/post/post';
+import { LocalStreamPostsService } from '@/services/local/stream/posts/posts';
 import { LocalPostTagService } from '@/services/local/tag/post/tag.post';
 import type { NexusTag, NexusTaggers } from '@/services/nexus/nexus.types';
 import { NexusPostService } from '@/services/nexus/post/post';
@@ -142,6 +147,46 @@ export class PostApplication {
     });
 
     return await LocalPostService.readDetails({ postId: compositeId });
+  }
+
+  static async getAuthoredCollections({ authorId }: TAuthoredCollectionsParams): Promise<CollectionPost[] | null> {
+    const streamId = buildAuthorCollectionStreamId(authorId);
+    const stream = await LocalStreamPostsService.read({ streamId });
+
+    if (!stream) return null;
+
+    const details = await LocalPostService.readDetailsByIdsPreserveOrder(stream.stream);
+
+    return details
+      .filter((post): post is PostDetailsModelSchema => post !== undefined && post.kind === 'collection')
+      .map((post) => {
+        const content = CollectionPostContent.parse(post.content);
+        return content ? { details: post, content } : null;
+      })
+      .filter((collection): collection is CollectionPost => collection !== null);
+  }
+
+  static async fetchAuthoredCollections({
+    authorId,
+    viewerId,
+  }: TAuthoredCollectionsParams): Promise<CollectionPost[] | null> {
+    const streamId = buildAuthorCollectionStreamId(authorId);
+    const { cacheMissPostIds } = await PostStreamApplication.fetchStreamSlice({
+      streamId,
+      streamHead: SKIP_FETCH_NEW_POSTS,
+      streamTail: NOT_FOUND_CACHED_STREAM,
+      limit: 100,
+      viewerId: viewerId ?? null,
+    });
+
+    if (cacheMissPostIds.length > 0) {
+      await PostStreamApplication.fetchMissingPostsFromNexus({
+        cacheMissPostIds,
+        viewerId,
+      });
+    }
+
+    return await this.getAuthoredCollections({ authorId, viewerId });
   }
 
   static async commitCreate({ postUrl, compositePostId, post, fileAttachments, tags }: TCreatePostInput) {

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -289,6 +289,10 @@ export class PostStreamApplication {
     };
   }
 
+  static async fetchStreamSlice(params: TFetchStreamParams): Promise<TPostStreamChunkResponse> {
+    return await this.fetchStreamFromNexus(params);
+  }
+
   // ============================================================================
   // Internal Helpers
   // ============================================================================

--- a/src/core/controllers/post/post.test.ts
+++ b/src/core/controllers/post/post.test.ts
@@ -12,6 +12,7 @@ import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.s
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
 import { PostTagsModel } from '@/models/post/tags/postTags';
 import type { TFileAttachmentResult } from '@/pipes/file/file.types';
+import { PostNormalizer } from '@/pipes/post/post.normalizer';
 import { HomeserverService } from '@/services/homeserver/homeserver';
 import type { NexusTaggers } from '@/services/nexus/nexus.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -647,6 +648,174 @@ describe('PostController', () => {
         );
       } finally {
         deleteSpy.mockRestore();
+        cleanupAuthUser();
+      }
+    });
+  });
+
+  describe('commitUpdateCollectionItem', () => {
+    const collectionPostId = buildCompositeId({ pubky: testData.authorPubky, id: 'collection123' });
+    const targetPostId = buildCompositeId({ pubky: 'target_author_pubky' as Pubky, id: 'target123' });
+    const targetPostUri = 'pubky://target_author_pubky/pub/pubky.app/posts/target123';
+
+    const createCollectionDetails = (items: string[] = [], overrides: Partial<PostDetailsModelSchema> = {}) =>
+      ({
+        id: collectionPostId,
+        content: JSON.stringify({ name: 'Saved posts', description: '', items }),
+        indexed_at: Date.now(),
+        kind: 'collection',
+        uri: `pubky://${testData.authorPubky}/pub/pubky.app/posts/collection123`,
+        attachments: null,
+        is_moderated: false,
+        is_blurred: false,
+        ...overrides,
+      }) as Awaited<ReturnType<typeof PostApplication.getDetails>>;
+
+    it('adds a post URI to a collection', async () => {
+      setupAuthUser(testData.authorPubky);
+      const getDetailsSpy = vi.spyOn(PostApplication, 'getDetails').mockResolvedValue(createCollectionDetails());
+      const toEditSpy = vi.spyOn(PostNormalizer, 'toEdit').mockResolvedValue({
+        post: { toJson: () => ({}) },
+        meta: { url: 'pubky://author/pub/pubky.app/posts/collection123' },
+      } as never);
+      const commitEditSpy = vi.spyOn(PostApplication, 'commitEdit').mockResolvedValue(undefined);
+
+      try {
+        const { PostController } = await import('./post');
+        await PostController.commitUpdateCollectionItem({
+          collectionId: collectionPostId,
+          postId: targetPostId,
+          shouldAdd: true,
+        });
+
+        expect(getDetailsSpy).toHaveBeenCalledWith({ compositeId: collectionPostId });
+        expect(toEditSpy).toHaveBeenCalledWith({
+          compositePostId: collectionPostId,
+          content: JSON.stringify({
+            name: 'Saved posts',
+            description: '',
+            items: [targetPostUri],
+            cover_image: null,
+          }),
+          currentUserPubky: testData.authorPubky,
+        });
+        expect(commitEditSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            compositePostId: collectionPostId,
+            postUrl: 'pubky://author/pub/pubky.app/posts/collection123',
+          }),
+        );
+      } finally {
+        cleanupAuthUser();
+      }
+    });
+
+    it('removes a post URI from a collection', async () => {
+      setupAuthUser(testData.authorPubky);
+      vi.spyOn(PostApplication, 'getDetails').mockResolvedValue(createCollectionDetails([targetPostUri]));
+      const toEditSpy = vi.spyOn(PostNormalizer, 'toEdit').mockResolvedValue({
+        post: { toJson: () => ({}) },
+        meta: { url: 'pubky://author/pub/pubky.app/posts/collection123' },
+      } as never);
+      vi.spyOn(PostApplication, 'commitEdit').mockResolvedValue(undefined);
+
+      try {
+        const { PostController } = await import('./post');
+        await PostController.commitUpdateCollectionItem({
+          collectionId: collectionPostId,
+          postId: targetPostId,
+          shouldAdd: false,
+        });
+
+        expect(toEditSpy).toHaveBeenCalledWith({
+          compositePostId: collectionPostId,
+          content: JSON.stringify({ name: 'Saved posts', description: '', items: [], cover_image: null }),
+          currentUserPubky: testData.authorPubky,
+        });
+      } finally {
+        cleanupAuthUser();
+      }
+    });
+
+    it('does not edit when adding an existing item or removing a missing item', async () => {
+      setupAuthUser(testData.authorPubky);
+      const getDetailsSpy = vi.spyOn(PostApplication, 'getDetails');
+      const toEditSpy = vi.spyOn(PostNormalizer, 'toEdit');
+      const commitEditSpy = vi.spyOn(PostApplication, 'commitEdit');
+      const { PostController } = await import('./post');
+
+      try {
+        getDetailsSpy.mockResolvedValueOnce(createCollectionDetails([targetPostUri]));
+        await PostController.commitUpdateCollectionItem({
+          collectionId: collectionPostId,
+          postId: targetPostId,
+          shouldAdd: true,
+        });
+
+        getDetailsSpy.mockResolvedValueOnce(createCollectionDetails());
+        await PostController.commitUpdateCollectionItem({
+          collectionId: collectionPostId,
+          postId: targetPostId,
+          shouldAdd: false,
+        });
+
+        expect(toEditSpy).not.toHaveBeenCalled();
+        expect(commitEditSpy).not.toHaveBeenCalled();
+      } finally {
+        cleanupAuthUser();
+      }
+    });
+
+    it('rejects missing collections', async () => {
+      setupAuthUser(testData.authorPubky);
+      vi.spyOn(PostApplication, 'getDetails').mockResolvedValue(null);
+
+      try {
+        const { PostController } = await import('./post');
+        await expect(
+          PostController.commitUpdateCollectionItem({
+            collectionId: collectionPostId,
+            postId: targetPostId,
+            shouldAdd: true,
+          }),
+        ).rejects.toThrow('Collection not found');
+      } finally {
+        cleanupAuthUser();
+      }
+    });
+
+    it('rejects collections with invalid content', async () => {
+      setupAuthUser(testData.authorPubky);
+      vi.spyOn(PostApplication, 'getDetails').mockResolvedValue(createCollectionDetails([], { content: 'not-json' }));
+
+      try {
+        const { PostController } = await import('./post');
+        await expect(
+          PostController.commitUpdateCollectionItem({
+            collectionId: collectionPostId,
+            postId: targetPostId,
+            shouldAdd: true,
+          }),
+        ).rejects.toThrow('Collection content is invalid');
+      } finally {
+        cleanupAuthUser();
+      }
+    });
+
+    it('rejects edits when the current user is not the collection author', async () => {
+      setupAuthUser('different_user_pubky' as Pubky);
+      vi.spyOn(PostApplication, 'getDetails').mockResolvedValue(createCollectionDetails());
+
+      try {
+        const { PostController } = await import('./post');
+        await expect(
+          PostController.commitUpdateCollectionItem({
+            collectionId: collectionPostId,
+            postId: targetPostId,
+            shouldAdd: true,
+          }),
+        ).rejects.toThrow('Current user is not the author of this post');
+      } finally {
         cleanupAuthUser();
       }
     });

--- a/src/core/controllers/post/post.test.ts
+++ b/src/core/controllers/post/post.test.ts
@@ -695,7 +695,6 @@ describe('PostController', () => {
             name: 'Saved posts',
             description: '',
             items: [targetPostUri],
-            cover_image: null,
           }),
           currentUserPubky: testData.authorPubky,
         });
@@ -729,7 +728,7 @@ describe('PostController', () => {
 
         expect(toEditSpy).toHaveBeenCalledWith({
           compositePostId: collectionPostId,
-          content: JSON.stringify({ name: 'Saved posts', description: '', items: [], cover_image: null }),
+          content: JSON.stringify({ name: 'Saved posts', description: '', items: [] }),
           currentUserPubky: testData.authorPubky,
         });
       } finally {

--- a/src/core/controllers/post/post.ts
+++ b/src/core/controllers/post/post.ts
@@ -1,9 +1,11 @@
+import { postUriBuilder } from 'pubky-app-specs';
 import { FileApplication } from '@/application/file/file';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import { PostApplication } from '@/application/post/post';
 import type { TGetOrFetchPostParams } from '@/application/post/post.types';
 import { TagKind, type TCreateTagInput } from '@/application/tag/tag.types';
 import type {
+  TCreateCollectionParams,
   TCreatePostParams,
   TDeletePostParams,
   TEditPostParams,
@@ -11,17 +13,20 @@ import type {
   TFetchPostTaggersParams,
   TFileAttachmentsParams,
   TNormalizeTagsParams,
+  TUpdateCollectionItemParams,
 } from '@/controllers/post/post.types';
 import type { TTagEventParams } from '@/controllers/tag/tag.types';
-import { ClientErrorCode } from '@/libs/error/error.codes';
+import { ClientErrorCode, ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
 import { buildCompositeId, parseCompositeId } from '@/models/models.utils';
+import type { CollectionPost, TAuthoredCollectionsParams } from '@/models/post/collection/collectionPost.types';
 import type { PostCountsModelSchema } from '@/models/post/counts/postCounts.schema';
 import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import type { TagCollectionModelSchema } from '@/models/shared/tag/tag.schema';
 import type { TFileAttachmentResult } from '@/pipes/file/file.types';
+import { CollectionPostContent } from '@/pipes/post/post.collection';
 import { inferPostKindForCreate, resolveTagTargetCompositeIdForPostCreate } from '@/pipes/post/post.kind';
 import { PostNormalizer } from '@/pipes/post/post.normalizer';
 import { PostValidators } from '@/pipes/post/post.validators';
@@ -105,6 +110,14 @@ export class PostController {
    */
   static async fetch(params: TGetOrFetchPostParams): Promise<PostDetailsModelSchema | null> {
     return await PostApplication.fetch(params);
+  }
+
+  static async getAuthoredCollections(params: TAuthoredCollectionsParams): Promise<CollectionPost[] | null> {
+    return await PostApplication.getAuthoredCollections(params);
+  }
+
+  static async fetchAuthoredCollections(params: TAuthoredCollectionsParams): Promise<CollectionPost[] | null> {
+    return await PostApplication.fetchAuthoredCollections(params);
   }
 
   /**
@@ -209,6 +222,101 @@ export class PostController {
     });
 
     return compositePostId;
+  }
+
+  static async commitCreateCollection({
+    authorId,
+    name,
+    description,
+    items,
+    coverImage,
+  }: TCreateCollectionParams): Promise<string> {
+    // Upload cover image to homeserver first when a File is supplied. We do this
+    // before normalization so the resulting `pubky://` URL participates in the
+    // envelope's max-length and protocol validation.
+    let coverImageUrl: string | null = null;
+    if (coverImage instanceof File) {
+      try {
+        const fileAttachment = await FileApplication.toFileAttachment({ file: coverImage, pubky: authorId });
+        await FileApplication.commitCreate({ fileAttachments: [fileAttachment] });
+        coverImageUrl = fileAttachment.fileResult.meta.url;
+      } catch (error) {
+        throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'Failed to upload collection cover image', {
+          service: ErrorService.Local,
+          operation: 'commitCreateCollection',
+          cause: error,
+        });
+      }
+    } else if (typeof coverImage === 'string') {
+      coverImageUrl = coverImage;
+    }
+
+    const { post, meta } = await PostNormalizer.toCollection(
+      {
+        name,
+        description,
+        items,
+        coverImage: coverImageUrl,
+      },
+      authorId,
+    );
+
+    const { id: postId } = meta;
+    const compositePostId = buildCompositeId({ pubky: authorId, id: postId });
+
+    await PostApplication.commitCreate({
+      compositePostId,
+      post,
+      postUrl: meta.url,
+    });
+
+    return compositePostId;
+  }
+
+  static async commitUpdateCollectionItem({
+    collectionId,
+    postId,
+    shouldAdd,
+  }: TUpdateCollectionItemParams): Promise<void> {
+    const currentUserPubky = useAuthStore.getState().selectCurrentUserPubky();
+    const collection = await PostApplication.getDetails({ compositeId: collectionId });
+
+    if (!collection) {
+      throw Err.client(ClientErrorCode.NOT_FOUND, 'Collection not found', {
+        service: ErrorService.Local,
+        operation: 'commitUpdateCollectionItem',
+        context: { collectionId },
+      });
+    }
+
+    const currentContent = CollectionPostContent.parse(collection.content);
+    if (!currentContent) {
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, 'Collection content is invalid', {
+        service: ErrorService.Local,
+        operation: 'commitUpdateCollectionItem',
+        context: { collectionId },
+      });
+    }
+
+    const { pubky: postAuthorId, id: rawPostId } = parseCompositeId(postId);
+    const itemUri = postUriBuilder(postAuthorId, rawPostId);
+    const nextContent = shouldAdd
+      ? CollectionPostContent.addItem(currentContent, itemUri)
+      : CollectionPostContent.removeItem(currentContent, itemUri);
+
+    if (nextContent.items === currentContent.items) return;
+
+    const { post, meta } = await PostNormalizer.toEdit({
+      compositePostId: collectionId,
+      content: JSON.stringify(nextContent),
+      currentUserPubky,
+    });
+
+    await PostApplication.commitEdit({
+      compositePostId: collectionId,
+      post,
+      postUrl: meta.url,
+    });
   }
 
   /**

--- a/src/core/controllers/post/post.types.ts
+++ b/src/core/controllers/post/post.types.ts
@@ -12,6 +12,27 @@ export interface TCreatePostParams {
   originalPostId?: string;
 }
 
+export interface TCreateCollectionParams {
+  authorId: Pubky;
+  name: string;
+  description?: string | null;
+  items?: string[] | null;
+  /**
+   * Optional cover image. Either:
+   * - a `File` (uploaded to the homeserver, the resulting `pubky://` URL is
+   *   stored as `cover_image` in the collection envelope), or
+   * - a string URL already accessible by Nexus (pubky/http/https), or
+   * - `null` / `undefined` for no cover.
+   */
+  coverImage?: File | string | null;
+}
+
+export interface TUpdateCollectionItemParams {
+  collectionId: string;
+  postId: string;
+  shouldAdd: boolean;
+}
+
 export interface TDeletePostParams {
   compositePostId: string;
 }

--- a/src/core/models/feed/feed.helpers.ts
+++ b/src/core/models/feed/feed.helpers.ts
@@ -40,6 +40,8 @@ export function postKindToString(kind: PubkyAppPostKind): string {
     [PubkyAppPostKind.Video]: 'video',
     [PubkyAppPostKind.Link]: 'link',
     [PubkyAppPostKind.File]: 'file',
+    [PubkyAppPostKind.Collection]: 'collection',
+    [PubkyAppPostKind.Unknown]: 'unknown',
   };
   return map[kind];
 }
@@ -64,13 +66,15 @@ export function sortToStreamSorting(sort: PubkyAppFeedSort): StreamSorting {
 
 export function contentToStreamKind(content: PubkyAppPostKind | null): StreamKind | undefined {
   if (content === null) return undefined;
-  const map: Record<PubkyAppPostKind, StreamKind> = {
+  const map: Record<PubkyAppPostKind, StreamKind | undefined> = {
     [PubkyAppPostKind.Short]: StreamKind.SHORT,
     [PubkyAppPostKind.Long]: StreamKind.LONG,
     [PubkyAppPostKind.Image]: StreamKind.IMAGE,
     [PubkyAppPostKind.Video]: StreamKind.VIDEO,
     [PubkyAppPostKind.Link]: StreamKind.LINK,
     [PubkyAppPostKind.File]: StreamKind.FILE,
+    [PubkyAppPostKind.Collection]: StreamKind.COLLECTION,
+    [PubkyAppPostKind.Unknown]: undefined,
   };
   return map[content];
 }

--- a/src/core/models/post/collection/collectionPost.types.ts
+++ b/src/core/models/post/collection/collectionPost.types.ts
@@ -1,13 +1,6 @@
+import type { PubkyAppCollectionContent } from 'pubky-app-specs';
 import type { Pubky } from '@/models/models.types';
 import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
-
-export type CollectionContent = {
-  name: string;
-  description: string;
-  items: string[];
-  /** Optional cover image URL (pubky/http/https). `null` when not set. */
-  cover_image: string | null;
-};
 
 export type CollectionContentInput = {
   name: string;
@@ -19,7 +12,7 @@ export type CollectionContentInput = {
 
 export type CollectionPost = {
   details: PostDetailsModelSchema;
-  content: CollectionContent;
+  content: PubkyAppCollectionContent;
 };
 
 export type TAuthoredCollectionsParams = {

--- a/src/core/models/post/collection/collectionPost.types.ts
+++ b/src/core/models/post/collection/collectionPost.types.ts
@@ -1,0 +1,28 @@
+import type { Pubky } from '@/models/models.types';
+import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
+
+export type CollectionContent = {
+  name: string;
+  description: string;
+  items: string[];
+  /** Optional cover image URL (pubky/http/https). `null` when not set. */
+  cover_image: string | null;
+};
+
+export type CollectionContentInput = {
+  name: string;
+  description?: string | null;
+  items?: string[] | null;
+  /** Optional cover image URL. Validated against the spec attachment URL rules. */
+  coverImage?: string | null;
+};
+
+export type CollectionPost = {
+  details: PostDetailsModelSchema;
+  content: CollectionContent;
+};
+
+export type TAuthoredCollectionsParams = {
+  authorId: Pubky;
+  viewerId?: Pubky | null;
+};

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -1,9 +1,9 @@
-import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
+import { StreamKind, StreamSource } from '@/services/nexus/stream/posts/postStream.types';
 
 // Post Stream ID Pattern: sorting:source:kind
 // - SORTING: timeline (recent), total_engagement (popularity)
 // - SOURCE: all, following, friends, me, bookmarks, post_replies, author, author_replies
-// - KIND: all, short (posts), long (articles), image, video, link, file
+// - KIND: all, short (posts), long (articles), image, video, link, file, collection
 //
 // Dynamic Post Reply Stream ID Pattern: postReplies:compositePostId
 // - compositePostId format: author:postId (e.g., "did:key:abc123:post456")
@@ -103,14 +103,20 @@ export enum PostStreamTypes {
 
 export type ReplyStreamCompositeId = `${StreamSource.REPLIES}:${string}`;
 export type AuthorStreamCompositeId = `${StreamSource.AUTHOR}:${string}`;
+export type AuthorKindStreamCompositeId = `${StreamSource.AUTHOR}:${string}:${StreamKind}`;
 export type AuthorRepliesStreamCompositeId = `${StreamSource.AUTHOR_REPLIES}:${string}`;
 
 export function buildPostReplyStreamId(compositePostId: string): ReplyStreamCompositeId {
   return `${StreamSource.REPLIES}:${compositePostId}`;
 }
 
+export function buildAuthorCollectionStreamId(authorId: string): AuthorKindStreamCompositeId {
+  return `${StreamSource.AUTHOR}:${authorId}:${StreamKind.COLLECTION}`;
+}
+
 export type PostStreamId =
   | PostStreamTypes
   | ReplyStreamCompositeId
   | AuthorStreamCompositeId
+  | AuthorKindStreamCompositeId
   | AuthorRepliesStreamCompositeId;

--- a/src/core/pipes/post/post.collection.test.ts
+++ b/src/core/pipes/post/post.collection.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  COLLECTION_CONTENT_MAX_LENGTH,
+  COLLECTION_ITEM_URI_MAX_LENGTH,
+  COLLECTION_ITEMS_MAX_COUNT,
+} from '@/config/posts';
+import { CollectionPostContent } from './post.collection';
+
+const VALID_ITEM_URI = 'pubky://1111111111111111111111111111111111111111111111111111/pub/pubky.app/posts/0034A0X7NJ52A';
+
+describe('CollectionPostContent', () => {
+  describe('normalize', () => {
+    it('trims name and description', () => {
+      expect(CollectionPostContent.normalize({ name: '  AI papers  ', description: '  Best stuff  ' })).toEqual({
+        name: 'AI papers',
+        description: 'Best stuff',
+        items: [],
+        cover_image: null,
+      });
+    });
+
+    it('accepts and validates an optional cover image URL', () => {
+      expect(
+        CollectionPostContent.normalize({
+          name: 'Cover',
+          coverImage: '  https://cdn.example.com/cover.png  ',
+        }),
+      ).toMatchObject({
+        cover_image: 'https://cdn.example.com/cover.png',
+      });
+    });
+
+    it('rejects cover images with unsupported protocols', () => {
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Cover',
+          coverImage: 'ftp://example.com/cover.png',
+        }),
+      ).toThrow('Collection cover image URL is invalid');
+    });
+
+    it('allows pubky, http, and https item URIs', () => {
+      expect(
+        CollectionPostContent.normalize({
+          name: 'Links',
+          items: [VALID_ITEM_URI, 'https://example.com/post', 'http://example.com/post'],
+        }).items,
+      ).toHaveLength(3);
+    });
+
+    it('rejects whitespace-only names', () => {
+      expect(() => CollectionPostContent.normalize({ name: '   ' })).toThrow('Collection name is required');
+    });
+
+    it('rejects too many items', () => {
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Too much',
+          items: Array.from(
+            { length: COLLECTION_ITEMS_MAX_COUNT + 1 },
+            (_, index) => `https://example.com/post/${index}`,
+          ),
+        }),
+      ).toThrow('Collection has too many items');
+    });
+
+    it('rejects item URIs over the spec limit', () => {
+      const uriPrefix = 'https://example.com/';
+      const overLimitUri = `${uriPrefix}${'a'.repeat(COLLECTION_ITEM_URI_MAX_LENGTH - uriPrefix.length + 1)}`;
+
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Too long',
+          items: [overLimitUri],
+        }),
+      ).toThrow('Collection item URI is too long');
+    });
+
+    it('rejects unsupported URI protocols', () => {
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Bad URI',
+          items: ['ftp://example.com/post'],
+        }),
+      ).toThrow('Collection item URI is invalid');
+    });
+
+    it('trims and deduplicates item URIs', () => {
+      expect(
+        CollectionPostContent.normalize({
+          name: 'Links',
+          items: [`  ${VALID_ITEM_URI}  `, VALID_ITEM_URI, '  https://example.com/post  '],
+        }),
+      ).toEqual({
+        name: 'Links',
+        description: '',
+        items: [VALID_ITEM_URI, 'https://example.com/post'],
+        cover_image: null,
+      });
+    });
+
+    it('rejects whitespace-only item URIs', () => {
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Links',
+          items: ['   '],
+        }),
+      ).toThrow('Collection item URI is required');
+    });
+
+    it('rejects serialized content over the spec limit', () => {
+      const stringifySpy = vi
+        .spyOn(JSON, 'stringify')
+        .mockReturnValueOnce('x'.repeat(COLLECTION_CONTENT_MAX_LENGTH + 1));
+
+      expect(() =>
+        CollectionPostContent.normalize({
+          name: 'Too big',
+          items: [VALID_ITEM_URI],
+        }),
+      ).toThrow('Collection content is too long');
+
+      stringifySpy.mockRestore();
+    });
+  });
+
+  describe('toJson and parse', () => {
+    it('serializes and parses a valid envelope', () => {
+      const json = CollectionPostContent.toJson({
+        name: 'Proof of Work',
+        description: 'Bitcoin writing',
+        items: [VALID_ITEM_URI],
+      });
+
+      expect(CollectionPostContent.parse(json)).toEqual({
+        name: 'Proof of Work',
+        description: 'Bitcoin writing',
+        items: [VALID_ITEM_URI],
+        cover_image: null,
+      });
+    });
+
+    it('round-trips a cover_image envelope from pubky-app-specs', () => {
+      // Mirrors the read shape from `pubky-app-specs` (`PubkyAppCollectionContent`),
+      // including `cover_image`. New fields are additive in the envelope; older
+      // payloads without `cover_image` are still accepted.
+      const json = CollectionPostContent.toJson({
+        name: 'Cover',
+        description: '',
+        items: [],
+        coverImage: 'https://cdn.example.com/cover.png',
+      });
+
+      expect(CollectionPostContent.parse(json)).toEqual({
+        name: 'Cover',
+        description: '',
+        items: [],
+        cover_image: 'https://cdn.example.com/cover.png',
+      });
+    });
+
+    it('parses minimal envelopes with only a name (per spec, other fields are optional)', () => {
+      // `description`/`items`/`cover_image` are all optional in the spec
+      // envelope, so a payload with just `name` is a valid (older) collection.
+      expect(CollectionPostContent.parse(JSON.stringify({ name: 'Minimal' }))).toEqual({
+        name: 'Minimal',
+        description: '',
+        items: [],
+        cover_image: null,
+      });
+    });
+
+    it('returns null for malformed envelopes', () => {
+      expect(CollectionPostContent.parse('not json')).toBeNull();
+      expect(CollectionPostContent.parse(JSON.stringify({ description: 'no name' }))).toBeNull();
+      expect(CollectionPostContent.parse(JSON.stringify({ name: 'Bad items', items: 'not-an-array' }))).toBeNull();
+      expect(CollectionPostContent.parse(JSON.stringify({ name: 'Bad cover', cover_image: 42 }))).toBeNull();
+    });
+
+    it('throws when the envelope shape is valid but content fails validation', () => {
+      expect(() =>
+        CollectionPostContent.parse(JSON.stringify({ name: 'Bad URI', items: ['ftp://example.com/post'] })),
+      ).toThrow('Collection item URI is invalid');
+    });
+  });
+
+  describe('item helpers', () => {
+    it('adds an item idempotently', () => {
+      const collection = CollectionPostContent.normalize({ name: 'Saved', items: [VALID_ITEM_URI] });
+
+      expect(CollectionPostContent.addItem(collection, VALID_ITEM_URI).items).toEqual([VALID_ITEM_URI]);
+    });
+
+    it('removes an item', () => {
+      const collection = CollectionPostContent.normalize({
+        name: 'Saved',
+        items: [VALID_ITEM_URI, 'https://example.com/post'],
+      });
+
+      expect(CollectionPostContent.removeItem(collection, VALID_ITEM_URI).items).toEqual(['https://example.com/post']);
+    });
+
+    it('returns the same collection when removing an absent item', () => {
+      const collection = CollectionPostContent.normalize({ name: 'Saved', items: [VALID_ITEM_URI] });
+
+      expect(CollectionPostContent.removeItem(collection, 'https://example.com/missing')).toBe(collection);
+    });
+  });
+});

--- a/src/core/pipes/post/post.collection.test.ts
+++ b/src/core/pipes/post/post.collection.test.ts
@@ -15,7 +15,7 @@ describe('CollectionPostContent', () => {
         name: 'AI papers',
         description: 'Best stuff',
         items: [],
-        cover_image: null,
+        cover_image: undefined,
       });
     });
 
@@ -95,7 +95,7 @@ describe('CollectionPostContent', () => {
         name: 'Links',
         description: '',
         items: [VALID_ITEM_URI, 'https://example.com/post'],
-        cover_image: null,
+        cover_image: undefined,
       });
     });
 
@@ -136,7 +136,7 @@ describe('CollectionPostContent', () => {
         name: 'Proof of Work',
         description: 'Bitcoin writing',
         items: [VALID_ITEM_URI],
-        cover_image: null,
+        cover_image: undefined,
       });
     });
 
@@ -166,7 +166,25 @@ describe('CollectionPostContent', () => {
         name: 'Minimal',
         description: '',
         items: [],
-        cover_image: null,
+        cover_image: undefined,
+      });
+    });
+
+    it('parses pubky-app-specs envelopes with null cover_image', () => {
+      expect(
+        CollectionPostContent.parse(
+          JSON.stringify({
+            name: 'Saved posts',
+            description: '',
+            items: [VALID_ITEM_URI],
+            cover_image: null,
+          }),
+        ),
+      ).toEqual({
+        name: 'Saved posts',
+        description: '',
+        items: [VALID_ITEM_URI],
+        cover_image: undefined,
       });
     });
 

--- a/src/core/pipes/post/post.collection.ts
+++ b/src/core/pipes/post/post.collection.ts
@@ -1,0 +1,205 @@
+import type { PubkyAppCollectionContent } from 'pubky-app-specs';
+import {
+  COLLECTION_CONTENT_MAX_LENGTH,
+  COLLECTION_COVER_IMAGE_ALLOWED_PROTOCOLS,
+  COLLECTION_COVER_IMAGE_URL_MAX_LENGTH,
+  COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH,
+  COLLECTION_ITEM_URI_MAX_LENGTH,
+  COLLECTION_ITEMS_MAX_COUNT,
+  COLLECTION_NAME_MAX_CHARACTER_LENGTH,
+} from '@/config/posts';
+import { ValidationErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
+import type { CollectionContent, CollectionContentInput } from '@/models/post/collection/collectionPost.types';
+
+const ALLOWED_COLLECTION_URL_PROTOCOLS = new Set(
+  COLLECTION_COVER_IMAGE_ALLOWED_PROTOCOLS.map((scheme) => `${scheme}:`),
+);
+
+function throwCollectionValidation(message: string, context?: Record<string, unknown>): never {
+  throw Err.validation(ValidationErrorCode.INVALID_INPUT, message, {
+    service: ErrorService.Local,
+    operation: 'validateCollectionContent',
+    context,
+  });
+}
+
+function isValidCollectionItemUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    return ALLOWED_COLLECTION_URL_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeCollectionItemUris(rawItems: string[]): string[] {
+  const items: string[] = [];
+  const seen = new Set<string>();
+
+  rawItems.forEach((raw, index) => {
+    const item = raw.trim();
+    if (!item) {
+      throwCollectionValidation('Collection item URI is required', { field: 'items', index });
+    }
+
+    if (seen.has(item)) return;
+
+    if (item.length > COLLECTION_ITEM_URI_MAX_LENGTH) {
+      throwCollectionValidation('Collection item URI is too long', {
+        field: 'items',
+        index,
+        maxLength: COLLECTION_ITEM_URI_MAX_LENGTH,
+      });
+    }
+
+    if (!isValidCollectionItemUri(item)) {
+      throwCollectionValidation('Collection item URI is invalid', { field: 'items', index });
+    }
+
+    seen.add(item);
+    items.push(item);
+  });
+
+  return items;
+}
+
+function isValidCollectionCoverImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_COLLECTION_URL_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeCoverImage(input: string | null | undefined): string | null {
+  if (input == null) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.length > COLLECTION_COVER_IMAGE_URL_MAX_LENGTH) {
+    throwCollectionValidation('Collection cover image URL is too long', {
+      field: 'coverImage',
+      maxLength: COLLECTION_COVER_IMAGE_URL_MAX_LENGTH,
+    });
+  }
+
+  if (!isValidCollectionCoverImageUrl(trimmed)) {
+    throwCollectionValidation('Collection cover image URL is invalid', {
+      field: 'coverImage',
+    });
+  }
+
+  return trimmed;
+}
+
+export class CollectionPostContent {
+  private constructor() {}
+
+  static normalize(input: CollectionContentInput): CollectionContent {
+    const name = input.name.trim();
+    const description = (input.description ?? '').trim();
+    const items = normalizeCollectionItemUris(input.items ?? []);
+    const cover_image = normalizeCoverImage(input.coverImage);
+
+    if (!name) {
+      throwCollectionValidation('Collection name is required', { field: 'name' });
+    }
+
+    if (name.length > COLLECTION_NAME_MAX_CHARACTER_LENGTH) {
+      throwCollectionValidation('Collection name is too long', {
+        field: 'name',
+        maxLength: COLLECTION_NAME_MAX_CHARACTER_LENGTH,
+      });
+    }
+
+    if (description.length > COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH) {
+      throwCollectionValidation('Collection description is too long', {
+        field: 'description',
+        maxLength: COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH,
+      });
+    }
+
+    if (items.length > COLLECTION_ITEMS_MAX_COUNT) {
+      throwCollectionValidation('Collection has too many items', {
+        field: 'items',
+        maxCount: COLLECTION_ITEMS_MAX_COUNT,
+        count: items.length,
+      });
+    }
+
+    const collection: CollectionContent = { name, description, items, cover_image };
+    if (JSON.stringify(collection).length > COLLECTION_CONTENT_MAX_LENGTH) {
+      throwCollectionValidation('Collection content is too long', {
+        field: 'content',
+        maxLength: COLLECTION_CONTENT_MAX_LENGTH,
+      });
+    }
+
+    return collection;
+  }
+
+  static toJson(input: CollectionContentInput): string {
+    return JSON.stringify(this.normalize(input));
+  }
+
+  /**
+   * Parse a `PubkyAppPost::content` envelope for a `kind = Collection` post.
+   *
+   * Read-side type-safety comes from `PubkyAppCollectionContent` (re-exported by
+   * `pubky-app-specs`); we never construct that envelope manually — the write
+   * side goes through `PubkySpecsBuilder.createCollectionPost(...)` which builds
+   * and serializes the envelope itself.
+   */
+  static parse(content: string): CollectionContent | null {
+    let parsed: Partial<PubkyAppCollectionContent>;
+    try {
+      parsed = JSON.parse(content) as Partial<PubkyAppCollectionContent>;
+    } catch {
+      return null;
+    }
+
+    if (typeof parsed.name !== 'string') return null;
+    if (parsed.description !== undefined && typeof parsed.description !== 'string') return null;
+    if (parsed.items !== undefined && !Array.isArray(parsed.items)) return null;
+    if (parsed.items && !parsed.items.every((item): item is string => typeof item === 'string')) return null;
+    if (parsed.cover_image !== undefined && parsed.cover_image !== null && typeof parsed.cover_image !== 'string') {
+      return null;
+    }
+
+    return this.normalize({
+      name: parsed.name,
+      description: parsed.description ?? '',
+      items: parsed.items ?? [],
+      coverImage: parsed.cover_image ?? null,
+    });
+  }
+
+  static addItem(collection: CollectionContent, itemUri: string): CollectionContent {
+    const trimmedUri = itemUri.trim();
+    if (collection.items.includes(trimmedUri)) {
+      return collection;
+    }
+
+    return this.normalize({
+      ...collection,
+      items: [...collection.items, trimmedUri],
+      coverImage: collection.cover_image,
+    });
+  }
+
+  static removeItem(collection: CollectionContent, itemUri: string): CollectionContent {
+    const trimmedUri = itemUri.trim();
+    if (!collection.items.includes(trimmedUri)) {
+      return collection;
+    }
+
+    return this.normalize({
+      ...collection,
+      items: collection.items.filter((item) => item !== trimmedUri),
+      coverImage: collection.cover_image,
+    });
+  }
+}

--- a/src/core/pipes/post/post.collection.ts
+++ b/src/core/pipes/post/post.collection.ts
@@ -11,7 +11,7 @@ import {
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
-import type { CollectionContent, CollectionContentInput } from '@/models/post/collection/collectionPost.types';
+import type { CollectionContentInput } from '@/models/post/collection/collectionPost.types';
 
 const ALLOWED_COLLECTION_URL_PROTOCOLS = new Set(
   COLLECTION_COVER_IMAGE_ALLOWED_PROTOCOLS.map((scheme) => `${scheme}:`),
@@ -74,10 +74,10 @@ function isValidCollectionCoverImageUrl(url: string): boolean {
   }
 }
 
-function normalizeCoverImage(input: string | null | undefined): string | null {
-  if (input == null) return null;
+function normalizeCoverImage(input: string | null | undefined): string | undefined {
+  if (input == null) return undefined;
   const trimmed = input.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return undefined;
 
   if (trimmed.length > COLLECTION_COVER_IMAGE_URL_MAX_LENGTH) {
     throwCollectionValidation('Collection cover image URL is too long', {
@@ -95,10 +95,26 @@ function normalizeCoverImage(input: string | null | undefined): string | null {
   return trimmed;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isOptionalStringArray(value: unknown): value is string[] | undefined {
+  return value === undefined || (Array.isArray(value) && value.every((item) => typeof item === 'string'));
+}
+
+function isNullableString(value: unknown): value is string | null | undefined {
+  return value == null || typeof value === 'string';
+}
+
 export class CollectionPostContent {
   private constructor() {}
 
-  static normalize(input: CollectionContentInput): CollectionContent {
+  static normalize(input: CollectionContentInput): PubkyAppCollectionContent {
     const name = input.name.trim();
     const description = (input.description ?? '').trim();
     const items = normalizeCollectionItemUris(input.items ?? []);
@@ -130,7 +146,7 @@ export class CollectionPostContent {
       });
     }
 
-    const collection: CollectionContent = { name, description, items, cover_image };
+    const collection: PubkyAppCollectionContent = { name, description, items, cover_image };
     if (JSON.stringify(collection).length > COLLECTION_CONTENT_MAX_LENGTH) {
       throwCollectionValidation('Collection content is too long', {
         field: 'content',
@@ -153,52 +169,57 @@ export class CollectionPostContent {
    * side goes through `PubkySpecsBuilder.createCollectionPost(...)` which builds
    * and serializes the envelope itself.
    */
-  static parse(content: string): CollectionContent | null {
-    let parsed: Partial<PubkyAppCollectionContent>;
+  static parse(content: string): PubkyAppCollectionContent | null {
+    let parsed: unknown;
     try {
-      parsed = JSON.parse(content) as Partial<PubkyAppCollectionContent>;
+      parsed = JSON.parse(content);
     } catch {
       return null;
     }
 
-    if (typeof parsed.name !== 'string') return null;
-    if (parsed.description !== undefined && typeof parsed.description !== 'string') return null;
-    if (parsed.items !== undefined && !Array.isArray(parsed.items)) return null;
-    if (parsed.items && !parsed.items.every((item): item is string => typeof item === 'string')) return null;
-    if (parsed.cover_image !== undefined && parsed.cover_image !== null && typeof parsed.cover_image !== 'string') {
-      return null;
-    }
+    if (!isRecord(parsed)) return null;
+
+    const { name, description, items, cover_image } = parsed;
+
+    if (typeof name !== 'string') return null;
+    if (!isOptionalString(description)) return null;
+    if (!isOptionalStringArray(items)) return null;
+    if (!isNullableString(cover_image)) return null;
 
     return this.normalize({
-      name: parsed.name,
-      description: parsed.description ?? '',
-      items: parsed.items ?? [],
-      coverImage: parsed.cover_image ?? null,
+      name,
+      description: description ?? '',
+      items: items ?? [],
+      coverImage: cover_image ?? undefined,
     });
   }
 
-  static addItem(collection: CollectionContent, itemUri: string): CollectionContent {
+  static addItem(collection: PubkyAppCollectionContent, itemUri: string): PubkyAppCollectionContent {
     const trimmedUri = itemUri.trim();
-    if (collection.items.includes(trimmedUri)) {
+    const items = collection.items ?? [];
+
+    if (items.includes(trimmedUri)) {
       return collection;
     }
 
     return this.normalize({
       ...collection,
-      items: [...collection.items, trimmedUri],
+      items: [...items, trimmedUri],
       coverImage: collection.cover_image,
     });
   }
 
-  static removeItem(collection: CollectionContent, itemUri: string): CollectionContent {
+  static removeItem(collection: PubkyAppCollectionContent, itemUri: string): PubkyAppCollectionContent {
     const trimmedUri = itemUri.trim();
-    if (!collection.items.includes(trimmedUri)) {
+    const items = collection.items ?? [];
+
+    if (!items.includes(trimmedUri)) {
       return collection;
     }
 
     return this.normalize({
       ...collection,
-      items: collection.items.filter((item) => item !== trimmedUri),
+      items: items.filter((item) => item !== trimmedUri),
       coverImage: collection.cover_image,
     });
   }

--- a/src/core/pipes/post/post.normalizer.test.ts
+++ b/src/core/pipes/post/post.normalizer.test.ts
@@ -476,7 +476,7 @@ describe('PostNormalizer', () => {
         'Proof of Work',
         'Bitcoin writing',
         [buildPubkyUri(TEST_PUBKY.USER_2, 'posts/post-1')],
-        null,
+        undefined,
       );
     });
 

--- a/src/core/pipes/post/post.normalizer.test.ts
+++ b/src/core/pipes/post/post.normalizer.test.ts
@@ -53,7 +53,9 @@ describe('PostNormalizer', () => {
     attachments: null,
   });
 
-  const createMockBuilder = (overrides?: Partial<{ createPost: ReturnType<typeof vi.fn> }>) => ({
+  const createMockBuilder = (
+    overrides?: Partial<{ createPost: ReturnType<typeof vi.fn>; createCollectionPost: ReturnType<typeof vi.fn> }>,
+  ) => ({
     createPost: vi.fn((content, kind, parent, embed, attachments) =>
       asOpaque<PostResult>({
         post: {
@@ -62,6 +64,23 @@ describe('PostNormalizer', () => {
           parent: parent || undefined,
           embed: embed || undefined,
           attachments: attachments || undefined,
+        },
+        meta: { url: buildPubkyUri(TEST_PUBKY.USER_1, `posts/${TEST_POST_IDS.POST_1}`) },
+      }),
+    ),
+    createCollectionPost: vi.fn((name, description, items, cover_image) =>
+      asOpaque<PostResult>({
+        post: {
+          content: JSON.stringify({
+            name,
+            description: description ?? '',
+            items: items ?? [],
+            cover_image: cover_image ?? null,
+          }),
+          kind: 'collection',
+          parent: undefined,
+          embed: undefined,
+          attachments: undefined,
         },
         meta: { url: buildPubkyUri(TEST_PUBKY.USER_1, `posts/${TEST_POST_IDS.POST_1}`) },
       }),
@@ -92,6 +111,8 @@ describe('PostNormalizer', () => {
       ['short', PubkyAppPostKind.Short],
       ['long', PubkyAppPostKind.Long],
       ['LONG', PubkyAppPostKind.Long],
+      ['collection', PubkyAppPostKind.Collection],
+      ['6', PubkyAppPostKind.Collection],
       ['unknown', PubkyAppPostKind.Short], // defaults to Short
     ])('should map "%s" to correct enum', (input, expected) => {
       expect(PostNormalizer.mapKindToEnum(input)).toBe(expected);
@@ -427,6 +448,67 @@ describe('PostNormalizer', () => {
           expect(returnedContent).toBe('🚀'.repeat(30_000));
         });
       });
+    });
+  });
+
+  describe('toCollection', () => {
+    let mockBuilder: ReturnType<typeof createMockBuilder>;
+
+    beforeEach(() => {
+      mockBuilder = createMockBuilder();
+      setupUnitTestMocks(mockBuilder);
+    });
+
+    afterEach(restoreMocks);
+
+    it('creates a collection post through pubky-app-specs', async () => {
+      await PostNormalizer.toCollection(
+        {
+          name: 'Proof of Work',
+          description: 'Bitcoin writing',
+          items: [buildPubkyUri(TEST_PUBKY.USER_2, 'posts/post-1')],
+        },
+        TEST_PUBKY.USER_1,
+      );
+
+      expect(PubkySpecsSingleton.get).toHaveBeenCalledWith(TEST_PUBKY.USER_1);
+      expect(mockBuilder.createCollectionPost).toHaveBeenCalledWith(
+        'Proof of Work',
+        'Bitcoin writing',
+        [buildPubkyUri(TEST_PUBKY.USER_2, 'posts/post-1')],
+        null,
+      );
+    });
+
+    it('forwards an optional cover_image URL to pubky-app-specs', async () => {
+      await PostNormalizer.toCollection(
+        {
+          name: 'Proof of Work',
+          coverImage: 'https://cdn.example.com/cover.png',
+        },
+        TEST_PUBKY.USER_1,
+      );
+
+      expect(mockBuilder.createCollectionPost).toHaveBeenCalledWith(
+        'Proof of Work',
+        '',
+        [],
+        'https://cdn.example.com/cover.png',
+      );
+    });
+
+    it('validates the collection envelope before calling specs', async () => {
+      await expect(
+        PostNormalizer.toCollection(
+          {
+            name: '   ',
+            description: 'No name',
+          },
+          TEST_PUBKY.USER_1,
+        ),
+      ).rejects.toThrow('Collection name is required');
+
+      expect(mockBuilder.createCollectionPost).not.toHaveBeenCalled();
     });
   });
 

--- a/src/core/pipes/post/post.normalizer.ts
+++ b/src/core/pipes/post/post.normalizer.ts
@@ -7,10 +7,12 @@ import { ErrorService } from '@/libs/error/error.types';
 import { Logger } from '@/libs/logger/logger';
 import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
+import type { CollectionContentInput } from '@/models/post/collection/collectionPost.types';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
 import { PubkySpecsSingleton } from '@/pipes/pipes.builder';
 import type { PostValidatorData } from '@/pipes/pipes.types';
+import { CollectionPostContent } from '@/pipes/post/post.collection';
 
 export class PostNormalizer {
   private constructor() {}
@@ -26,10 +28,37 @@ export class PostNormalizer {
    */
   static mapKindToEnum(kind: string): PubkyAppPostKind {
     const normalized = kind.toLowerCase();
-    if (normalized === 'long' || normalized === '1') {
+    if (normalized === 'long' || normalized === String(PubkyAppPostKind.Long)) {
       return PubkyAppPostKind.Long;
     }
+    if (normalized === 'collection' || normalized === String(PubkyAppPostKind.Collection)) {
+      return PubkyAppPostKind.Collection;
+    }
     return PubkyAppPostKind.Short;
+  }
+
+  static async toCollection(collection: CollectionContentInput, specsPubky: Pubky): Promise<PostResult> {
+    try {
+      const builder = PubkySpecsSingleton.get(specsPubky);
+      const normalized = CollectionPostContent.normalize(collection);
+      return builder.createCollectionPost(
+        normalized.name,
+        normalized.description,
+        normalized.items,
+        normalized.cover_image,
+      );
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, message, {
+        service: ErrorService.PubkyAppSpecs,
+        operation: 'createCollectionPost',
+        context: { specsPubky, itemCount: collection.items?.length ?? 0 },
+        cause: error,
+      });
+    }
   }
 
   static async to(post: PostValidatorData, specsPubky: Pubky): Promise<PostResult> {
@@ -62,10 +91,12 @@ export class PostNormalizer {
       if (error instanceof AppError) {
         throw error;
       }
-      throw Err.validation(ValidationErrorCode.INVALID_INPUT, error as string, {
+      const message = error instanceof Error ? error.message : String(error);
+      throw Err.validation(ValidationErrorCode.INVALID_INPUT, message, {
         service: ErrorService.PubkyAppSpecs,
         operation: 'createPost',
         context: { post, specsPubky },
+        cause: error,
       });
     }
   }

--- a/src/core/services/local/post/post.ts
+++ b/src/core/services/local/post/post.ts
@@ -19,7 +19,11 @@ import type { PostRelationshipsModelSchema } from '@/models/post/relationships/p
 import { PostTagsModel } from '@/models/post/tags/postTags';
 import { PostTtlModel } from '@/models/post/ttl/postTtl';
 import type { TagCollectionModelSchema } from '@/models/shared/tag/tag.schema';
-import { type PostStreamId, PostStreamTypes } from '@/models/stream/post/postStream.types';
+import {
+  buildAuthorCollectionStreamId,
+  type PostStreamId,
+  PostStreamTypes,
+} from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';
 import { UserCountsModel } from '@/models/user/counts/userCounts';
@@ -36,6 +40,13 @@ export class LocalPostService {
    */
   static async readDetails({ postId }: { postId: string }) {
     return PostDetailsModel.findById(postId);
+  }
+
+  /**
+   * Reads post details for multiple IDs while preserving the input order.
+   */
+  static async readDetailsByIdsPreserveOrder(postIds: string[]): Promise<(PostDetailsModelSchema | undefined)[]> {
+    return PostDetailsModel.findByIdsPreserveOrder(postIds);
   }
 
   /**
@@ -400,6 +411,9 @@ export class LocalPostService {
       });
       ops.push(updateStream(`author_replies:${authorId}`, [compositePostId]));
       ops.push(updateStream(`post_replies:${parentCompositeId}`, [compositePostId]));
+    } else if (kind === 'collection') {
+      ops.push(updateStream(buildAuthorCollectionStreamId(authorId), [compositePostId]));
+      ops.push(removeFromUnreadStream(buildAuthorCollectionStreamId(authorId), [compositePostId]));
     } else {
       ops.push(updateStream(PostStreamTypes.TIMELINE_ALL_ALL, [compositePostId]));
       ops.push(updateStream(`timeline:all:${kind}` as PostStreamId, [compositePostId]));

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import type { Pubky } from '@/models/models.types';
-import { type PostStreamId, PostStreamTypes } from '@/models/stream/post/postStream.types';
+import {
+  buildAuthorCollectionStreamId,
+  type PostStreamId,
+  PostStreamTypes,
+} from '@/models/stream/post/postStream.types';
 import { type NexusPost, type NexusPostsKeyStream, StreamSorting } from '@/services/nexus/nexus.types';
 import { queryNexus } from '@/services/nexus/nexus.utils';
 import {
@@ -589,6 +593,7 @@ describe('createPostStreamParams', () => {
       { kind: 'video', tags: 'tutorials,vlogs', expectedKind: StreamKind.VIDEO },
       { kind: 'link', tags: 'resources,refs', expectedKind: StreamKind.LINK },
       { kind: 'file', tags: 'docs,pdfs', expectedKind: StreamKind.FILE },
+      { kind: 'collection', tags: 'lists,research', expectedKind: StreamKind.COLLECTION },
     ])('should handle tags in $kind content stream', ({ kind, tags, expectedKind }) => {
       const streamIdWithTags = `timeline:bookmarks:${kind}:${tags}` as PostStreamId;
       const result = createPostStreamParams({
@@ -602,6 +607,25 @@ describe('createPostStreamParams', () => {
       expect(result.params.tags).toBe(tags);
       expect(result.params.kind).toBe(expectedKind);
       expect(result.params.sorting).toBe(StreamSorting.TIMELINE);
+    });
+  });
+
+  describe('Collection streams', () => {
+    it('should fetch authored collections with source author and kind collection', () => {
+      const authorId = 'author-pubky-id';
+      const result = createPostStreamParams({
+        streamId: buildAuthorCollectionStreamId(authorId),
+        streamTail: 0,
+        streamHead: 0,
+        limit: 20,
+        viewerId: mockViewerId,
+      });
+
+      expect(result.invokeEndpoint).toBe(StreamSource.AUTHOR);
+      expect(result.extraParams.author_id).toBe(authorId);
+      expect(result.extraParams.post_id).toBeUndefined();
+      expect(result.params.kind).toBe(StreamKind.COLLECTION);
+      expect(result.params.limit).toBe(20);
     });
   });
 });

--- a/src/core/services/nexus/stream/posts/postStream.types.ts
+++ b/src/core/services/nexus/stream/posts/postStream.types.ts
@@ -25,6 +25,7 @@ export enum StreamKind {
   VIDEO = 'video',
   LINK = 'link',
   FILE = 'file',
+  COLLECTION = 'collection',
 }
 
 export enum StreamOrder {

--- a/src/core/services/nexus/stream/posts/postStream.utils.ts
+++ b/src/core/services/nexus/stream/posts/postStream.utils.ts
@@ -44,7 +44,8 @@ export function createPostStreamParams({
   }
   params.limit = limit;
   params.order = order;
-  let extraParams = handleNotCommonStreamParams({ authorId: sorting, postId: content });
+  const postId = invokeEndpoint === StreamSource.REPLIES ? content : undefined;
+  let extraParams = handleNotCommonStreamParams({ authorId: sorting, postId });
   setStreamPagination({ params, streamTail, streamHead });
   return { params, invokeEndpoint, extraParams };
 }
@@ -124,6 +125,10 @@ export function breakDownStreamId(streamId: PostStreamId): TStreamIdBreakdown {
       // [pubky, post_replies, postId]
       return [invokeEndpoint, toStreamSource({ value: sorting }), kind, limitTags];
     }
+    if (sorting === StreamSource.AUTHOR) {
+      // [author, pubky, kind]
+      return [invokeEndpoint, toStreamSource({ value: sorting }), kind, limitTags];
+    }
     // Applies to timeline pattern
     return [sorting, toStreamSource({ value: invokeEndpoint }), kind, limitTags];
   }
@@ -161,6 +166,7 @@ function parseContent(content: string): StreamKind | undefined {
     video: StreamKind.VIDEO,
     link: StreamKind.LINK,
     file: StreamKind.FILE,
+    collection: StreamKind.COLLECTION,
   };
   return contentMap[content];
 }

--- a/src/hooks/useAuthoredCollections/useAuthoredCollections.test.ts
+++ b/src/hooks/useAuthoredCollections/useAuthoredCollections.test.ts
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthoredCollections } from './useAuthoredCollections';
+
+type LocalFirstParams = {
+  queryFn: () => Promise<unknown>;
+  fetchFn: () => Promise<unknown>;
+  deps: unknown[];
+  enabled: boolean;
+};
+
+const mocks = vi.hoisted(() => ({
+  currentUserPubky: 'current-user' as string | null,
+  capturedParams: null as LocalFirstParams | null,
+  localFirstResult: {
+    data: undefined as unknown,
+    isLoading: false,
+  },
+  getAuthoredCollections: vi.fn(),
+  fetchAuthoredCollections: vi.fn(),
+}));
+
+const authoredCollections = [
+  {
+    details: { id: 'current-user:collection1' },
+    content: {
+      name: 'Proof of Work',
+      description: 'Bitcoin writing',
+      items: [],
+    },
+  },
+];
+
+vi.mock('@/controllers/post/post', () => ({
+  PostController: {
+    getAuthoredCollections: (...args: unknown[]) => mocks.getAuthoredCollections(...args),
+    fetchAuthoredCollections: (...args: unknown[]) => mocks.fetchAuthoredCollections(...args),
+  },
+}));
+
+vi.mock('@/hooks/useLocalFirstQuery/useLocalFirstQuery', () => ({
+  useLocalFirstQuery: (params: LocalFirstParams) => {
+    mocks.capturedParams = params;
+    return mocks.localFirstResult;
+  },
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) =>
+    selector({ currentUserPubky: mocks.currentUserPubky }),
+}));
+
+describe('useAuthoredCollections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.currentUserPubky = 'current-user';
+    mocks.capturedParams = null;
+    mocks.localFirstResult = {
+      data: authoredCollections,
+      isLoading: false,
+    };
+    mocks.getAuthoredCollections.mockResolvedValue(authoredCollections);
+    mocks.fetchAuthoredCollections.mockResolvedValue(authoredCollections);
+  });
+
+  it('returns collections and loading state from the local-first query', () => {
+    const { result } = renderHook(() => useAuthoredCollections());
+
+    expect(result.current.collections).toEqual(authoredCollections);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('wires local and network collection reads to the current user', async () => {
+    renderHook(() => useAuthoredCollections());
+
+    expect(mocks.capturedParams).toMatchObject({
+      deps: ['current-user'],
+      enabled: true,
+    });
+
+    await mocks.capturedParams!.queryFn();
+    await mocks.capturedParams!.fetchFn();
+
+    expect(mocks.getAuthoredCollections).toHaveBeenCalledWith({ authorId: 'current-user' });
+    expect(mocks.fetchAuthoredCollections).toHaveBeenCalledWith({
+      authorId: 'current-user',
+      viewerId: 'current-user',
+    });
+  });
+
+  it('returns an empty list and disables reads when there is no current user', () => {
+    mocks.currentUserPubky = null;
+    mocks.localFirstResult = {
+      data: undefined,
+      isLoading: false,
+    };
+
+    const { result } = renderHook(() => useAuthoredCollections());
+
+    expect(result.current.collections).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mocks.capturedParams).toMatchObject({
+      deps: [null],
+      enabled: false,
+    });
+  });
+
+  it('respects an explicit disabled flag', () => {
+    renderHook(() => useAuthoredCollections(false));
+
+    expect(mocks.capturedParams).toMatchObject({
+      deps: ['current-user'],
+      enabled: false,
+    });
+  });
+});

--- a/src/hooks/useAuthoredCollections/useAuthoredCollections.ts
+++ b/src/hooks/useAuthoredCollections/useAuthoredCollections.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { PostController } from '@/controllers/post/post';
+import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import { useAuthStore } from '@/stores/auth/auth.store';
+
+type AuthoredCollections = NonNullable<Awaited<ReturnType<typeof PostController.getAuthoredCollections>>>;
+
+type UseAuthoredCollectionsResult = {
+  collections: AuthoredCollections;
+  isLoading: boolean;
+};
+
+export function useAuthoredCollections(enabled = true): UseAuthoredCollectionsResult {
+  const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
+
+  const { data, isLoading } = useLocalFirstQuery<AuthoredCollections>({
+    queryFn: () => PostController.getAuthoredCollections({ authorId: currentUserPubky! }),
+    fetchFn: () => PostController.fetchAuthoredCollections({ authorId: currentUserPubky!, viewerId: currentUserPubky }),
+    deps: [currentUserPubky],
+    enabled: enabled && !!currentUserPubky,
+  });
+
+  return {
+    collections: data ?? [],
+    isLoading,
+  };
+}

--- a/src/hooks/useAuthoredCollections/useAuthoredCollections.ts
+++ b/src/hooks/useAuthoredCollections/useAuthoredCollections.ts
@@ -2,9 +2,10 @@
 
 import { PostController } from '@/controllers/post/post';
 import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import type { CollectionPost } from '@/models/post/collection/collectionPost.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 
-type AuthoredCollections = NonNullable<Awaited<ReturnType<typeof PostController.getAuthoredCollections>>>;
+type AuthoredCollections = CollectionPost[];
 
 type UseAuthoredCollectionsResult = {
   collections: AuthoredCollections;

--- a/src/hooks/useBookmark/useBookmark.test.ts
+++ b/src/hooks/useBookmark/useBookmark.test.ts
@@ -1,7 +1,9 @@
+import { usePathname } from 'next/navigation';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import type { Pubky } from '@/models/models.types';
+import { useTimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { mockAuthStore } from '@/test-utils/stores';
 import { useBookmark } from './useBookmark';
@@ -16,6 +18,12 @@ vi.mock('@/controllers/bookmark/bookmark', () => ({
     commitCreate: vi.fn(),
     commitDelete: vi.fn(),
   },
+}));
+vi.mock('@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext', () => ({
+  useTimelineFeedContext: vi.fn(() => null),
+}));
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
 }));
 
 // Mock molecules (useToast)
@@ -33,6 +41,8 @@ describe('useBookmark', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useAuthStore).mockImplementation((selector) => selector(mockAuthStore({ currentUserPubky: mockUserId })));
+    vi.mocked(useTimelineFeedContext).mockReturnValue(null);
+    vi.mocked(usePathname).mockReturnValue('/');
   });
 
   it('returns isBookmarked false when post is not bookmarked', async () => {
@@ -131,6 +141,52 @@ describe('useBookmark', () => {
       title: 'Bookmark removed',
       description: 'Post removed from your bookmarks',
     });
+  });
+
+  it('removes the post from the visible bookmarks timeline after unbookmarking', async () => {
+    const removePosts = vi.fn();
+    vi.mocked(usePathname).mockReturnValue('/collections/bookmarks');
+    vi.mocked(useTimelineFeedContext).mockReturnValue({
+      prependPosts: vi.fn(),
+      removePosts,
+    });
+    vi.mocked(BookmarkController.exists).mockResolvedValue(true);
+    vi.mocked(BookmarkController.commitDelete).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useBookmark(mockPostId));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggle();
+    });
+
+    expect(removePosts).toHaveBeenCalledWith(mockPostId);
+  });
+
+  it('does not remove the post from other routes after unbookmarking', async () => {
+    const removePosts = vi.fn();
+    vi.mocked(usePathname).mockReturnValue('/home');
+    vi.mocked(useTimelineFeedContext).mockReturnValue({
+      prependPosts: vi.fn(),
+      removePosts,
+    });
+    vi.mocked(BookmarkController.exists).mockResolvedValue(true);
+    vi.mocked(BookmarkController.commitDelete).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useBookmark(mockPostId));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggle();
+    });
+
+    expect(removePosts).not.toHaveBeenCalled();
   });
 
   it('shows error toast when user is not logged in', async () => {

--- a/src/hooks/useBookmark/useBookmark.ts
+++ b/src/hooks/useBookmark/useBookmark.ts
@@ -1,10 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { COLLECTION_ROUTES } from '@/app/routes';
 import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import { Logger } from '@/libs/logger/logger';
 import { useToast } from '@/molecules/Toaster/use-toast';
+import { useTimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext';
 import { useAuthStore } from '@/stores/auth/auth.store';
 
 export interface UseBookmarkResult {
@@ -38,6 +41,8 @@ export function useBookmark(postId: string): UseBookmarkResult {
   const tToast = useTranslations('toast');
   const tBookmark = useTranslations('toast.bookmark');
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
+  const timelineFeed = useTimelineFeedContext();
+  const pathname = usePathname();
 
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -64,7 +69,7 @@ export function useBookmark(postId: string): UseBookmarkResult {
       });
   }, [postId]);
 
-  const toggle = useCallback(async (): Promise<void> => {
+  const toggle = async (): Promise<void> => {
     if (!currentUserPubky) {
       toast({
         title: tToast('error'),
@@ -80,6 +85,9 @@ export function useBookmark(postId: string): UseBookmarkResult {
       if (isBookmarked) {
         await BookmarkController.commitDelete({ postId, userId: currentUserPubky });
         setIsBookmarked(false);
+        if (pathname === COLLECTION_ROUTES.BOOKMARKS) {
+          timelineFeed?.removePosts(postId);
+        }
         toast({
           title: tBookmark('removed'),
           description: tBookmark('removedDesc'),
@@ -101,7 +109,7 @@ export function useBookmark(postId: string): UseBookmarkResult {
     } finally {
       setIsToggling(false);
     }
-  }, [postId, currentUserPubky, isBookmarked, isToggling, toast, tToast, tBookmark]);
+  };
 
   return {
     isBookmarked,

--- a/src/hooks/useCollectionsOwner/useCollectionsOwner.test.tsx
+++ b/src/hooks/useCollectionsOwner/useCollectionsOwner.test.tsx
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileController } from '@/controllers/file/file';
+import { useCurrentUserProfile } from '@/hooks/useCurrentUserProfile/useCurrentUserProfile';
+import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
+import type { LocalFilesStore } from '@/stores/localFiles/localFiles.types';
+import { useCollectionsOwner } from './useCollectionsOwner';
+
+vi.mock('@/controllers/file/file', () => ({
+  FileController: {
+    getAvatarUrl: vi.fn(
+      (pubky: string, version?: string | number) => `https://example.com/avatar/${pubky}?v=${version}`,
+    ),
+  },
+}));
+
+vi.mock('@/hooks/useCurrentUserProfile/useCurrentUserProfile', () => ({
+  useCurrentUserProfile: vi.fn(),
+}));
+
+vi.mock('@/hooks/useLocalFirstQuery/useLocalFirstQuery', () => ({
+  useLocalFirstQuery: vi.fn(),
+}));
+
+vi.mock('@/stores/localFiles/localFiles.store', () => ({
+  useLocalFilesStore: vi.fn(),
+}));
+
+const mockLocalFilesState = { profile: null, posts: {} } as LocalFilesStore;
+
+describe('useCollectionsOwner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCurrentUserProfile).mockReturnValue({
+      currentUserPubky: 'test-pubky',
+      userDetails: {
+        id: 'test-pubky',
+        name: 'Test User',
+        image: 'avatar',
+        indexed_at: 123,
+        bio: '',
+        links: [],
+        status: '',
+      },
+    });
+    vi.mocked(useLocalFirstQuery).mockReturnValue({
+      data: { bookmarks: 29 },
+      isLoading: false,
+    });
+    vi.mocked(useLocalFilesStore).mockImplementation((selector) => selector(mockLocalFilesState));
+  });
+
+  it('returns owner profile fields and bookmark count', () => {
+    const { result } = renderHook(() => useCollectionsOwner());
+
+    expect(result.current.avatarName).toBe('Test User');
+    expect(result.current.avatarSeed).toBe('test-pubky');
+    expect(result.current.bookmarkCount).toBe(29);
+    expect(result.current.avatarUrl).toBe('https://example.com/avatar/test-pubky?v=123');
+    expect(FileController.getAvatarUrl).toHaveBeenCalledWith('test-pubky', 123);
+  });
+
+  it('prefers the local profile avatar over the CDN avatar', () => {
+    vi.mocked(useLocalFilesStore).mockImplementation((selector) =>
+      selector({ ...mockLocalFilesState, profile: 'blob:local-avatar' }),
+    );
+
+    const { result } = renderHook(() => useCollectionsOwner());
+
+    expect(result.current.avatarUrl).toBe('blob:local-avatar');
+    expect(FileController.getAvatarUrl).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the display name when pubky is missing', () => {
+    vi.mocked(useCurrentUserProfile).mockReturnValue({
+      currentUserPubky: null,
+      userDetails: undefined,
+    });
+    vi.mocked(useLocalFirstQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useCollectionsOwner());
+
+    expect(result.current.avatarName).toBe('U');
+    expect(result.current.avatarSeed).toBe('U');
+    expect(result.current.bookmarkCount).toBe(0);
+  });
+});

--- a/src/hooks/useCollectionsOwner/useCollectionsOwner.ts
+++ b/src/hooks/useCollectionsOwner/useCollectionsOwner.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { FileController } from '@/controllers/file/file';
+import { UserController } from '@/controllers/user/user';
+import { useCurrentUserProfile } from '@/hooks/useCurrentUserProfile/useCurrentUserProfile';
+import { useLocalFirstQuery } from '@/hooks/useLocalFirstQuery/useLocalFirstQuery';
+import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
+
+/**
+ * Shared owner profile and bookmark count for collections surfaces.
+ */
+export function useCollectionsOwner() {
+  const { userDetails, currentUserPubky } = useCurrentUserProfile();
+  const localAvatarUrl = useLocalFilesStore((state) => state.profile);
+  const { data: userCounts, isLoading: isCountsLoading } = useLocalFirstQuery({
+    queryFn: () => UserController.getCounts({ userId: currentUserPubky! }),
+    fetchFn: () => UserController.fetchCounts({ userId: currentUserPubky! }),
+    deps: [currentUserPubky],
+    enabled: !!currentUserPubky,
+  });
+
+  const avatarUrl =
+    localAvatarUrl ??
+    (currentUserPubky && userDetails?.image
+      ? FileController.getAvatarUrl(currentUserPubky, userDetails.indexed_at)
+      : undefined);
+  const avatarName = userDetails?.name || 'U';
+  const avatarSeed = currentUserPubky ?? avatarName;
+
+  return {
+    currentUserPubky,
+    avatarUrl,
+    avatarName,
+    avatarSeed,
+    bookmarkCount: userCounts?.bookmarks ?? 0,
+    isCountsLoading,
+  };
+}

--- a/src/hooks/useCoverImagePicker/useCoverImagePicker.test.ts
+++ b/src/hooks/useCoverImagePicker/useCoverImagePicker.test.ts
@@ -1,0 +1,122 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ChangeEvent } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asInvalid } from '@/test-utils/type-assertions';
+import { useCoverImagePicker } from './useCoverImagePicker';
+
+const stubbedUrl = vi.hoisted(() => ({
+  createObjectURL: vi.fn<(file: File) => string>(() => 'blob:cover-mock'),
+  revokeObjectURL: vi.fn(),
+}));
+
+const buildChangeEvent = (file: File | null): ChangeEvent<HTMLInputElement> =>
+  asInvalid<ChangeEvent<HTMLInputElement>>({
+    target: { files: file ? [file] : [], value: '' },
+  });
+
+describe('useCoverImagePicker', () => {
+  beforeEach(() => {
+    stubbedUrl.createObjectURL.mockClear();
+    stubbedUrl.revokeObjectURL.mockClear();
+    vi.stubGlobal('URL', { ...URL, ...stubbedUrl });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts empty and exposes an initial preview URL when provided', () => {
+    const { result } = renderHook(() => useCoverImagePicker({ initialPreviewUrl: 'https://cdn/x.png' }));
+
+    expect(result.current.file).toBeNull();
+    expect(result.current.previewUrl).toBe('https://cdn/x.png');
+    expect(result.current.isCleared).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('accepts an image file and exposes a blob preview URL', () => {
+    const { result } = renderHook(() => useCoverImagePicker());
+
+    const file = new File(['cover'], 'cover.png', { type: 'image/png' });
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(file));
+    });
+
+    expect(stubbedUrl.createObjectURL).toHaveBeenCalledWith(file);
+    expect(result.current.file).toBe(file);
+    expect(result.current.previewUrl).toBe('blob:cover-mock');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('rejects non-image files with an `invalid-type` error and keeps state', () => {
+    const { result } = renderHook(() => useCoverImagePicker());
+
+    const file = new File(['notes'], 'notes.txt', { type: 'text/plain' });
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(file));
+    });
+
+    expect(result.current.error).toBe('invalid-type');
+    expect(result.current.file).toBeNull();
+    expect(result.current.previewUrl).toBeNull();
+  });
+
+  it('rejects oversize files with a `too-large` error', () => {
+    const { result } = renderHook(() => useCoverImagePicker({ maxSize: 4 }));
+
+    const file = new File(['12345678'], 'big.png', { type: 'image/png' });
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(file));
+    });
+
+    expect(result.current.error).toBe('too-large');
+    expect(result.current.file).toBeNull();
+  });
+
+  it('marks the picker cleared when removing an initial preview', () => {
+    const { result } = renderHook(() => useCoverImagePicker({ initialPreviewUrl: 'https://cdn/x.png' }));
+
+    act(() => {
+      result.current.remove();
+    });
+
+    expect(result.current.previewUrl).toBeNull();
+    expect(result.current.isCleared).toBe(true);
+  });
+
+  it('reset() restores the initial preview and clears the file state', () => {
+    const { result } = renderHook(() => useCoverImagePicker({ initialPreviewUrl: 'https://cdn/x.png' }));
+
+    const file = new File(['cover'], 'cover.png', { type: 'image/png' });
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(file));
+    });
+    expect(result.current.previewUrl).toBe('blob:cover-mock');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.file).toBeNull();
+    expect(result.current.previewUrl).toBe('https://cdn/x.png');
+    expect(result.current.isCleared).toBe(false);
+    expect(stubbedUrl.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('revokes the blob URL when the previewing file changes', () => {
+    const { result } = renderHook(() => useCoverImagePicker());
+
+    const first = new File(['1'], 'first.png', { type: 'image/png' });
+    const second = new File(['2'], 'second.png', { type: 'image/png' });
+
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(first));
+    });
+    act(() => {
+      result.current.onInputChange(buildChangeEvent(second));
+    });
+
+    expect(stubbedUrl.createObjectURL).toHaveBeenCalledTimes(2);
+    expect(stubbedUrl.revokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCoverImagePicker/useCoverImagePicker.ts
+++ b/src/hooks/useCoverImagePicker/useCoverImagePicker.ts
@@ -1,0 +1,140 @@
+'use client';
+
+import { type ChangeEvent, type RefObject, useEffect, useRef, useState } from 'react';
+import { ATTACHMENT_MAX_IMAGE_SIZE } from '@/config/posts';
+
+type CoverImagePickerError = 'invalid-type' | 'too-large';
+
+type UseCoverImagePickerParams = {
+  /** Maximum allowed file size in bytes. Defaults to `ATTACHMENT_MAX_IMAGE_SIZE`. */
+  maxSize?: number;
+  /**
+   * Existing cover image URL (e.g. a `pubky://` URL on edit). When set, it is
+   * surfaced as `previewUrl` until the user picks a new file or removes it.
+   */
+  initialPreviewUrl?: string | null;
+};
+
+export type UseCoverImagePickerResult = {
+  /** Newly picked file. `null` when the user has not picked a file in this session. */
+  file: File | null;
+  /** URL to render in the UI: blob URL for a new file, or `initialPreviewUrl` until cleared. */
+  previewUrl: string | null;
+  /** `true` when the user explicitly removed an `initialPreviewUrl` without picking a new file. */
+  isCleared: boolean;
+  /** Validation error from the last `onInputChange`. Codes are translated by the consumer. */
+  error: CoverImagePickerError | null;
+  /** Ref to the hidden `<input type="file">` element managed by the consumer. */
+  inputRef: RefObject<HTMLInputElement | null>;
+  /** Wire to `<input type="file" onChange={...}>`. */
+  onInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  /** Open the native file picker by clicking the hidden input. */
+  choose: () => void;
+  /** Clear the current preview/file (also clears any initial preview). */
+  remove: () => void;
+  /** Reset to the initial state (re-shows `initialPreviewUrl`). */
+  reset: () => void;
+};
+
+/**
+ * Manages the lifecycle of a cover image picker — file state, blob preview,
+ * validation, and cleanup of object URLs. Designed for create/edit flows where
+ * the cover image is uploaded separately and only the resulting URL is stored
+ * in the collection (or post) envelope.
+ *
+ * @example
+ * ```tsx
+ * const cover = useCoverImagePicker();
+ * <button onClick={cover.choose}>{cover.previewUrl ? 'Change' : 'Add image'}</button>
+ * <input type="file" accept="image/*" ref={cover.inputRef} onChange={cover.onInputChange} hidden />
+ * ```
+ */
+export function useCoverImagePicker({
+  maxSize = ATTACHMENT_MAX_IMAGE_SIZE,
+  initialPreviewUrl = null,
+}: UseCoverImagePickerParams = {}): UseCoverImagePickerResult {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [localPreviewUrl, setLocalPreviewUrl] = useState<string | null>(null);
+  const [isInitialCleared, setIsInitialCleared] = useState(false);
+  const [error, setError] = useState<CoverImagePickerError | null>(null);
+
+  // Revoke any blob URL we created when it changes or on unmount. We only
+  // create blob URLs in `onInputChange`, so a single guarded revoke covers
+  // the lifecycle without leaking on identity-only re-renders.
+  useEffect(() => {
+    return () => {
+      if (localPreviewUrl && localPreviewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(localPreviewUrl);
+      }
+    };
+  }, [localPreviewUrl]);
+
+  const clearLocalPreview = () => {
+    setLocalPreviewUrl((prev) => {
+      if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
+      return null;
+    });
+  };
+
+  const clearNativeInput = () => {
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  const choose = () => {
+    inputRef.current?.click();
+  };
+
+  const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.files?.[0] ?? null;
+    if (!next) return;
+
+    if (!next.type.startsWith('image/')) {
+      setError('invalid-type');
+      return;
+    }
+
+    if (next.size > maxSize) {
+      setError('too-large');
+      return;
+    }
+
+    setLocalPreviewUrl((prev) => {
+      if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(next);
+    });
+    setFile(next);
+    setIsInitialCleared(false);
+    setError(null);
+  };
+
+  const remove = () => {
+    setFile(null);
+    clearLocalPreview();
+    setIsInitialCleared(true);
+    setError(null);
+    clearNativeInput();
+  };
+
+  const reset = () => {
+    setFile(null);
+    clearLocalPreview();
+    setIsInitialCleared(false);
+    setError(null);
+    clearNativeInput();
+  };
+
+  const previewUrl = localPreviewUrl ?? (isInitialCleared ? null : (initialPreviewUrl ?? null));
+
+  return {
+    file,
+    previewUrl,
+    isCleared: isInitialCleared && !file,
+    error,
+    inputRef,
+    onInputChange,
+    choose,
+    remove,
+    reset,
+  };
+}

--- a/src/hooks/useCreateCollection/useCreateCollection.test.ts
+++ b/src/hooks/useCreateCollection/useCreateCollection.test.ts
@@ -1,0 +1,177 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCreateCollection } from './useCreateCollection';
+import { CREATE_COLLECTION_FORM_FIELDS } from './useCreateCollection.types';
+
+const mocks = vi.hoisted(() => ({
+  commitCreateCollection: vi.fn(),
+  toast: vi.fn(),
+  currentUserPubky: 'current-user' as string | null,
+  cover: {
+    file: null as File | null,
+    previewUrl: null as string | null,
+    isCleared: false,
+    error: null as 'invalid-type' | 'too-large' | null,
+    inputRef: { current: null },
+    onInputChange: vi.fn(),
+    choose: vi.fn(),
+    remove: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+const translations: Record<string, string> = {
+  'collections.new.nameRequired': 'Collection title is required.',
+  'collections.new.created': 'Collection {name} created',
+  'collections.new.createFailed': 'Failed to create collection.',
+  'toast.success': 'Success',
+  'toast.error': 'Error',
+};
+
+vi.mock('@/controllers/post/post', () => ({
+  PostController: {
+    commitCreateCollection: (...args: unknown[]) => mocks.commitCreateCollection(...args),
+  },
+}));
+
+vi.mock('@/hooks/useCoverImagePicker/useCoverImagePicker', () => ({
+  useCoverImagePicker: () => mocks.cover,
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) =>
+    selector({ currentUserPubky: mocks.currentUserPubky }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace: string) =>
+    (key: string, values?: Record<string, string>): string =>
+      Object.entries(values ?? {}).reduce(
+        (msg, [n, v]) => msg.replace(`{${n}}`, v),
+        translations[`${namespace}.${key}`] ?? key,
+      ),
+}));
+
+describe('useCreateCollection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cover.file = null;
+    mocks.cover.reset.mockClear();
+    mocks.currentUserPubky = 'current-user';
+  });
+
+  it('exposes an RHF form with empty defaults and an idle cover picker', () => {
+    const { result } = renderHook(() => useCreateCollection());
+
+    expect(result.current.form.getValues()).toEqual({
+      [CREATE_COLLECTION_FORM_FIELDS.NAME]: '',
+      [CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION]: '',
+    });
+    expect(result.current.cover.file).toBeNull();
+    expect(result.current.form.formState.isSubmitting).toBe(false);
+  });
+
+  it('rejects an empty title via zod and does not call the controller', async () => {
+    const { result } = renderHook(() => useCreateCollection());
+
+    let saved: boolean | null = null;
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toBe(false);
+    expect(mocks.commitCreateCollection).not.toHaveBeenCalled();
+    // Whitespace-only also rejected
+    act(() => result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.NAME, '   '));
+
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toBe(false);
+    expect(mocks.commitCreateCollection).not.toHaveBeenCalled();
+  });
+
+  it('saves the collection with the picker file and toasts success', async () => {
+    mocks.commitCreateCollection.mockResolvedValue('current-user:c1');
+    const file = new File(['x'], 'cover.png', { type: 'image/png' });
+    mocks.cover.file = file;
+
+    const { result } = renderHook(() => useCreateCollection());
+
+    act(() => result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.NAME, '  Proof of Work  '));
+    act(() => result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION, 'Bitcoin writing'));
+
+    let saved: boolean | null = null;
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toBe(true);
+    expect(mocks.commitCreateCollection).toHaveBeenCalledWith({
+      authorId: 'current-user',
+      name: '  Proof of Work  ',
+      description: 'Bitcoin writing',
+      coverImage: file,
+    });
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Success',
+      description: 'Collection Proof of Work created',
+    });
+  });
+
+  it('returns false and toasts an error when the controller throws', async () => {
+    mocks.commitCreateCollection.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useCreateCollection());
+
+    act(() => result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.NAME, 'Reading list'));
+
+    let saved: boolean | null = null;
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toBe(false);
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Error',
+      description: 'Failed to create collection.',
+    });
+  });
+
+  it('returns false without calling the controller when the user is unauthenticated', async () => {
+    mocks.currentUserPubky = null;
+    const { result } = renderHook(() => useCreateCollection());
+
+    act(() => result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.NAME, 'Reading list'));
+
+    let saved: boolean | null = null;
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toBe(false);
+    expect(mocks.commitCreateCollection).not.toHaveBeenCalled();
+  });
+
+  it('reset() clears form values and resets the cover picker', () => {
+    const { result } = renderHook(() => useCreateCollection());
+
+    act(() => {
+      result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.NAME, 'Reading list');
+      result.current.form.setValue(CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION, 'Some books');
+    });
+
+    act(() => result.current.reset());
+
+    expect(result.current.form.getValues()).toEqual({
+      [CREATE_COLLECTION_FORM_FIELDS.NAME]: '',
+      [CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION]: '',
+    });
+    expect(mocks.cover.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useCreateCollection/useCreateCollection.ts
+++ b/src/hooks/useCreateCollection/useCreateCollection.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
+import { useForm, type UseFormReturn } from 'react-hook-form';
+import { PostController } from '@/controllers/post/post';
+import { useCoverImagePicker, type UseCoverImagePickerResult } from '@/hooks/useCoverImagePicker/useCoverImagePicker';
+import { Logger } from '@/libs/logger/logger';
+import { useToast } from '@/molecules/Toaster/use-toast';
+import { useAuthStore } from '@/stores/auth/auth.store';
+import {
+  CREATE_COLLECTION_FORM_FIELDS,
+  type CreateCollectionFormData,
+  createCollectionFormDefaults,
+  createCollectionFormSchema,
+} from './useCreateCollection.types';
+
+type UseCreateCollectionResult = {
+  /** React Hook Form instance — wire to `ControlledInputField` via `form.control`. */
+  form: UseFormReturn<CreateCollectionFormData>;
+  /** Cover image picker — file/preview/error state plus handlers. */
+  cover: UseCoverImagePickerResult;
+  /**
+   * Validate + commit the collection. Returns `true` on success, `false`
+   * otherwise (validation rejected the form, or the controller threw). Uses
+   * RHF's `handleSubmit` so field-level errors surface in the UI.
+   */
+  submit: () => Promise<boolean>;
+  /** Clear the form fields and the cover picker. */
+  reset: () => void;
+};
+
+/**
+ * Encapsulates the "create collection" form on top of react-hook-form + zod.
+ *
+ * - Schema lives in `./useCreateCollection.types.ts`
+ * - Cover image is managed by `useCoverImagePicker` (separate concern: file
+ *   pickers don't fit RHF's `register`/`Controller` model cleanly because of
+ *   blob URL lifecycle and image-specific validation)
+ * - Validation mode is `all`: required feedback appears after blur and clears
+ *   as the user edits a valid value.
+ * - `submit()` returns `Promise<boolean>` so the caller can decide what to do
+ *   on success (close dialog, navigate, etc.)
+ */
+export function useCreateCollection(): UseCreateCollectionResult {
+  const t = useTranslations('collections.new');
+  const tToast = useTranslations('toast');
+  const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
+  const { toast } = useToast();
+  const cover = useCoverImagePicker();
+
+  const form = useForm<CreateCollectionFormData>({
+    resolver: zodResolver(createCollectionFormSchema(t)),
+    defaultValues: createCollectionFormDefaults,
+    mode: 'all',
+  });
+
+  const submit = async (): Promise<boolean> => {
+    if (!currentUserPubky) return false;
+
+    let succeeded = false;
+    await form.handleSubmit(async (data) => {
+      const name = data[CREATE_COLLECTION_FORM_FIELDS.NAME];
+      const description = data[CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION];
+      try {
+        await PostController.commitCreateCollection({
+          authorId: currentUserPubky,
+          name,
+          description,
+          coverImage: cover.file,
+        });
+        toast({
+          title: tToast('success'),
+          description: t('created', { name: name.trim() }),
+        });
+        succeeded = true;
+      } catch (error) {
+        Logger.error('[useCreateCollection] Failed to create collection', { error });
+        toast({
+          title: tToast('error'),
+          description: t('createFailed'),
+        });
+      }
+    })();
+    return succeeded;
+  };
+
+  const reset = () => {
+    form.reset(createCollectionFormDefaults);
+    cover.reset();
+  };
+
+  return {
+    form,
+    cover,
+    submit,
+    reset,
+  };
+}

--- a/src/hooks/useCreateCollection/useCreateCollection.types.ts
+++ b/src/hooks/useCreateCollection/useCreateCollection.types.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH, COLLECTION_NAME_MAX_CHARACTER_LENGTH } from '@/config/posts';
+
+export const CREATE_COLLECTION_FORM_FIELDS = {
+  NAME: 'name',
+  DESCRIPTION: 'description',
+};
+
+/**
+ * Translator function shape we accept from the consumer (`next-intl`'s
+ * `useTranslations('collections.new')` returns a compatible function). We use
+ * it inside the schema factory so validation messages can be localized.
+ */
+type CreateCollectionTranslator = (key: string) => string;
+
+/**
+ * Schema for the "create collection" form.
+ *
+ * Wrapped in a factory so the dialog can pass its `useTranslations` callable
+ * and zod issues become locale-aware error messages — matching the rest of
+ * the codebase's i18n posture.
+ */
+export const createCollectionFormSchema = (t: CreateCollectionTranslator) =>
+  z.object({
+    [CREATE_COLLECTION_FORM_FIELDS.NAME]: z
+      .string()
+      .max(COLLECTION_NAME_MAX_CHARACTER_LENGTH)
+      .refine((value) => value.trim().length > 0, { message: t('nameRequired') }),
+    [CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION]: z.string().max(COLLECTION_DESCRIPTION_MAX_CHARACTER_LENGTH),
+  });
+
+export type CreateCollectionFormData = z.infer<ReturnType<typeof createCollectionFormSchema>>;
+
+/** Default values for the create-collection form. */
+export const createCollectionFormDefaults: CreateCollectionFormData = {
+  [CREATE_COLLECTION_FORM_FIELDS.NAME]: '',
+  [CREATE_COLLECTION_FORM_FIELDS.DESCRIPTION]: '',
+};

--- a/src/hooks/usePostSaveTargets/usePostSaveTargets.test.ts
+++ b/src/hooks/usePostSaveTargets/usePostSaveTargets.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePostSaveTargets } from './usePostSaveTargets';
+
+const mocks = vi.hoisted(() => ({
+  commitUpdateCollectionItem: vi.fn(),
+  commitCreateCollection: vi.fn(),
+  toggleBookmark: vi.fn(),
+  toast: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+  success: 'Success',
+  addedToCollection: 'Post added to {name}.',
+  removedFromCollection: 'Post removed from {name}.',
+};
+
+vi.mock('@/controllers/post/post', () => ({
+  PostController: {
+    commitUpdateCollectionItem: (...args: unknown[]) => mocks.commitUpdateCollectionItem(...args),
+    commitCreateCollection: (...args: unknown[]) => mocks.commitCreateCollection(...args),
+  },
+}));
+
+vi.mock('@/hooks/useBookmark/useBookmark', () => ({
+  useBookmark: () => ({
+    isBookmarked: true,
+    isLoading: false,
+    isToggling: false,
+    toggle: mocks.toggleBookmark,
+  }),
+}));
+
+vi.mock('@/hooks/useAuthoredCollections/useAuthoredCollections', () => ({
+  useAuthoredCollections: () => ({
+    collections: [
+      {
+        details: { id: 'author:collection1' },
+        content: {
+          name: 'Proof of Work',
+          description: 'Bitcoin writing',
+          items: ['pubky://author/pub/pubky.app/posts/post1'],
+        },
+      },
+      {
+        details: { id: 'author:collection2' },
+        content: {
+          name: 'AI Papers',
+          description: '',
+          items: [],
+        },
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string }) => unknown) =>
+    selector({ currentUserPubky: 'current-user' }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string>) =>
+    Object.entries(values ?? {}).reduce(
+      (message, [name, value]) => message.replace(`{${name}}`, value),
+      translations[key] ?? key,
+    ),
+}));
+
+describe('usePostSaveTargets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('combines bookmark state and collection membership', () => {
+    const { result } = renderHook(() => usePostSaveTargets('author:post1'));
+
+    expect(result.current.isBookmarked).toBe(true);
+    expect(result.current.collections).toEqual([
+      expect.objectContaining({ id: 'author:collection1', name: 'Proof of Work', isSaved: true }),
+      expect.objectContaining({ id: 'author:collection2', name: 'AI Papers', isSaved: false }),
+    ]);
+  });
+
+  it('toggles collection membership separately from bookmarks', async () => {
+    const { result } = renderHook(() => usePostSaveTargets('author:post1'));
+
+    await act(async () => {
+      await result.current.toggleCollection('author:collection1');
+    });
+
+    expect(mocks.commitUpdateCollectionItem).toHaveBeenCalledWith({
+      collectionId: 'author:collection1',
+      postId: 'author:post1',
+      shouldAdd: false,
+    });
+    expect(mocks.toggleBookmark).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Success',
+      description: 'Post removed from Proof of Work.',
+    });
+  });
+
+  it('shows the target collection name when adding a post to a collection', async () => {
+    const { result } = renderHook(() => usePostSaveTargets('author:post1'));
+
+    await act(async () => {
+      await result.current.toggleCollection('author:collection2');
+    });
+
+    expect(mocks.commitUpdateCollectionItem).toHaveBeenCalledWith({
+      collectionId: 'author:collection2',
+      postId: 'author:post1',
+      shouldAdd: true,
+    });
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Success',
+      description: 'Post added to AI Papers.',
+    });
+  });
+
+  it('creates a collection with the current post URI as first item', async () => {
+    const { result } = renderHook(() => usePostSaveTargets('author:post1'));
+
+    await act(async () => {
+      await result.current.createCollectionWithPost('New collection');
+    });
+
+    expect(mocks.commitCreateCollection).toHaveBeenCalledWith({
+      authorId: 'current-user',
+      name: 'New collection',
+      items: ['pubky://author/pub/pubky.app/posts/post1'],
+    });
+  });
+});

--- a/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
+++ b/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { postUriBuilder } from 'pubky-app-specs';
+import { PostController } from '@/controllers/post/post';
+import { useAuthoredCollections } from '@/hooks/useAuthoredCollections/useAuthoredCollections';
+import { useBookmark } from '@/hooks/useBookmark/useBookmark';
+import { Logger } from '@/libs/logger/logger';
+import { parseCompositeId } from '@/models/models.utils';
+import { useToast } from '@/molecules/Toaster/use-toast';
+import { useAuthStore } from '@/stores/auth/auth.store';
+
+export type PostSaveCollectionTarget = {
+  id: string;
+  name: string;
+  description: string;
+  isSaved: boolean;
+  isUpdating: boolean;
+};
+
+type UsePostSaveTargetsResult = {
+  isBookmarked: boolean;
+  isBookmarkLoading: boolean;
+  isBookmarkToggling: boolean;
+  collections: PostSaveCollectionTarget[];
+  isCollectionsLoading: boolean;
+  isCreatingCollection: boolean;
+  toggleBookmark: () => Promise<void>;
+  toggleCollection: (collectionId: string) => Promise<void>;
+  createCollectionWithPost: (name: string) => Promise<void>;
+};
+
+export function usePostSaveTargets(postId: string): UsePostSaveTargetsResult {
+  const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
+  const bookmark = useBookmark(postId);
+  const { collections, isLoading: isCollectionsLoading } = useAuthoredCollections(Boolean(currentUserPubky));
+  const { toast } = useToast();
+  const tToast = useTranslations('toast');
+  const tSave = useTranslations('postSave');
+  const [updatingCollectionIds, setUpdatingCollectionIds] = useState<Set<string>>(new Set());
+  const [isCreatingCollection, setIsCreatingCollection] = useState(false);
+
+  const { pubky, id } = parseCompositeId(postId);
+  const postUri = postUriBuilder(pubky, id);
+
+  const saveTargets: PostSaveCollectionTarget[] = collections.map((collection) => ({
+    id: collection.details.id,
+    name: collection.content.name,
+    description: collection.content.description,
+    isSaved: collection.content.items.includes(postUri),
+    isUpdating: updatingCollectionIds.has(collection.details.id),
+  }));
+
+  const setCollectionUpdating = (collectionId: string, isUpdating: boolean) => {
+    setUpdatingCollectionIds((current) => {
+      const next = new Set(current);
+      if (isUpdating) {
+        next.add(collectionId);
+      } else {
+        next.delete(collectionId);
+      }
+      return next;
+    });
+  };
+
+  const toggleCollection = async (collectionId: string) => {
+    const target = saveTargets.find((collection) => collection.id === collectionId);
+    if (!target || target.isUpdating) return;
+
+    setCollectionUpdating(collectionId, true);
+
+    try {
+      await PostController.commitUpdateCollectionItem({
+        collectionId,
+        postId,
+        shouldAdd: !target.isSaved,
+      });
+      toast({
+        title: tToast('success'),
+        description: target.isSaved
+          ? tSave('removedFromCollection', { name: target.name })
+          : tSave('addedToCollection', { name: target.name }),
+      });
+    } catch (error) {
+      Logger.error('[usePostSaveTargets] Failed to update collection membership', { error, collectionId, postId });
+      toast({
+        title: tToast('error'),
+        description: tSave('updateCollectionFailed'),
+      });
+    } finally {
+      setCollectionUpdating(collectionId, false);
+    }
+  };
+
+  const createCollectionWithPost = async (name: string) => {
+    if (!currentUserPubky || isCreatingCollection) return;
+
+    setIsCreatingCollection(true);
+
+    try {
+      await PostController.commitCreateCollection({
+        authorId: currentUserPubky,
+        name,
+        items: [postUri],
+      });
+      toast({
+        title: tToast('success'),
+        description: tSave('collectionCreated'),
+      });
+    } catch (error) {
+      Logger.error('[usePostSaveTargets] Failed to create collection', { error, postId });
+      toast({
+        title: tToast('error'),
+        description: tSave('createCollectionFailed'),
+      });
+    } finally {
+      setIsCreatingCollection(false);
+    }
+  };
+
+  return {
+    isBookmarked: bookmark.isBookmarked,
+    isBookmarkLoading: bookmark.isLoading,
+    isBookmarkToggling: bookmark.isToggling,
+    collections: saveTargets,
+    isCollectionsLoading,
+    isCreatingCollection,
+    toggleBookmark: bookmark.toggle,
+    toggleCollection,
+    createCollectionWithPost,
+  };
+}

--- a/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
+++ b/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
@@ -47,8 +47,8 @@ export function usePostSaveTargets(postId: string): UsePostSaveTargetsResult {
   const saveTargets: PostSaveCollectionTarget[] = collections.map((collection) => ({
     id: collection.details.id,
     name: collection.content.name,
-    description: collection.content.description,
-    isSaved: collection.content.items.includes(postUri),
+    description: collection.content.description ?? '',
+    isSaved: (collection.content.items ?? []).includes(postUri),
     isUpdating: updatingCollectionIds.has(collection.details.id),
   }));
 


### PR DESCRIPTION
## Summary

- Adds a dedicated system **Bookmarks** page at `/collections/bookmarks` with a Figma-aligned header (`bg-card`), owner metadata, and a three-column post grid.
- Introduces `BookmarksCollectionPosts` with bookmark stream pagination, collection-specific `PostMain` layout (tags/actions row, full-width media, stacked articles), and no reply threads or end-of-feed message.
- Extracts `useCollectionsOwner` for shared avatar/name/bookmark count between Collections landing and Bookmarks detail; unbookmark on the bookmarks page removes the post from the visible list.

Resovles #1867 