### PR TITLE
fix(homeserver): stop list 404s reaching Sentry

### DIFF
--- a/src/core/application/feed/feed.test.ts
+++ b/src/core/application/feed/feed.test.ts
@@ -8,6 +8,9 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TFeedPersistCreateParams, TFeedPersistDeleteParams } from '@/application/feed/feed.types';
 import { db } from '@/database/franky/franky';
+import { AppError } from '@/libs/error/error';
+import { ServerErrorCode } from '@/libs/error/error.codes';
+import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import { FeedModel } from '@/models/feed/feed';
@@ -596,6 +599,28 @@ describe('FeedApplication', () => {
       const result = await FeedApplication.fetchFeeds(testUserId);
 
       expect(result).toEqual([]);
+    });
+
+    it('should propagate non-404 AppError from HomeserverService.list', async () => {
+      const { listSpy } = setupFetchMocks();
+      const serverError = new AppError({
+        category: ErrorCategory.Server,
+        code: ServerErrorCode.INTERNAL_ERROR,
+        message: 'Server error',
+        service: ErrorService.Homeserver,
+        operation: 'list',
+        context: { statusCode: 500 },
+      });
+      listSpy.mockRejectedValue(serverError);
+
+      await expect(FeedApplication.fetchFeeds(testUserId)).rejects.toThrow('Server error');
+    });
+
+    it('should propagate non-AppError exceptions', async () => {
+      const { listSpy } = setupFetchMocks();
+      listSpy.mockRejectedValue(new Error('network-fail'));
+
+      await expect(FeedApplication.fetchFeeds(testUserId)).rejects.toThrow('network-fail');
     });
   });
 });

--- a/src/core/application/feed/feed.ts
+++ b/src/core/application/feed/feed.ts
@@ -5,8 +5,7 @@ import { db } from '@/database/franky/franky';
 import { ValidationErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
 import { ErrorService } from '@/libs/error/error.types';
-import { hasHttpStatus } from '@/libs/error/error.utils';
-import { HttpMethod, HttpStatusCode } from '@/libs/http/http.types';
+import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import { FeedModel } from '@/models/feed/feed';
 import { buildFeedStreamId } from '@/models/feed/feed.helpers';
@@ -134,17 +133,7 @@ export class FeedApplication {
    */
   static async fetchFeeds(userId: Pubky): Promise<FeedModelSchema[]> {
     const feedsDirectory = `${baseUriBuilder(userId)}feeds/`;
-
-    let feedUris: string[];
-    try {
-      feedUris = await HomeserverService.list({ baseDirectory: feedsDirectory });
-    } catch (error) {
-      if (hasHttpStatus(error, HttpStatusCode.NOT_FOUND)) {
-        Logger.info('Feeds directory not found, defaulting to empty list', { userId });
-        return [];
-      }
-      throw error;
-    }
+    const feedUris = await HomeserverService.list({ baseDirectory: feedsDirectory });
 
     const validFeeds: FeedModelSchema[] = [];
 

--- a/src/core/application/mute/mute.test.ts
+++ b/src/core/application/mute/mute.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@/database/franky/franky';
 import { AppError } from '@/libs/error/error';
-import { ClientErrorCode, ServerErrorCode } from '@/libs/error/error.codes';
+import { ServerErrorCode } from '@/libs/error/error.codes';
 import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
-import { HttpMethod, HttpStatusCode } from '@/libs/http/http.types';
+import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';
 import { UserStreamModel } from '@/models/stream/user/userStream';
 import { UserStreamTypes } from '@/models/stream/user/userStream.types';
@@ -315,16 +315,8 @@ describe('MuteApplication.fetchMutedUsers', () => {
     expect(result).toEqual(['mutee_aaa']);
   });
 
-  it('should return empty array when homeserver returns 404', async () => {
-    const notFoundError = new AppError({
-      category: ErrorCategory.Client,
-      code: ClientErrorCode.NOT_FOUND,
-      message: 'Not found',
-      service: ErrorService.Homeserver,
-      operation: 'list',
-      context: { statusCode: HttpStatusCode.NOT_FOUND },
-    });
-    vi.spyOn(HomeserverService, 'list').mockRejectedValue(notFoundError);
+  it('should return empty array when homeserver list returns empty (404 absorbed at service layer)', async () => {
+    vi.spyOn(HomeserverService, 'list').mockResolvedValue([]);
 
     const result = await MuteApplication.fetchMutedUsers(pubky);
 

--- a/src/core/application/mute/mute.ts
+++ b/src/core/application/mute/mute.ts
@@ -2,9 +2,7 @@ import { baseUriBuilder } from 'pubky-app-specs';
 import type { TMuteApplicationCommitParams } from '@/application/mute/mute.types';
 import { MUTE_HOMESERVER_EVENTS_PATH_PREFIX } from '@/config/mute-sync';
 import type { TMuteDirectoryEvent } from '@/controllers/mute/mute.types';
-import { hasHttpStatus } from '@/libs/error/error.utils';
-import { HttpMethod, HttpStatusCode } from '@/libs/http/http.types';
-import { Logger } from '@/libs/logger/logger';
+import { HttpMethod } from '@/libs/http/http.types';
 import type { Pubky } from '@/models/models.types';
 import { UserStreamTypes } from '@/models/stream/user/userStream.types';
 import { HomeserverService } from '@/services/homeserver/homeserver';
@@ -40,20 +38,10 @@ export class MuteApplication {
    * @returns Array of muted user pubkeys
    */
   static async fetchMutedUsers(pubky: Pubky): Promise<Pubky[]> {
-    let stream: Pubky[] = [];
-    try {
-      const mutesDirectory = `${baseUriBuilder(pubky)}mutes/`;
-      const muteUris = await HomeserverService.list({ baseDirectory: mutesDirectory });
-      stream = muteUris.map((uri) => uri.split('/').pop()).filter((id): id is string => !!id) as Pubky[];
-    } catch (error) {
-      if (hasHttpStatus(error, HttpStatusCode.NOT_FOUND)) {
-        Logger.info('Mutes directory not found, defaulting to empty list', { pubky });
-      } else {
-        throw error;
-      }
-    }
+    const mutesDirectory = `${baseUriBuilder(pubky)}mutes/`;
+    const muteUris = await HomeserverService.list({ baseDirectory: mutesDirectory });
+    const stream = muteUris.map((uri) => uri.split('/').pop()).filter((id): id is string => !!id) as Pubky[];
 
-    // Persist the muted users to the local MUTED stream
     await LocalStreamUsersService.upsert({
       streamId: UserStreamTypes.MUTED,
       stream,

--- a/src/core/services/homeserver/homeserver.test.ts
+++ b/src/core/services/homeserver/homeserver.test.ts
@@ -736,6 +736,14 @@ describe('HomeserverService', () => {
           code: ServerErrorCode.INTERNAL_ERROR,
         });
       });
+
+      it('should return empty array when directory returns 404', async () => {
+        mockState.publicStorageList.mockRejectedValue({ data: { statusCode: 404 } });
+
+        const result = await HomeserverService.list({ baseDirectory: 'pubky://user/pub/missing/' });
+
+        expect(result).toEqual([]);
+      });
     });
 
     describe('delete', () => {

--- a/src/core/services/homeserver/homeserver.ts
+++ b/src/core/services/homeserver/homeserver.ts
@@ -29,7 +29,7 @@ import type {
   THomeserverSignUpParams,
 } from '@/services/homeserver/homeserver.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
-import { handleError } from './error.utils';
+import { extractStatusCode, handleError } from './error.utils';
 import type {
   PubPath,
   TGenerateSignupAuthUrlParams,
@@ -396,6 +396,11 @@ export class HomeserverService {
       Logger.debug('List successful', { baseDirectory, filesCount: files.length });
       return files;
     } catch (error) {
+      // 404 here is not an error: missing directory means empty list. Bypass handleError to avoid Sentry capture.
+      if (extractStatusCode(error) === HttpStatusCode.NOT_FOUND) {
+        Logger.warn('[homeserver:list]', { outcome: 'fallback', reason: 'not_found', baseDirectory });
+        return [];
+      }
       return handleError({ error, additionalContext: { url: baseDirectory, baseDirectory } });
     }
   }


### PR DESCRIPTION
## Summary
For new accounts, missing `mutes/` or `feeds/` directories returned 404 — caught later as empty lists, but Sentry already had the event. Now absorbed at the listing layer. Refs #1854.

## Root cause
- New users have no mute or feed directories on their homeserver, so listing them returns   404.
- The shared error helper turned that 404 into a typed application error, which auto-reports to Sentry the moment the error object is constructed.
- The mute/feed callers caught the 404 afterwards and defaulted to an empty list, but
Sentry had already logged the event — too late to suppress.                                 

## Fix
- **Absorb 404 at the listing layer** — when a homeserver directory is missing, return an empty list directly with a warn-level log, before the typed error is ever constructed.
- **Drop redundant 404 catches in callers** — mute and feed fetchers no longer need to special-case 404; non-404 errors still propagate unchanged.

## Why this approach 
Mirrors the pattern from #1858 (og-metadata): expected external outcomes degrade quietly    at the service boundary instead of being constructed as errors and then filtered after the fact. Other listing callers (profile delete/download) also benefit — an empty list is the semantically correct fallback for a missing directory.

## Testing
- Added a unit test that listing a missing directory resolves to an empty array.
- Updated mute test to assert the new contract (service returns empty list); added equivalent propagation tests for feed (non-404 application error and non-application error still throw).

## Manual smoke test
(Sentry enabled locally via `NEXT_PUBLIC_SENTRY_DSN` + `NEXT_PUBLIC_SENTRY_ENVIRONMENT`, watched the real Sentry project for incoming events):
- **Mute**: signed in / cleared IndexedDB on an account with no muted users — the mute
list API call fires and previously hit Sentry with a 404. Now no event arrives.
- **Feed**: signed in as a brand-new account with no custom feeds — feeds API call fires
with 404. Now no event arrives.
- Sign-in completes normally in both cases.

## Notes
- 5xx, auth, and network errors continue to flow to Sentry exactly as before.
- The testnet/E2E noise mentioned in the issue (PUBKY-APP-12/13) is a separate environment-separation task and is not addressed here.