### PR TITLE
fix: Explore Mode UI bugs

### DIFF
--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -157,16 +157,6 @@ vi.mock('@/molecules/HeaderHome/HeaderHome', () => {
   };
 });
 
-vi.mock('@/molecules/HeaderJoin/HeaderJoin', () => {
-  return {
-    HeaderJoin: () => (
-      <div data-testid="header-join">
-        <button aria-label="Join Pubky">Join</button>
-      </div>
-    ),
-  };
-});
-
 vi.mock('@/molecules/HeaderSignIn/HeaderSignIn', () => {
   return {
     HeaderSignIn: () => (
@@ -624,7 +614,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-explore-navigation-buttons')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-home')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-sign-in')).not.toBeInTheDocument();
     });
@@ -638,7 +627,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-explore-navigation-buttons')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
     });
 
     it('renders HeaderHome when unauthenticated on non-public route', () => {
@@ -650,7 +638,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-home')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
     });
 
     it('renders explore navigation when unauthenticated on a core explore route', () => {
@@ -662,7 +649,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-explore-navigation-buttons')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-home')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-sign-in')).not.toBeInTheDocument();
     });
@@ -686,7 +672,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-sign-in')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-home')).not.toBeInTheDocument();
     });
 
@@ -726,7 +711,6 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('onboarding-header')).toBeInTheDocument();
-      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -615,7 +615,7 @@ describe('Header', () => {
   });
 
   describe('Public Route Behavior', () => {
-    it('renders HeaderJoin when unauthenticated on another user profile', () => {
+    it('renders explore navigation when unauthenticated on another user profile', () => {
       mockCurrentUserPubky = null;
       mockIsPublicRoute.mockReturnValue(true);
       mockIsCoreExploreRoute.mockReturnValue(false);
@@ -623,7 +623,8 @@ describe('Header', () => {
 
       render(<Header />);
 
-      expect(screen.getByTestId('header-join')).toBeInTheDocument();
+      expect(screen.getByTestId('header-explore-navigation-buttons')).toBeInTheDocument();
+      expect(screen.queryByTestId('header-join')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-home')).not.toBeInTheDocument();
       expect(screen.queryByTestId('header-sign-in')).not.toBeInTheDocument();
     });

--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -703,6 +703,20 @@ describe('Header', () => {
       expect(screen.getByTestId('search-input')).toBeInTheDocument();
     });
 
+    it('hides header on mobile when signed in on another user profile page', () => {
+      mockCurrentUserPubky = 'test-pubky-123';
+      mockIsPublicRoute.mockReturnValue(true);
+      mockIsCoreExploreRoute.mockReturnValue(false);
+      mockUsePathname.mockReturnValue('/profile/o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy');
+
+      render(<Header />);
+
+      const headerContainer = screen.getByTestId('header-container');
+      expect(headerContainer).toHaveAttribute('data-class-name', 'hidden lg:block');
+      expect(screen.getByTestId('header-sign-in')).toBeInTheDocument();
+      expect(screen.getByTestId('search-input')).toBeInTheDocument();
+    });
+
     it('prioritizes onboarding header over public route state', () => {
       mockCurrentUserPubky = null;
       mockIsPublicRoute.mockReturnValue(true);

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -22,10 +22,8 @@ export function Header() {
   const t = useTranslations('onboarding.steps');
   const isAuthenticated = useAuthStore((state) => Boolean(state.currentUserPubky));
   const { isCoreExploreRoute, isDynamicPublicRoute } = usePublicRoute();
-  const isGuestOnDynamicPublicRoute = isDynamicPublicRoute && !isAuthenticated;
 
   const isOnboarding = pathname?.startsWith('/onboarding') ?? false;
-  const isOnPostRoute = pathname ? isPostRoute(pathname) : false;
   const isCopyrightPage = pathname === '/copyright';
   const stepConfig = pathname ? pathToStepConfig[pathname] : undefined;
   const currentStep = stepConfig?.step ?? 1;
@@ -33,14 +31,10 @@ export function Header() {
 
   // Hide header on mobile when:
   // - User is on a core explore route (/home, /hot, /search) — MobileHeader + MobileFooter
-  // - Guest on dynamic public routes (post/profile) — minimal MobileHeader
-  // - Any user on /post — PostPageShell renders MobileHeader with drawer icons
-  // - Authenticated on standard app routes (not post/profile) — MobileHeader + MobileFooter
+  // - Any user on a dynamic public route (/post/..., /profile/[pubky]) — page shell owns mobile chrome
+  // - Authenticated on standard app routes — MobileHeader + MobileFooter
   const shouldHideHeaderOnMobile =
-    isCoreExploreRoute ||
-    isGuestOnDynamicPublicRoute ||
-    isOnPostRoute ||
-    (isAuthenticated && !isOnboarding && !isDynamicPublicRoute);
+    isCoreExploreRoute || isDynamicPublicRoute || (isAuthenticated && !isOnboarding && !isDynamicPublicRoute);
   // Show title only for onboarding/logout pages (when stepConfig exists) and user is not authenticated,
   // or during profile setup (step 5)
   const shouldShowTitle = currentTitle && (!isAuthenticated || currentStep === 5);

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -2,7 +2,6 @@
 
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { isPostRoute } from '@/app/routes';
 import { usePublicRoute } from '@/hooks/usePublicRoute/usePublicRoute';
 import {
   HeaderContainer,
@@ -11,7 +10,6 @@ import {
   HeaderTitle,
 } from '@/molecules/Header/Header';
 import { HeaderHome } from '@/molecules/HeaderHome/HeaderHome';
-import { HeaderJoin } from '@/molecules/HeaderJoin/HeaderJoin';
 import { HeaderSignIn } from '@/molecules/HeaderSignIn/HeaderSignIn';
 import { Logo } from '@/molecules/Logo/Logo';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -48,9 +46,7 @@ export function Header() {
   // Determine which header content to show:
   // - Onboarding: HeaderOnboarding
   // - Authenticated: HeaderSignIn (navigation + avatar)
-  // - Unauthenticated on core explore route (home/hot/search): public explore navigation + join
-  // - Unauthenticated on /post: explore navigation + join (same as /home at lg+)
-  // - Unauthenticated on other dynamic public (e.g. profile): HeaderJoin
+  // - Unauthenticated on core explore or dynamic public routes (home/hot/search/post/profile): explore navigation + join
   // - Unauthenticated on landing/other: HeaderHome (social links + sign in)
   const renderHeaderContent = () => {
     if (isOnboarding) {
@@ -59,11 +55,8 @@ export function Header() {
     if (isAuthenticated) {
       return <HeaderSignIn />;
     }
-    if (isCoreExploreRoute || (pathname && isPostRoute(pathname))) {
+    if (isCoreExploreRoute || isDynamicPublicRoute) {
       return <HeaderExploreNavigationButtons />;
-    }
-    if (isDynamicPublicRoute) {
-      return <HeaderJoin />;
     }
     return <HeaderHome />;
   };


### PR DESCRIPTION
Two bugs fixes:
1. The desktop header (with search bar) was showing on mobile when signed in and viewing other's profile page
2. On desktop in Explore mode, the header was wrong on profile page: it had the old design with just profile avatar. Now it matches the other pages with search bar, all buttons and new avatar design with + symbol.