### PR TITLE
feat: share collection and support for posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,8 @@ public/sw.js.map
 # AI Context Plans
 .plans
 
+# Screenshots
+.screenshots
+
 # Serena
 .serena

--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
@@ -29,7 +29,7 @@ import type { PostPreviewCardProps } from './PostPreviewCard.types';
  * - Reply previews: Shows the post being replied to (in DialogReply)
  * - Any nested context where a compact post preview is needed
  */
-export function PostPreviewCard({ postId, className }: PostPreviewCardProps) {
+export function PostPreviewCard({ postId, className, contrast }: PostPreviewCardProps) {
   const { navigateToPost } = usePostNavigation();
   const { ref: ttlRef } = useTtlSubscription({
     type: 'post',
@@ -62,7 +62,7 @@ export function PostPreviewCard({ postId, className }: PostPreviewCardProps) {
     >
       <CardContent className="flex min-w-0 flex-col gap-4 p-6">
         <PostHeader postId={postId} showPopover={false} />
-        <PostContentBase postId={postId} />
+        <PostContentBase postId={postId} contrast={contrast} />
       </CardContent>
     </Card>
   );

--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.types.ts
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.types.ts
@@ -3,4 +3,11 @@ export interface PostPreviewCardProps {
   postId: string;
   /** Optional className applied to the outer Card wrapper */
   className?: string;
+  /**
+   * Contrast hint forwarded to kind-specific preview renders inside the card
+   * (currently only collections use it). Default `'subtle'` is right when the
+   * preview card is itself the deepest surface; pass `'strong'` from callers
+   * that wrap it in additional card layers (e.g. timeline reposts).
+   */
+  contrast?: 'subtle' | 'strong';
 }

--- a/src/components/organisms/CollectionHero/CollectionHero.test.tsx
+++ b/src/components/organisms/CollectionHero/CollectionHero.test.tsx
@@ -4,6 +4,7 @@ import type { EnrichedPostDetails } from '@/application/moderation/moderation.ty
 import { TagKind } from '@/application/tag/tag.types';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { usePostReplyRepostDialogs } from '@/hooks/usePostReplyRepostDialogs/usePostReplyRepostDialogs';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { CollectionHero } from './CollectionHero';
@@ -31,6 +32,10 @@ vi.mock('@/hooks/useUserProfile/useUserProfile', () => ({
 
 vi.mock('@/hooks/useBookmark/useBookmark', () => ({
   useBookmark: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePostReplyRepostDialogs/usePostReplyRepostDialogs', () => ({
+  usePostReplyRepostDialogs: vi.fn(),
 }));
 
 vi.mock('@/stores/auth/auth.store', () => ({
@@ -108,6 +113,7 @@ const COLLECTION_CONTENT_NO_COVER = JSON.stringify({
 const mockUsePostDetails = vi.mocked(usePostDetails);
 const mockUseUserProfile = vi.mocked(useUserProfile);
 const mockUseBookmark = vi.mocked(useBookmark);
+const mockUsePostReplyRepostDialogs = vi.mocked(usePostReplyRepostDialogs);
 
 function setAuthStore(currentUserPubky: string | null) {
   mockUseAuthStore.mockImplementation((selector: (state: { currentUserPubky: string | null }) => unknown) =>
@@ -162,12 +168,24 @@ function setBookmark({ isBookmarked = false, isToggling = false } = {}) {
   return toggle;
 }
 
+function setRepostDialogs() {
+  const openRepostDialog = vi.fn();
+  const openReplyDialog = vi.fn();
+  mockUsePostReplyRepostDialogs.mockReturnValue({
+    openRepostDialog,
+    openReplyDialog,
+    dialogs: <div data-testid="repost-dialogs" />,
+  });
+  return { openRepostDialog, openReplyDialog };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   setAuthStore(null);
   setPostDetails(COLLECTION_CONTENT);
   setOwnerProfile('Bitcoin Wizard', 'https://example.com/avatar.png');
   setBookmark();
+  setRepostDialogs();
 });
 
 // ---------------------------------------------------------------------------
@@ -252,6 +270,19 @@ describe('CollectionHero', () => {
 
       expect(toggle).not.toHaveBeenCalled();
     });
+
+    it('opens the repost dialog when the owner clicks Share', () => {
+      setAuthStore(AUTHOR_PUBKY);
+      const { openRepostDialog } = setRepostDialogs();
+
+      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      fireEvent.click(screen.getByLabelText('collections.single.share'));
+
+      expect(openRepostDialog).toHaveBeenCalledTimes(1);
+      expect(mockUsePostReplyRepostDialogs).toHaveBeenCalledWith(COMPOSITE_ID);
+      expect(screen.getByTestId('repost-dialogs')).toBeInTheDocument();
+    });
   });
 
   describe('CTA — non-owner', () => {
@@ -295,6 +326,17 @@ describe('CollectionHero', () => {
       expect(button).toBeDisabled();
       fireEvent.click(button);
       expect(toggle).not.toHaveBeenCalled();
+    });
+
+    it('opens the repost dialog when a non-owner clicks Share', () => {
+      setAuthStore('some-other-user');
+      const { openRepostDialog } = setRepostDialogs();
+
+      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      fireEvent.click(screen.getByLabelText('collections.single.share'));
+
+      expect(openRepostDialog).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/organisms/CollectionHero/CollectionHero.test.tsx.snap
+++ b/src/components/organisms/CollectionHero/CollectionHero.test.tsx.snap
@@ -177,6 +177,9 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the non-owner Fol
       </button>
     </div>
   </div>
+  <div
+    data-testid="repost-dialogs"
+  />
 </div>
 `;
 
@@ -395,6 +398,9 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
       </button>
     </div>
   </div>
+  <div
+    data-testid="repost-dialogs"
+  />
 </div>
 `;
 
@@ -563,5 +569,8 @@ exports[`CollectionHero - Snapshots > matches the snapshot when no cover image a
       </button>
     </div>
   </div>
+  <div
+    data-testid="repost-dialogs"
+  />
 </div>
 `;

--- a/src/components/organisms/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/CollectionHero/CollectionHero.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/atoms/Skeleton/Skeleton';
 import { Typography } from '@/atoms/Typography/Typography';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { usePostReplyRepostDialogs } from '@/hooks/usePostReplyRepostDialogs/usePostReplyRepostDialogs';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { parseCollectionContent, resolveCollectionCoverImage } from '@/libs/post/collectionContent';
 import { cn } from '@/libs/utils/utils';
@@ -97,9 +98,12 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
     void toggle();
   };
 
+  // Sharing a collection = reposting the underlying post; reuse the standard dialog.
+  const { openRepostDialog, dialogs } = usePostReplyRepostDialogs(compositeId);
+  const handleShare = openRepostDialog;
+
   // Placeholder actions — the flows themselves are out of scope this slice.
-  // TODO: wire in collection share / edit / delete (#1866 follow-ups).
-  const handleShare = () => {};
+  // TODO: wire in collection edit / delete (#1866 follow-ups).
   const handleEdit = () => {};
   const handleDelete = () => {};
 
@@ -246,6 +250,7 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
           )}
         </Container>
       </CardContent>
+      {dialogs}
     </Card>
   );
 }

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
@@ -303,6 +303,49 @@ describe('CollectionCard', () => {
       expect(toggle).not.toHaveBeenCalled();
     });
   });
+
+  describe('variant="preview"', () => {
+    it('renders title, description, item count, and owner avatar', () => {
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} variant="preview" />);
+
+      expect(screen.getByText('Based Bitcoin')).toBeInTheDocument();
+      expect(screen.getByText('A bit of Bitcoin purity amidst all of the madness.')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-name', 'Bitcoin Wizard');
+    });
+
+    it('hides the inline tags row, Follow/Unfollow, and Delete actions for non-owners', () => {
+      setAuthStore('some-other-user');
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} variant="preview" />);
+
+      expect(screen.queryByTestId('clickable-tags-list')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.unfollow')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
+    });
+
+    it('hides the inline tags row and Delete action for the owner', () => {
+      setAuthStore(AUTHOR_PUBKY);
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} variant="preview" />);
+
+      expect(screen.queryByTestId('clickable-tags-list')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('preview contrast', () => {
+    it('keeps the action row hidden regardless of contrast value', () => {
+      setAuthStore('some-other-user');
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} variant="preview" contrast="strong" />);
+
+      expect(screen.queryByTestId('clickable-tags-list')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('CollectionCard - Snapshots', () => {

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -35,6 +35,21 @@ interface CollectionCardProps {
    * async existence check resolves to "Unfollow".
    */
   initialIsBookmarked?: boolean;
+  /**
+   * `'default'` (landing sections) renders the full card with inline tags and
+   * the Follow/Delete action. `'preview'` is the read-only embed used wherever
+   * a collection post is rendered as content (inline in a feed, or nested in
+   * another preview surface) — actions and tags row are dropped.
+   */
+  variant?: 'default' | 'preview';
+  /**
+   * Background contrast for the `preview` variant. `'subtle'` (default) uses
+   * `bg-muted` and is right when the parent is one `bg-card` step away.
+   * `'strong'` uses `bg-accent` for deeper nesting (e.g. timeline reposts,
+   * where the surrounding PostPreviewCard is itself already `bg-muted`).
+   * Ignored when there is a cover image (the cover overlay handles contrast).
+   */
+  contrast?: 'subtle' | 'strong';
 }
 
 /**
@@ -53,7 +68,14 @@ interface CollectionCardProps {
  * all the hooks that depend on the loaded envelope (`useBookmark` toast
  * copy reads from the parsed title, etc.).
  */
-export function CollectionCard({ authorPubky, postId, className, initialIsBookmarked }: CollectionCardProps) {
+export function CollectionCard({
+  authorPubky,
+  postId,
+  className,
+  initialIsBookmarked,
+  variant = 'default',
+  contrast = 'subtle',
+}: CollectionCardProps) {
   const compositeId = buildCompositeId({ pubky: authorPubky, id: postId });
   const { postDetails } = usePostDetails(compositeId);
 
@@ -69,6 +91,8 @@ export function CollectionCard({ authorPubky, postId, className, initialIsBookma
       postDetails={postDetails}
       className={className}
       initialIsBookmarked={initialIsBookmarked}
+      variant={variant}
+      contrast={contrast}
     />
   );
 }
@@ -80,6 +104,8 @@ interface CollectionCardContentProps {
   postDetails: EnrichedPostDetails;
   className?: string;
   initialIsBookmarked?: boolean;
+  variant: 'default' | 'preview';
+  contrast: 'subtle' | 'strong';
 }
 
 function CollectionCardContent({
@@ -89,7 +115,10 @@ function CollectionCardContent({
   postDetails,
   className,
   initialIsBookmarked,
+  variant,
+  contrast,
 }: CollectionCardContentProps) {
+  const isPreview = variant === 'preview';
   const t = useTranslations('collections.card');
   const tCardToast = useTranslations('collections.card.toast');
   const format = useFormatter();
@@ -162,6 +191,11 @@ function CollectionCardContent({
         className={cn(
           'relative h-full gap-0 overflow-hidden rounded-md py-0',
           coverImage && 'border-transparent bg-card/40',
+          // Preview contexts pick their bg based on how nested they are:
+          // one card-step deep (inline feed, dialog repost) reads fine on `bg-muted`,
+          // two steps deep (timeline repost — PostPreviewCard already uses `bg-muted`)
+          // needs `bg-accent` to stay distinct.
+          isPreview && !coverImage && (contrast === 'strong' ? 'bg-accent' : 'bg-muted'),
         )}
       >
         {coverImage && (
@@ -221,51 +255,56 @@ function CollectionCardContent({
             </Typography>
           )}
 
-          {/* Bottom row: tags (left, grows) | action button (right) */}
-          <Container
-            overrideDefaults
-            onClick={suppressCardNavigation}
-            onAuxClick={suppressCardNavigation}
-            className="flex w-full flex-wrap items-center justify-between gap-3 sm:flex-nowrap"
-          >
-            <Container overrideDefaults className="min-w-0 flex-1">
-              <ClickableTagsList
-                taggedId={compositeId}
-                taggedKind={TagKind.POST}
-                showCount={true}
-                showInput={false}
-                showAddButton={true}
-                addMode={true}
-              />
-            </Container>
+          {/* Bottom row: tags (left, grows) | action button (right).
+              Hidden in `preview` so embedded collections (repost dialog, repost
+              previews) match how normal reposts render — no inline tags, no
+              actions on the previewed post. */}
+          {!isPreview && (
+            <Container
+              overrideDefaults
+              onClick={suppressCardNavigation}
+              onAuxClick={suppressCardNavigation}
+              className="flex w-full flex-wrap items-center justify-between gap-3 sm:flex-nowrap"
+            >
+              <Container overrideDefaults className="min-w-0 flex-1">
+                <ClickableTagsList
+                  taggedId={compositeId}
+                  taggedKind={TagKind.POST}
+                  showCount={true}
+                  showInput={false}
+                  showAddButton={true}
+                  addMode={true}
+                />
+              </Container>
 
-            <Container overrideDefaults className="flex shrink-0 items-center gap-2">
-              {isOwn ? (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleDelete}
-                  aria-label={t('delete')}
-                  className="gap-2 text-xs"
-                >
-                  <Trash2 className="size-4" />
-                  {t('delete')}
-                </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleFollowToggle}
-                  disabled={isToggling}
-                  aria-label={isBookmarked ? t('unfollow') : t('follow')}
-                  className="gap-2 text-xs"
-                >
-                  {isBookmarked ? <Minus className="size-4" /> : <Plus className="size-4" />}
-                  {isBookmarked ? t('unfollow') : t('follow')}
-                </Button>
-              )}
+              <Container overrideDefaults className="flex shrink-0 items-center gap-2">
+                {isOwn ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleDelete}
+                    aria-label={t('delete')}
+                    className="gap-2 text-xs"
+                  >
+                    <Trash2 className="size-4" />
+                    {t('delete')}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleFollowToggle}
+                    disabled={isToggling}
+                    aria-label={isBookmarked ? t('unfollow') : t('follow')}
+                    className="gap-2 text-xs"
+                  >
+                    {isBookmarked ? <Minus className="size-4" /> : <Plus className="size-4" />}
+                    {isBookmarked ? t('unfollow') : t('follow')}
+                  </Button>
+                )}
+              </Container>
             </Container>
-          </Container>
+          )}
         </CardContent>
       </Card>
     </Link>

--- a/src/components/organisms/PostContent/PostContent.tsx
+++ b/src/components/organisms/PostContent/PostContent.tsx
@@ -26,7 +26,9 @@ export function PostContent({ postId, className, textClassName }: PostContentOrg
       <PostContentBase postId={postId} className={className} textClassName={textClassName} />
 
       {/* Show original post preview for reposts */}
-      {shouldRenderRepostPreview && <PostPreviewCard postId={originalPostId} className={'bg-muted'} />}
+      {shouldRenderRepostPreview && (
+        <PostPreviewCard postId={originalPostId} className={'bg-muted'} contrast="strong" />
+      )}
     </>
   );
 }

--- a/src/components/organisms/PostContentBase/PostContentBase.test.tsx
+++ b/src/components/organisms/PostContentBase/PostContentBase.test.tsx
@@ -81,6 +81,30 @@ vi.mock('../PostArticle/PostArticle', () => ({
   PostArticle: vi.fn(({ content }: { content: string }) => <div data-testid="post-article">{content}</div>),
 }));
 
+vi.mock('@/organisms/Collections/CollectionCard/CollectionCard', () => ({
+  CollectionCard: vi.fn(
+    ({
+      authorPubky,
+      postId,
+      variant,
+      contrast,
+    }: {
+      authorPubky: string;
+      postId: string;
+      variant?: string;
+      contrast?: string;
+    }) => (
+      <div
+        data-testid="collection-card"
+        data-author-pubky={authorPubky}
+        data-post-id={postId}
+        data-variant={variant}
+        data-contrast={contrast ?? ''}
+      />
+    ),
+  ),
+}));
+
 vi.mock('../PostAttachments/PostAttachments', () => ({
   PostAttachments: vi.fn(() => <div data-testid="post-attachments" />),
 }));
@@ -103,7 +127,7 @@ const createMockPostDetails = (
     content: string;
     attachments: string[] | null;
     is_blurred: boolean;
-    kind: 'short' | 'long';
+    kind: 'short' | 'long' | 'collection';
   }> = {},
 ): EnrichedPostDetails => ({
   id: 'test-author:test-post',
@@ -275,6 +299,42 @@ describe('PostContentBase', () => {
 
     expect(screen.getByTestId('post-article')).toBeInTheDocument();
     expect(screen.queryByTestId('container')).not.toBeInTheDocument();
+  });
+
+  it('renders CollectionCard (preview variant) when kind is collection', () => {
+    mockUsePostDetails.mockReturnValue({
+      postDetails: createMockPostDetails({
+        content: '{"name":"My Collection"}',
+        kind: 'collection',
+      }),
+      isLoading: false,
+    });
+
+    render(<PostContentBase postId="author-pubky:raw-post-id" className="custom-class" />);
+
+    const card = screen.getByTestId('collection-card');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('data-author-pubky', 'author-pubky');
+    expect(card).toHaveAttribute('data-post-id', 'raw-post-id');
+    expect(card).toHaveAttribute('data-variant', 'preview');
+    expect(screen.queryByTestId('container')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('post-article')).not.toBeInTheDocument();
+  });
+
+  it('forwards contrast to CollectionCard for the collection branch', () => {
+    mockUsePostDetails.mockReturnValue({
+      postDetails: createMockPostDetails({
+        content: '{"name":"My Collection"}',
+        kind: 'collection',
+      }),
+      isLoading: false,
+    });
+
+    render(<PostContentBase postId="author-pubky:raw-post-id" contrast="strong" />);
+
+    const card = screen.getByTestId('collection-card');
+    expect(card).toHaveAttribute('data-variant', 'preview');
+    expect(card).toHaveAttribute('data-contrast', 'strong');
   });
 
   it('prioritizes is_blurred over kind for blurred articles', () => {

--- a/src/components/organisms/PostContentBase/PostContentBase.tsx
+++ b/src/components/organisms/PostContentBase/PostContentBase.tsx
@@ -3,9 +3,11 @@
 import { Container } from '@/atoms/Container/Container';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { cn, isPostDeleted } from '@/libs/utils/utils';
+import { parseCompositeId } from '@/models/models.utils';
 import { PostDeleted } from '@/molecules/PostDeleted/PostDeleted';
 import { PostLinkEmbeds } from '@/molecules/PostLinkEmbeds/PostLinkEmbeds';
 import { PostText } from '@/molecules/PostText/PostText';
+import { CollectionCard } from '@/organisms/Collections/CollectionCard/CollectionCard';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 import { PostArticle } from '../PostArticle/PostArticle';
 import { PostAttachments } from '../PostAttachments/PostAttachments';
@@ -18,7 +20,7 @@ import type { PostContentBaseProps } from './PostContentBase.types';
  * This component is used internally by PostContent and PostPreviewCard.
  * It only renders the content elements: text, link embeds, and attachments.
  */
-export function PostContentBase({ postId, className, textClassName }: PostContentBaseProps) {
+export function PostContentBase({ postId, className, textClassName, contrast }: PostContentBaseProps) {
   const localAttachments = useLocalFilesStore((s) => s.posts[postId]);
 
   // Fetch post details for content
@@ -32,6 +34,7 @@ export function PostContentBase({ postId, className, textClassName }: PostConten
   const hasContent = postDetails.content.trim().length > 0;
   const isBlurred = postDetails.is_blurred;
   const isArticle = postDetails.kind === 'long';
+  const isCollection = postDetails.kind === 'collection';
 
   if (isDeleted) return <PostDeleted />;
 
@@ -46,6 +49,13 @@ export function PostContentBase({ postId, className, textClassName }: PostConten
         className={className}
       />
     );
+
+  if (isCollection) {
+    const { pubky, id } = parseCompositeId(postId);
+    return (
+      <CollectionCard authorPubky={pubky} postId={id} variant="preview" contrast={contrast} className={className} />
+    );
+  }
 
   if (!hasContent && !postDetails.attachments?.length && !localAttachments) return null;
 

--- a/src/components/organisms/PostContentBase/PostContentBase.types.ts
+++ b/src/components/organisms/PostContentBase/PostContentBase.types.ts
@@ -2,4 +2,10 @@ export interface PostContentBaseProps {
   postId: string;
   className?: string;
   textClassName?: string;
+  /**
+   * Forwarded to kind-specific preview renders that need a contrast hint.
+   * Used by the collection branch to pick `bg-muted` (subtle, default) vs
+   * `bg-accent` (strong) based on how deeply this content is nested.
+   */
+  contrast?: 'subtle' | 'strong';
 }

--- a/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
+++ b/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
@@ -537,6 +537,20 @@ describe('usePostMenuActions', () => {
       expect(copyTextItem).toBeUndefined();
     });
 
+    it('does not include copy text action for collections', () => {
+      mockUsePostDetails.mockReturnValue({
+        postDetails: { id: 'post789', content: '{"name":"My Collection"}', kind: 'collection' },
+        isLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        usePostMenuActions(mockPostId, { onReportClick: vi.fn(), onEditClick: vi.fn(), onDeleteClick: vi.fn() }),
+      );
+
+      const copyTextItem = result.current.menuItems.find((item) => item.id === POST_MENU_ACTION_IDS.COPY_TEXT);
+      expect(copyTextItem).toBeUndefined();
+    });
+
     it('calls copyToClipboard with post content on copy text click', async () => {
       const { result } = renderHook(() =>
         usePostMenuActions(mockPostId, { onReportClick: vi.fn(), onEditClick: vi.fn(), onDeleteClick: vi.fn() }),

--- a/src/hooks/usePostMenuActions/usePostMenuActions.tsx
+++ b/src/hooks/usePostMenuActions/usePostMenuActions.tsx
@@ -77,6 +77,9 @@ export function usePostMenuActions(postId: string, options: UsePostMenuActionsOp
   const rawUsername = authorProfile?.name || postAuthorId;
   const username = truncateString(rawUsername, 15);
   const isArticle = postDetails?.kind === 'long';
+  // Collections store a JSON envelope in `content`; copying that raw JSON would
+  // be useless to the user, so we hide "Copy text" for them just like articles.
+  const isCollection = postDetails?.kind === 'collection';
   const isLoading = isPostLoading || isAuthorLoading || isFollowingLoading || isMutedUsersLoading;
   const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}${POST_ROUTES.POST}/${parsedId.pubky}/${parsedId.id}`;
   const menuItems: PostMenuActionItem[] = [];
@@ -137,7 +140,7 @@ export function usePostMenuActions(postId: string, options: UsePostMenuActionsOp
     },
     variant: POST_MENU_ACTION_VARIANTS.DEFAULT,
   });
-  if (!isArticle) {
+  if (!isArticle && !isCollection) {
     menuItems.push({
       id: POST_MENU_ACTION_IDS.COPY_TEXT,
       label: t('copyText'),


### PR DESCRIPTION
## Summary

  Hooks up the Share button on `CollectionHero` and teaches the post-rendering
   pipeline to display collection posts as a `CollectionCard` wherever they
  appear. Sharing a collection now reuses the existing repost flow, since a
  collection is just a post with `kind === 'collection'` and a JSON envelope
  in its content.

  ## What changed

  ### ✨ Share a collection (= repost it)
  - `CollectionHero` no longer stubs `handleShare`. It now opens
  `DialogRepost` via `usePostReplyRepostDialogs(compositeId)` and renders the
  returned `{dialogs}` JSX.
  - Both the owner Share button and the non-owner Share button are wired to
  the same handler.
  - No new dialog, no new mutation — the existing repost infrastructure
  already accepts any post id and writes the `embed` field correctly
  regardless of original kind.

  ### 🧱 Collections render as `CollectionCard` everywhere
  - Added a `kind === 'collection'` branch in `PostContentBase` that splits
  the composite id via `parseCompositeId` and renders `<CollectionCard
  variant="preview" ... />`.
  - One branch covers every consumer:
    - **Timeline / profile feeds** (`Posts.tsx` → `PostMain` → `PostContent` →
   `PostContentBase`)
    - **DialogRepost compose preview** (`PostInput` → `PostPreviewCard` →
  `PostContentBase`)
    - **Embedded preview of a repost-of-a-collection** (`PostContent` →
  `PostPreviewCard` → `PostContentBase`)

  ### 🎨 `CollectionCard` gains a `preview` variant and contrast control
  - New `variant?: 'default' | 'preview'` prop:
    - `default` — unchanged landing-section card with inline tags +
  Follow/Delete.
    - `preview` — read-only embed for posts contexts: bottom action row
  (inline tags + Follow/Delete) is hidden, matching how normal reposts behave.
  - New `contrast?: 'subtle' | 'strong'` prop:
    - `subtle` (default) → `bg-muted` — right when the parent is one `bg-card`
   step away (inline timeline, dialog repost preview).
    - `strong` → `bg-accent` — for deeper nesting (timeline reposts, where the
   wrapping `PostPreviewCard` is itself already `bg-muted`).
    - Ignored when there's a cover image — the existing `bg-card/40` cover
  overlay handles contrast.

  ### 🪜 Contrast plumbing through the preview tree
  - `PostContentBase` gained a `contrast?: 'subtle' | 'strong'` prop,
  forwarded into the collection branch.
  - `PostPreviewCard` gained a `contrast?` prop and forwards it to its
  `PostContentBase`.
  - `PostContent` passes `contrast="strong"` to the timeline repost preview —
  the only site that needs it.

  ### 🧹 Edge case fix: "Copy text of post" for collections
  - `usePostMenuActions` already hid the "Copy text" item for articles (whose
  content is JSON). Extended the same gate to collections so users don't copy
  raw JSON envelopes.

  ## Tests

  - New CollectionHero tests asserting Share opens the repost dialog (owner
  and non-owner).
  - New CollectionCard tests for `variant="preview"` (no tags, no actions) and
   the `contrast` axis.
  - New PostContentBase test for the `kind === 'collection'` branch and
  `contrast` forwarding.
  - New `usePostMenuActions` test mirroring the article gate for collections.
  - Snapshots regenerated.
  - ✅ Full vitest run: **10,193 passed** / 0 failed.
  - ✅ `npm run typecheck` clean.
  - ✅ `npm run lint` clean.

  ---

  _This pull request summary was generated, for full implementation details
  please reference the file changes._