### PR TITLE
refactor: filter empty collections from discover section

### DIFF
--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
@@ -97,6 +97,9 @@ vi.mock('@/organisms/Collections/CollectionCard/CollectionCard.skeleton', () => 
 // Helpers
 // ---------------------------------------------------------------------------
 
+const collectionContent = (items: string[] = ['item:1']) =>
+  JSON.stringify({ name: 'Test Collection', items, description: '', cover_image: '' });
+
 const mockUseLiveQuery = vi.mocked(useLiveQuery);
 const mockGetOrFetchStreamSlice = vi.mocked(StreamPostsController.getOrFetchStreamSlice);
 const mockPrepareStreamForInitialLoad = vi.mocked(StreamPostsController.prepareStreamForInitialLoad);
@@ -316,7 +319,32 @@ describe('DiscoverCollections', () => {
     mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2'], reachedEnd: true }));
     mockGetDetailsByIds.mockResolvedValue([
       asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: '[DELETED]' }),
-      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: 'live' }),
+      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent() }),
+    ]);
+
+    await act(async () => {
+      render(<DiscoverCollections />);
+    });
+
+    await waitFor(() => {
+      const cards = screen.getAllByTestId('collection-card');
+      expect(cards).toHaveLength(1);
+      expect(cards[0]).toHaveAttribute('data-author-pubky', 'b');
+      expect(cards[0]).toHaveAttribute('data-post-id', '2');
+    });
+  });
+
+  it('fetch-time filter drops slice ids whose local PostDetails has zero items', async () => {
+    // Fourth filter layer (after own / followed / deleted): collections with
+    // an empty `items` array have nothing to discover, so they shouldn't reach
+    // `visibleIds`. Unparseable content (null envelope) is treated the same as
+    // empty — defensive against malformed content drifting in from Nexus.
+    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
+    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2', 'c:3'], reachedEnd: true }));
+    mockGetDetailsByIds.mockResolvedValue([
+      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: collectionContent([]) }),
+      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent(['x:1']) }),
+      asOpaque<PostDetailsModelSchema>({ id: 'c:3', kind: 'collection', content: 'not-json' }),
     ]);
 
     await act(async () => {
@@ -341,8 +369,8 @@ describe('DiscoverCollections', () => {
     // Fetch-time details are clean (live content); deletion only happens
     // mid-session and is surfaced by the live overlay.
     mockGetDetailsByIds.mockResolvedValue([
-      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: 'live' }),
-      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: 'live' }),
+      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: collectionContent() }),
+      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent() }),
     ]);
     // Two live queries — bookmarks (deps: []) returns []; deletions (deps:
     // [visibleIds]) returns the deleted-id Set.

--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
@@ -17,6 +17,7 @@ import { BookmarkController } from '@/controllers/bookmark/bookmark';
 import { PostController } from '@/controllers/post/post';
 import { StreamPostsController } from '@/controllers/stream/posts/posts';
 import { Logger } from '@/libs/logger/logger';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { isPostDeleted } from '@/libs/utils/utils';
 import { parseCompositeId } from '@/models/models.utils';
 import { buildDiscoverCollectionsStreamId } from '@/models/stream/post/postStream.types';
@@ -52,6 +53,8 @@ const EMPTY_CURSOR: DiscoverCursor = { lastPostId: undefined, streamTail: 0 };
  * filters out:
  *   - The current user's own collections.
  *   - Collections the current user has already bookmarked (followed).
+ *   - Collections whose local PostDetails is tombstoned (`'[DELETED]'`).
+ *   - Collections with zero items (nothing to discover).
  *
  * Filtering happens in two layers:
  *
@@ -181,19 +184,27 @@ export function DiscoverCollections() {
         let reachedPageCap = false;
         if (result.nextPageIds.length > 0) {
           // Read the local bookmark set after persist has committed.
-          // Filter own + already-bookmarked + deleted collections.
+          // Filter own + already-bookmarked + deleted + empty collections.
           const bookmarkedIds = new Set(await BookmarkController.getAll());
           if (token?.cancelled) return;
-          // Slice post details to identify already-deleted collections in this
-          // batch. Mirrors the timeline's `isPostDeleted` guard in
-          // `useVisualFeedTiles` and FollowedCollections' live-query filter.
+          // Slice post details to identify already-deleted and empty
+          // collections in this batch. Mirrors the timeline's `isPostDeleted`
+          // guard in `useVisualFeedTiles` and FollowedCollections' live-query
+          // filter; the empty-items check drops collections with nothing to
+          // discover.
           const sliceDetails = await PostController.getDetailsByIds({ compositeIds: result.nextPageIds });
           if (token?.cancelled) return;
           const deletedIds = new Set<string>();
+          const emptyIds = new Set<string>();
           for (let i = 0; i < result.nextPageIds.length; i += 1) {
             const detail = sliceDetails[i];
-            if (detail && isPostDeleted(detail.content)) {
+            if (!detail) continue;
+            if (isPostDeleted(detail.content)) {
               deletedIds.add(result.nextPageIds[i]);
+              continue;
+            }
+            if ((parseCollectionContent(detail.content)?.items?.length ?? 0) === 0) {
+              emptyIds.add(result.nextPageIds[i]);
             }
           }
           const alreadyVisible = new Set([...visibleIdsRef.current, ...collected]);
@@ -203,6 +214,7 @@ export function DiscoverCollections() {
             if (alreadyVisible.has(id)) continue;
             if (bookmarkedIds.has(id)) continue;
             if (deletedIds.has(id)) continue;
+            if (emptyIds.has(id)) continue;
             if (isOwnCollection(id, currentUserPubky)) continue;
             collected.push(id);
             alreadyVisible.add(id);
@@ -302,28 +314,34 @@ export function DiscoverCollections() {
   // first paint.
   const bookmarkedLive = useLiveQuery(() => BookmarkController.getAll(), []);
   const bookmarkedSet = bookmarkedLive ? new Set(bookmarkedLive) : null;
-  // Live overlay for deletions: subscribes to `post_details` (via
-  // `getDetailsByIds`) for the current visible set and returns the subset whose
-  // content has flipped to '[DELETED]'. This catches deletions that happen
-  // mid-session — e.g. an author deletes a collection on another device — so
-  // the card disappears from Discover without a reload. The fetch-time filter
-  // covers the cold path; this overlay covers the live path.
-  const deletedLive = useLiveQuery(async () => {
+  // Live overlay for deletions + empty collections: subscribes to `post_details`
+  // (via `getDetailsByIds`) for the current visible set and returns the subset
+  // whose content has flipped to '[DELETED]' OR whose item count has fallen to
+  // zero. Catches mid-session changes — e.g. an author deletes a collection or
+  // removes its last item on another device — so the card disappears from
+  // Discover without a reload. The fetch-time filter covers the cold path; this
+  // overlay covers the live path.
+  const hideLive = useLiveQuery(async () => {
     if (visibleIds.length === 0) return new Set<string>();
     const details = await PostController.getDetailsByIds({ compositeIds: visibleIds });
-    const deleted = new Set<string>();
+    const hide = new Set<string>();
     for (let i = 0; i < visibleIds.length; i += 1) {
       const detail = details[i];
-      if (detail && isPostDeleted(detail.content)) {
-        deleted.add(visibleIds[i]);
+      if (!detail) continue;
+      if (isPostDeleted(detail.content)) {
+        hide.add(visibleIds[i]);
+        continue;
+      }
+      if ((parseCollectionContent(detail.content)?.items?.length ?? 0) === 0) {
+        hide.add(visibleIds[i]);
       }
     }
-    return deleted;
+    return hide;
   }, [visibleIds]);
-  const deletedSet = deletedLive ?? null;
+  const hideSet = hideLive ?? null;
   const displayIds = visibleIds.filter((id) => {
     if (bookmarkedSet && bookmarkedSet.has(id)) return false;
-    if (deletedSet && deletedSet.has(id)) return false;
+    if (hideSet && hideSet.has(id)) return false;
     return true;
   });
 


### PR DESCRIPTION
## Summary

  Adds a fourth filter layer to `DiscoverCollections` that hides collections with zero items — there's nothing to discover
   in an empty collection. Slots in alongside the existing own / followed / deleted filters.

  ## Changes

  ### `DiscoverCollections.tsx`

  - 📦 Imported `parseCollectionContent` from `@/libs/post/collectionContent` to read the items array off the local
  `post_details` envelope.
  - 📝 Expanded the component docstring's filter list to call out all four layers (own / followed / deleted / empty).
  - 🪛 **Fetch-time filter**: built an `emptyIds` set inside the existing slice walk — alongside `deletedIds` — using
  `(parseCollectionContent(detail.content)?.items?.length ?? 0) === 0`. Added `if (emptyIds.has(id)) continue;` to the
  candidate loop. Unparseable envelopes (returns `null`) are treated as empty.
  - 🪛 **Live overlay**: folded the empty-items check into the existing `deletedLive` subscription. Renamed `deletedLive`
  / `deletedSet` → `hideLive` / `hideSet` since it now subtracts both deleted and empty ids. No additional
  `getDetailsByIds` subscription — both checks ride the same observer.

  ### `DiscoverCollections.test.tsx`

  - 🧪 Added a `collectionContent(items)` helper that emits a valid envelope (`{ name, items, description, cover_image
  }`).
  - 🧪 Updated the two existing deletion tests so their "keeper" rows use real envelopes — the previous `'live'` stand-in
  would now be flagged as empty by the new filter.
  - 🧪 Added a new test asserting the fetch-time filter drops both zero-item collections and unparseable content, while
  keeping collections with at least one item.

  ### Pagination

  Unchanged. The cursor (`lastPostId` + `streamTail`) advances by `rawConsumed` — raw stream ids walked, not ids kept — so
   empty/filtered ids still move the cursor forward. The backfill loop (capped by
  `COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS`) refills the page when the filter empties a slice. The live overlay only
  subtracts from the rendered list and never touches `visibleIds` or the cursor, so "Show more" semantics are intact.

  _This pull request summary was generated, for full implementation details please reference the file changes._