### PR TITLE
build: bump pubky app specs to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "next": "16.2.6",
         "next-intl": "4.12.0",
         "next-themes": "0.4.6",
-        "pubky-app-specs": "0.5.2-rc2",
+        "pubky-app-specs": "0.5.3",
         "qrcode.react": "4.2.0",
         "radix-ui": "1.4.3",
         "react": "19.2.6",
@@ -16580,9 +16580,9 @@
       "license": "MIT"
     },
     "node_modules/pubky-app-specs": {
-      "version": "0.5.2-rc2",
-      "resolved": "https://registry.npmjs.org/pubky-app-specs/-/pubky-app-specs-0.5.2-rc2.tgz",
-      "integrity": "sha512-sgj6YWfUddaWEC1LHo9pn7vZw8xLwDKlM/gkLMtQXnKZBiqXTH9tiL8qUugF/86smdKXXAtXYYTqNdjFMwHKlQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/pubky-app-specs/-/pubky-app-specs-0.5.3.tgz",
+      "integrity": "sha512-Yl6+h0hUAXoWYt7B5KY7TI18NcYmakQNX8xpRUoFAxoUCVzwKhqImEmtiPr4o4n/SGokroUpIGtb1NpbdpWoWw==",
       "license": "MIT"
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "next": "16.2.6",
     "next-intl": "4.12.0",
     "next-themes": "0.4.6",
-    "pubky-app-specs": "0.5.2-rc2",
+    "pubky-app-specs": "0.5.3",
     "qrcode.react": "4.2.0",
     "radix-ui": "1.4.3",
     "react": "19.2.6",

--- a/src/core/models/feed/feed.helpers.ts
+++ b/src/core/models/feed/feed.helpers.ts
@@ -20,6 +20,7 @@ export function layoutToString(layout: PubkyAppFeedLayout): string {
     [PubkyAppFeedLayout.Columns]: 'columns',
     [PubkyAppFeedLayout.Wide]: 'wide',
     [PubkyAppFeedLayout.Visual]: 'visual',
+    [PubkyAppFeedLayout.List]: 'list',
   };
   return map[layout];
 }


### PR DESCRIPTION
## 📦 Upgrade `pubky-app-specs` 0.5.2-rc2 → 0.5.3

  Bumps `pubky-app-specs` to the new stable release and adapts the codebase to the only TypeScript-level break introduced
  by the upgrade.

  ### 🔍 What changed upstream

  Audited the full [v0.5.2…v0.5.3 diff](https://github.com/pubky/pubky-app-specs/compare/v0.5.2...v0.5.3.diff):

  - ➕ New enum variant `PubkyAppFeedLayout.List` (additive)
  - 📈 `postAttachmentsMaxCount` limit relaxed: **4 → 10** (consumed dynamically via `validationLimits`, no source change
  required)
  - 🦀 `PubkyId` gained `Eq, Hash` derives (Rust-only, no JS impact)
  - 🔧 Internal Rust dep bumps: `pubky` 0.8.0 → 0.9.1, `pkarr` 6.0.0 → 6.0.1 (no JS impact)

  No `.d.ts` removals, renames, signature changes, or required-field changes.

  ### 🛠️  Code changes

  - **`package.json`** — bumped `pubky-app-specs` to `0.5.3`
  - **`src/core/models/feed/feed.helpers.ts`** — added `[PubkyAppFeedLayout.List]: 'list'` to the exhaustive
  `Record<PubkyAppFeedLayout, string>` in `layoutToString` (the only place where `tsc` would have failed against the new
  enum variant)

  ### 🧭 Audited but intentionally untouched

  - **`src/core/utils/pubky-app-spec-feed-mappers.ts`** — switch statements already use `default: return undefined`, so
  `List` safely falls back to "no home equivalent" (same pattern used for `PubkyAppFeedReach.Followers`)
  - **`src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx`** — the layout option array does not need to
  enumerate every spec variant; adding a "List" UI option is a product feature, not a compat fix
  - **`src/core/stores/home/home.types.ts` `LAYOUT`** — kept as 3 layouts; expanding the home store is out of scope for a
  version bump

  ### ✅ Verification

  - 🧪 `npx tsc --noEmit` — clean
  - 🧪 `npx vitest run` — **648 files, 10393 passed, 4 skipped, 0 failed**

  _This pull request summary was generated, for full implementation details please reference the file changes._