### PR TITLE
fix(#1801): add missing translations for post page header title

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -442,6 +442,8 @@
     "addArticle": "اضافة مقال",
     "posting": "جاري النشر...",
     "viewOriginal": "عرض المنشور الاصلي",
+    "postBy": "منشور بواسطة",
+    "replyBy": "رد بواسطة",
     "youReposted": "أعدت النشر",
     "newPostsSingular": "عرض {count} منشور جديد",
     "newPostsPlural": "عرض {count} منشورات جديدة",

--- a/messages/de.json
+++ b/messages/de.json
@@ -442,6 +442,8 @@
     "addArticle": "Artikel hinzufügen",
     "posting": "Wird gepostet...",
     "viewOriginal": "Originalbeitrag ansehen",
+    "postBy": "Beitrag von",
+    "replyBy": "Antwort von",
     "youReposted": "Du hast geteilt",
     "newPostsSingular": "{count} neuen Beitrag anzeigen",
     "newPostsPlural": "{count} neue Beiträge anzeigen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -442,6 +442,8 @@
     "addArticle": "Add article",
     "posting": "Posting...",
     "viewOriginal": "View original post",
+    "postBy": "Post by",
+    "replyBy": "Reply by",
     "youReposted": "You reposted",
     "newPostsSingular": "See {count} new post",
     "newPostsPlural": "See {count} new posts",

--- a/messages/es.json
+++ b/messages/es.json
@@ -450,6 +450,8 @@
     "addArticle": "Agregar articulo",
     "posting": "Publicando...",
     "viewOriginal": "Ver publicación original",
+    "postBy": "Publicado por",
+    "replyBy": "Respondido por",
     "youReposted": "Republicaste",
     "newPostsSingular": "Ver {count} nueva publicación",
     "newPostsPlural": "Ver {count} nuevas publicaciónes",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -442,6 +442,8 @@
     "addArticle": "Ajouter un article",
     "posting": "Publication en cours...",
     "viewOriginal": "Voir la publication originale",
+    "postBy": "Publié par",
+    "replyBy": "Répondu par",
     "youReposted": "Vous avez republié",
     "newPostsSingular": "Voir {count} nouvelle publication",
     "newPostsPlural": "Voir {count} nouvelles publications",

--- a/messages/it.json
+++ b/messages/it.json
@@ -442,6 +442,8 @@
     "addArticle": "Aggiungi articolo",
     "posting": "Pubblicazione...",
     "viewOriginal": "Vedi post originale",
+    "postBy": "Pubblicato da",
+    "replyBy": "Risposto da",
     "youReposted": "Hai ripubblicato",
     "newPostsSingular": "Vedi {count} nuovo post",
     "newPostsPlural": "Vedi {count} nuovi post",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -442,6 +442,8 @@
     "addArticle": "記事を追加",
     "posting": "投稿中...",
     "viewOriginal": "元の投稿を見る",
+    "postBy": "投稿者",
+    "replyBy": "返信者",
     "youReposted": "リポストしました",
     "newPostsSingular": "{count}件の新しい投稿を見る",
     "newPostsPlural": "{count}件の新しい投稿を見る",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -442,6 +442,8 @@
     "addArticle": "Adicionar artigo",
     "posting": "Publicando...",
     "viewOriginal": "Ver post original",
+    "postBy": "Publicado por",
+    "replyBy": "Respondido por",
     "youReposted": "Você repostou",
     "newPostsSingular": "Ver {count} novo post",
     "newPostsPlural": "Ver {count} novos posts",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -442,6 +442,8 @@
     "addArticle": "添加文章",
     "posting": "发布中...",
     "viewOriginal": "查看原帖",
+    "postBy": "发布者",
+    "replyBy": "回复者",
     "youReposted": "你转发了",
     "newPostsSingular": "查看 {count} 条新帖子",
     "newPostsPlural": "查看 {count} 条新帖子",

--- a/src/components/organisms/PostPageHeader/PostPageHeader.tsx
+++ b/src/components/organisms/PostPageHeader/PostPageHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useTranslations } from 'next-intl';
 import { Container } from '@/atoms/Container/Container';
 import { PageHeader } from '@/atoms/PageHeader/PageHeader';
 import { Typography } from '@/atoms/Typography/Typography';
@@ -31,6 +32,7 @@ import type { PostPageHeaderProps } from './PostPageHeader.types';
  * ```
  */
 export function PostPageHeader({ postId }: PostPageHeaderProps) {
+  const t = useTranslations('post');
   const { ancestors, isLoading: ancestorsLoading } = usePostAncestors(postId);
   const { navigateToPost } = usePostNavigation();
 
@@ -65,7 +67,7 @@ export function PostPageHeader({ postId }: PostPageHeaderProps) {
     return <PostPageHeaderSkeleton />;
   }
 
-  const titlePrefix = hasParents ? 'Reply by' : 'Post by';
+  const titlePrefix = hasParents ? t('replyBy') : t('postBy');
 
   return (
     <PageHeader data-testid="post-page-header" className="pt-0 pb-3">


### PR DESCRIPTION
## Summary
- fix #1801
- `Post by` / `Reply by` in the post page header were hardcoded English literals, so non-English locales (e.g. German) rendered English text instead of a translation.
- Wire both prefixes through `next-intl` and provide translations for all 9 supported locales.

## Changes
- `PostPageHeader.tsx`: add `useTranslations('post')` and replace the hardcoded `'Post by'` / `'Reply by'` with `t('postBy')` / `t('replyBy')`.
- Add `postBy` / `replyBy` keys to the `post` namespace in every locale file (`en`, `de`, `es`, `fr`, `it`, `ja`, `pt-BR`, `zh`, `ar`).
- German resolves to `Beitrag von` (matches the issue's expected behaviour).

## Test plan
- [x] `npm run test PostPageHeader` — 8 tests pass, snapshots unchanged (English values identical, so no snapshot churn).
- [ ] German locale, root post → title reads `Beitrag von <name>`.
- [ ] German locale, reply → title reads `Antwort von <name>`.

## Notes
- The prefix and author name are kept as separate strings (not one interpolated message) because the layout relies on placing the name in its own truncating `<span>`.