### PR TITLE
Fix and optimize landing header actions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -828,7 +828,7 @@ body {
   }
 
   :root[data-landing-swirl='final'] .landing-swirl-background__graphic {
-    --landing-swirl-size: min(2500vw, 110rem);
+    --landing-swirl-size: min(320vw, 80rem);
     --landing-swirl-clip: circle(75% at 50% 50%);
     --landing-swirl-mask-hole: 35%;
     --landing-swirl-mask-ring-start: 36%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -845,14 +845,6 @@ body {
     will-change: transform;
   }
 
-  :root[data-landing-swirl='broken'] .landing-hero-brand-footer,
-  :root[data-landing-swirl='how'] .landing-hero-brand-footer,
-  :root[data-landing-swirl='freedom'] .landing-hero-brand-footer,
-  :root[data-landing-swirl='final'] .landing-hero-brand-footer {
-    pointer-events: none;
-    opacity: 0;
-  }
-
   @media (min-width: 1024px) {
     .landing-swirl-background__graphic {
       --landing-swirl-size: min(75vw, 60rem);

--- a/src/components/molecules/HeaderHome/HeaderHome.test.tsx
+++ b/src/components/molecules/HeaderHome/HeaderHome.test.tsx
@@ -1,14 +1,48 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { usePathname } from 'next/navigation';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ONBOARDING_ROUTES } from '@/app/routes';
+import { LANDING_HERO_SECTION_ID } from '@/templates/Public/Landing/Landing.constants';
 import { HeaderHome } from './HeaderHome';
 
 const mockPush = vi.fn();
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+let mockIntersectionCallback: IntersectionObserverCallback | undefined;
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  usePathname: vi.fn(),
 }));
+
+class MockIntersectionObserver implements IntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    mockIntersectionCallback = callback;
+  }
+
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = '-30% 0px -35% 0px';
+  readonly thresholds: ReadonlyArray<number> = [0];
+
+  observe = mockObserve;
+  unobserve = vi.fn();
+  disconnect = mockDisconnect;
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+const createIntersectionEntry = (target: Element, isIntersecting: boolean): IntersectionObserverEntry => ({
+  boundingClientRect: target.getBoundingClientRect(),
+  intersectionRatio: isIntersecting ? 1 : 0,
+  intersectionRect: isIntersecting ? target.getBoundingClientRect() : new DOMRectReadOnly(),
+  isIntersecting,
+  rootBounds: null,
+  target,
+  time: 0,
+});
 
 // Mock molecules
 vi.mock('@/molecules/Header/Header', () => {
@@ -43,6 +77,15 @@ vi.mock('@/atoms/Container/Container', () => {
 });
 
 describe('HeaderHome', () => {
+  beforeEach(() => {
+    vi.mocked(usePathname).mockReturnValue('/');
+    mockIntersectionCallback = undefined;
+    document.body.innerHTML = '';
+
+    globalThis.IntersectionObserver = MockIntersectionObserver;
+    window.IntersectionObserver = MockIntersectionObserver;
+  });
+
   it('renders social links and sign in button', () => {
     render(<HeaderHome />);
 
@@ -52,8 +95,51 @@ describe('HeaderHome', () => {
   });
 
   it('does not render the landing join button when the landing hero is absent', () => {
-    render(<HeaderHome showLandingJoinButton />);
+    render(<HeaderHome />);
 
+    expect(screen.queryByRole('button', { name: /join/i })).not.toBeInTheDocument();
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+
+  it('renders the landing join button after the hero leaves the viewport', () => {
+    const heroSection = document.createElement('section');
+    heroSection.id = LANDING_HERO_SECTION_ID;
+    document.body.appendChild(heroSection);
+
+    render(<HeaderHome />);
+
+    act(() => {
+      mockIntersectionCallback?.([createIntersectionEntry(heroSection, false)], {} as IntersectionObserver);
+    });
+
+    expect(screen.getByRole('button', { name: /join/i })).toBeInTheDocument();
+  });
+
+  it('navigates to onboarding when the landing join button is clicked', () => {
+    const heroSection = document.createElement('section');
+    heroSection.id = LANDING_HERO_SECTION_ID;
+    document.body.appendChild(heroSection);
+
+    render(<HeaderHome />);
+
+    act(() => {
+      mockIntersectionCallback?.([createIntersectionEntry(heroSection, false)], {} as IntersectionObserver);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /join/i }));
+
+    expect(mockPush).toHaveBeenCalledWith(ONBOARDING_ROUTES.HUMAN);
+  });
+
+  it('does not observe the landing hero outside the homepage', () => {
+    vi.mocked(usePathname).mockReturnValue('/home');
+    const heroSection = document.createElement('section');
+    heroSection.id = LANDING_HERO_SECTION_ID;
+    document.body.appendChild(heroSection);
+
+    render(<HeaderHome />);
+
+    expect(mockObserve).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /join/i })).not.toBeInTheDocument();
   });
 

--- a/src/components/molecules/HeaderHome/HeaderHome.test.tsx
+++ b/src/components/molecules/HeaderHome/HeaderHome.test.tsx
@@ -48,6 +48,13 @@ describe('HeaderHome', () => {
 
     expect(screen.getByTestId('header-social-links')).toBeInTheDocument();
     expect(screen.getByTestId('header-button-sign-in')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /join/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render the landing join button when the landing hero is absent', () => {
+    render(<HeaderHome showLandingJoinButton />);
+
+    expect(screen.queryByRole('button', { name: /join/i })).not.toBeInTheDocument();
   });
 
   it('applies correct container classes', () => {

--- a/src/components/molecules/HeaderHome/HeaderHome.tsx
+++ b/src/components/molecules/HeaderHome/HeaderHome.tsx
@@ -12,12 +12,19 @@ import { LANDING_HERO_SECTION_ID } from '@/templates/Public/Landing/Landing.cons
 import { HeaderSocialLinks } from '../Header/Header';
 import { HeaderButtonSignIn } from '../HeaderButtonSignIn/HeaderButtonSignIn';
 
-export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+interface HeaderHomeProps extends React.HTMLAttributes<HTMLDivElement> {
+  showLandingJoinButton?: boolean;
+}
+
+export const HeaderHome = ({ showLandingJoinButton = false, ...props }: HeaderHomeProps) => {
   const router = useRouter();
   const t = useTranslations('landing');
   const [showJoinButton, setShowJoinButton] = React.useState(false);
 
   React.useEffect(() => {
+    setShowJoinButton(false);
+
+    if (!showLandingJoinButton) return;
     if (typeof IntersectionObserver === 'undefined') return;
 
     const heroSection = document.getElementById(LANDING_HERO_SECTION_ID);
@@ -43,7 +50,7 @@ export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) =
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [showLandingJoinButton]);
 
   const handleJoin = () => {
     router.push(ONBOARDING_ROUTES.HUMAN);
@@ -66,10 +73,10 @@ export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) =
                 id="header-join-btn"
                 variant="brand"
                 onClick={handleJoin}
-                className="shrink-0 gap-2 whitespace-nowrap"
+                className="size-10 shrink-0 gap-0 px-0 whitespace-nowrap sm:h-10 sm:w-auto sm:gap-2 sm:px-4"
               >
                 <UserRoundPlus className="size-4" />
-                {t('join')}
+                <span className="sr-only sm:not-sr-only">{t('join')}</span>
               </Button>
             </div>
           </motion.div>

--- a/src/components/molecules/HeaderHome/HeaderHome.tsx
+++ b/src/components/molecules/HeaderHome/HeaderHome.tsx
@@ -19,12 +19,12 @@ export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) =
   const pathname = usePathname();
   const [showJoinButton, setShowJoinButton] = React.useState(false);
 
-  const isHomePage = pathname === '/';
+  const isLandingPage = pathname === '/';
 
   React.useEffect(() => {
     setShowJoinButton(false);
 
-    if (!isHomePage) return;
+    if (!isLandingPage) return;
     if (typeof IntersectionObserver === 'undefined') return;
 
     const heroSection = document.getElementById(LANDING_HERO_SECTION_ID);
@@ -50,7 +50,7 @@ export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) =
     return () => {
       observer.disconnect();
     };
-  }, [isHomePage]);
+  }, [isLandingPage]);
 
   const handleJoin = () => {
     router.push(ONBOARDING_ROUTES.HUMAN);
@@ -68,7 +68,7 @@ export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) =
             exit={{ opacity: 0, width: 0 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
           >
-            <div className="flex shrink-0 items-center p-2">
+            <div className="flex shrink-0 items-center px-2">
               <Button
                 id="header-join-btn"
                 variant="brand"

--- a/src/components/molecules/HeaderHome/HeaderHome.tsx
+++ b/src/components/molecules/HeaderHome/HeaderHome.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { UserRoundPlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useTranslations } from 'next-intl';
@@ -12,19 +13,18 @@ import { LANDING_HERO_SECTION_ID } from '@/templates/Public/Landing/Landing.cons
 import { HeaderSocialLinks } from '../Header/Header';
 import { HeaderButtonSignIn } from '../HeaderButtonSignIn/HeaderButtonSignIn';
 
-interface HeaderHomeProps extends React.HTMLAttributes<HTMLDivElement> {
-  showLandingJoinButton?: boolean;
-}
-
-export const HeaderHome = ({ showLandingJoinButton = false, ...props }: HeaderHomeProps) => {
+export const HeaderHome = ({ ...props }: React.HTMLAttributes<HTMLDivElement>) => {
   const router = useRouter();
   const t = useTranslations('landing');
+  const pathname = usePathname();
   const [showJoinButton, setShowJoinButton] = React.useState(false);
+
+  const isHomePage = pathname === '/';
 
   React.useEffect(() => {
     setShowJoinButton(false);
 
-    if (!showLandingJoinButton) return;
+    if (!isHomePage) return;
     if (typeof IntersectionObserver === 'undefined') return;
 
     const heroSection = document.getElementById(LANDING_HERO_SECTION_ID);
@@ -50,7 +50,7 @@ export const HeaderHome = ({ showLandingJoinButton = false, ...props }: HeaderHo
     return () => {
       observer.disconnect();
     };
-  }, [showLandingJoinButton]);
+  }, [isHomePage]);
 
   const handleJoin = () => {
     router.push(ONBOARDING_ROUTES.HUMAN);

--- a/src/components/molecules/Home/Home.test.tsx
+++ b/src/components/molecules/Home/Home.test.tsx
@@ -205,6 +205,13 @@ describe('HomeFooter', () => {
     expect(screen.getByTestId('dialog-privacy')).toBeInTheDocument();
     expect(screen.getByTestId('dialog-age')).toBeInTheDocument();
   });
+
+  it('renders Synonym and Tether branding below the agreement text', () => {
+    render(<HomeFooter />);
+
+    expect(screen.getByAltText('Synonym')).toBeInTheDocument();
+    expect(screen.getByAltText('a tether. company')).toBeInTheDocument();
+  });
 });
 
 describe('HomeBrandFooter', () => {

--- a/src/components/molecules/Home/Home.test.tsx.snap
+++ b/src/components/molecules/Home/Home.test.tsx.snap
@@ -102,6 +102,38 @@ exports[`Home - Snapshots > matches snapshot for HomeFooter with default props 1
     </a>
      and was built with love and dedication by Synonym Software, S.A. DE C.V. ©2026. All rights reserved.
   </div>
+  <div
+    class="landing-brand-footer inline-flex min-w-max items-center gap-2 whitespace-nowrap transition-opacity duration-300 [&_*]:shrink-0 mt-2"
+  >
+    <a
+      class="inline-flex items-center"
+      data-testid="link"
+      href="https://synonym.to"
+      target="_blank"
+    >
+      <img
+        alt="Synonym"
+        data-testid="image"
+        height="24"
+        src="/images/synonym-grey-logo.svg"
+        width="95"
+      />
+    </a>
+    <a
+      class="inline-flex items-center"
+      data-testid="link"
+      href="https://tether.io/"
+      target="_blank"
+    >
+      <img
+        alt="a tether. company"
+        data-testid="image"
+        height="16"
+        src="/images/a-tether-company.svg"
+        width="109"
+      />
+    </a>
+  </div>
 </div>
 `;
 

--- a/src/components/molecules/Home/Home.tsx
+++ b/src/components/molecules/Home/Home.tsx
@@ -60,6 +60,7 @@ export const HomeFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDiv
           ),
         })}
       </FooterLinks>
+      <HomeBrandFooter className="mt-2" />
     </Container>
   );
 };

--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -148,8 +148,8 @@ vi.mock('@/molecules/Header/Header', () => {
 
 vi.mock('@/molecules/HeaderHome/HeaderHome', () => {
   return {
-    HeaderHome: () => (
-      <div data-testid="header-home">
+    HeaderHome: ({ showLandingJoinButton }: { showLandingJoinButton?: boolean }) => (
+      <div data-testid="header-home" data-show-landing-join-button={String(Boolean(showLandingJoinButton))}>
         <div data-testid="header-social-links">Social Links</div>
         <button>Sign in</button>
       </div>
@@ -638,6 +638,19 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-home')).toBeInTheDocument();
+      expect(screen.getByTestId('header-home')).toHaveAttribute('data-show-landing-join-button', 'true');
+    });
+
+    it('does not enable the landing join button on non-landing HeaderHome routes', () => {
+      mockCurrentUserPubky = null;
+      mockIsPublicRoute.mockReturnValue(false);
+      mockIsCoreExploreRoute.mockReturnValue(false);
+      mockUsePathname.mockReturnValue(AUTH_ROUTES.SIGN_IN);
+
+      render(<Header />);
+
+      expect(screen.getByTestId('header-home')).toBeInTheDocument();
+      expect(screen.getByTestId('header-home')).toHaveAttribute('data-show-landing-join-button', 'false');
     });
 
     it('renders explore navigation when unauthenticated on a core explore route', () => {

--- a/src/components/organisms/Header/Header.test.tsx
+++ b/src/components/organisms/Header/Header.test.tsx
@@ -148,8 +148,8 @@ vi.mock('@/molecules/Header/Header', () => {
 
 vi.mock('@/molecules/HeaderHome/HeaderHome', () => {
   return {
-    HeaderHome: ({ showLandingJoinButton }: { showLandingJoinButton?: boolean }) => (
-      <div data-testid="header-home" data-show-landing-join-button={String(Boolean(showLandingJoinButton))}>
+    HeaderHome: () => (
+      <div data-testid="header-home">
         <div data-testid="header-social-links">Social Links</div>
         <button>Sign in</button>
       </div>
@@ -638,7 +638,7 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-home')).toBeInTheDocument();
-      expect(screen.getByTestId('header-home')).toHaveAttribute('data-show-landing-join-button', 'true');
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
     });
 
     it('does not enable the landing join button on non-landing HeaderHome routes', () => {
@@ -650,7 +650,7 @@ describe('Header', () => {
       render(<Header />);
 
       expect(screen.getByTestId('header-home')).toBeInTheDocument();
-      expect(screen.getByTestId('header-home')).toHaveAttribute('data-show-landing-join-button', 'false');
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
     });
 
     it('renders explore navigation when unauthenticated on a core explore route', () => {

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -61,7 +61,7 @@ export function Header() {
     if (isCoreExploreRoute || isDynamicPublicRoute) {
       return <HeaderExploreNavigationButtons />;
     }
-    return <HeaderHome showLandingJoinButton={isLandingPage} />;
+    return <HeaderHome />;
   };
 
   // Copyright page shows only logo (minimal header).

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -61,7 +61,7 @@ export function Header() {
     if (isCoreExploreRoute || isDynamicPublicRoute) {
       return <HeaderExploreNavigationButtons />;
     }
-    return <HeaderHome />;
+    return <HeaderHome showLandingJoinButton={isLandingPage} />;
   };
 
   // Copyright page shows only logo (minimal header).

--- a/src/components/templates/Public/Landing/Landing.tsx
+++ b/src/components/templates/Public/Landing/Landing.tsx
@@ -1,5 +1,5 @@
 import { Container } from '@/atoms/Container/Container';
-import { HomeActions, HomeBrandFooter, HomeFooter, HomePageHeading, HomeSectionTitle } from '@/molecules/Home/Home';
+import { HomeActions, HomeFooter, HomePageHeading, HomeSectionTitle } from '@/molecules/Home/Home';
 import { PageContainer } from '@/molecules/Page/Page';
 import { LANDING_HERO_SECTION_ID } from './Landing.constants';
 import { LandingBrokenSection } from './LandingBrokenSection';
@@ -29,7 +29,6 @@ export function Landing() {
           </PageContainer>
           <LandingVideo />
         </div>
-        <HomeBrandFooter className="landing-hero-brand-footer fixed bottom-6 left-6 z-20" />
       </Container>
       <LandingBrokenSection />
       <LandingHowItWorksSection />

--- a/src/components/templates/Public/Landing/LandingBrokenSection.tsx
+++ b/src/components/templates/Public/Landing/LandingBrokenSection.tsx
@@ -39,7 +39,7 @@ export function LandingBrokenSection() {
   const t = useTranslations('landing.broken');
 
   return (
-    <section id={LANDING_NEXT_SECTION_ID} className="relative z-0 min-h-svh scroll-mt-[48px] py-20 sm:py-24">
+    <section id={LANDING_NEXT_SECTION_ID} className="relative z-0 min-h-svh scroll-mt-[48px] py-10 sm:py-24">
       <Container size="container" className="gap-10 px-6">
         <Container className="mx-0 max-w-[760px] gap-5">
           <Typography as="span" size="xs" className="text-brand tracking-[1.2px] uppercase">

--- a/src/components/templates/Public/Landing/LandingFinalSection.tsx
+++ b/src/components/templates/Public/Landing/LandingFinalSection.tsx
@@ -27,7 +27,7 @@ export function LandingFinalSection() {
   };
 
   return (
-    <section id={LANDING_FINAL_SECTION_ID} className="relative z-0 flex min-h-svh items-center px-6 py-20">
+    <section id={LANDING_FINAL_SECTION_ID} className="relative z-0 flex min-h-svh items-center px-6 py-10 sm:py-20">
       <Container size="container" className="items-center gap-8 text-center">
         <Heading level={2} size="xl" className="max-w-[820px] text-5xl sm:text-7xl">
           {t.rich('title', {

--- a/src/components/templates/Public/Landing/LandingFreedomSection.tsx
+++ b/src/components/templates/Public/Landing/LandingFreedomSection.tsx
@@ -65,7 +65,7 @@ export function LandingFreedomSection() {
     <section
       ref={sectionRef}
       id={LANDING_FREEDOM_SECTION_ID}
-      className="relative z-0 min-h-svh scroll-mt-[48px] py-20 sm:py-24"
+      className="relative z-0 min-h-svh scroll-mt-[48px] py-10 sm:py-24"
     >
       <Container size="container" className="gap-10 px-6">
         <Container className="mx-0 max-w-[760px] gap-5">

--- a/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
+++ b/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
@@ -16,7 +16,7 @@ export function LandingHowItWorksSection() {
   const t = useTranslations('landing.howItWorks');
 
   return (
-    <section id={LANDING_HOW_SECTION_ID} className="relative z-0 min-h-svh scroll-mt-[48px] py-20 sm:py-24">
+    <section id={LANDING_HOW_SECTION_ID} className="relative z-0 min-h-svh scroll-mt-[48px] py-10 sm:py-24">
       <Container size="container" className="gap-10 px-6">
         <Container className="mx-0 max-w-[760px] gap-5">
           <Typography as="span" size="xs" className="text-brand tracking-[1.2px] uppercase">


### PR DESCRIPTION
Fixes #2012 

## Summary

- Restricts the animated header Join button to the public landing page only.
- Makes the landing header Join button icon-only on the smallest mobile breakpoint.
- Moves the Synonym / a tether company brand element back into the hero footer flow.
- Reduces mobile-only vertical spacing between landing sections.
- Removes unused fixed hero brand footer CSS.

## Validation

- `npx eslint src/components/molecules/Home/Home.tsx src/components/molecules/Home/Home.test.tsx src/components/templates/Public/Landing/Landing.tsx src/components/templates/Public/Landing/LandingBrokenSection.tsx src/components/templates/Public/Landing/LandingHowItWorksSection.tsx src/components/templates/Public/Landing/LandingFreedomSection.tsx src/components/templates/Public/Landing/LandingFinalSection.tsx src/components/molecules/HeaderHome/HeaderHome.tsx src/components/molecules/HeaderHome/HeaderHome.test.tsx src/components/organisms/Header/Header.tsx src/components/organisms/Header/Header.test.tsx`
- `npx vitest run src/components/molecules/Home/Home.test.tsx src/components/molecules/HeaderHome/HeaderHome.test.tsx src/components/organisms/Header/Header.test.tsx`