### PR TITLE
feat(profile): add Collections tab to user profile

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "الاشعارات",
       "posts": "المنشورات",
+      "collections": "المجموعات",
       "replies": "الردود",
       "followers": "المتابعون",
       "following": "المتابَعون",

--- a/messages/de.json
+++ b/messages/de.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "Benachrichtigungen",
       "posts": "Beiträge",
+      "collections": "Sammlungen",
       "replies": "Antworten",
       "followers": "Follower",
       "following": "Folge ich",

--- a/messages/en.json
+++ b/messages/en.json
@@ -465,6 +465,7 @@
     "tabs": {
       "notifications": "Notifications",
       "posts": "Posts",
+      "collections": "Collections",
       "replies": "Replies",
       "followers": "Followers",
       "following": "Following",

--- a/messages/es.json
+++ b/messages/es.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "Notificaciones",
       "posts": "Publicaciones",
+      "collections": "Colecciones",
       "replies": "Respuestas",
       "followers": "Seguidores",
       "following": "Siguiendo",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "Notifications",
       "posts": "Publications",
+      "collections": "Collections",
       "replies": "Réponses",
       "followers": "Abonnes",
       "following": "Abonnements",

--- a/messages/it.json
+++ b/messages/it.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "Notifiche",
       "posts": "Post",
+      "collections": "Collezioni",
       "replies": "Risposte",
       "followers": "Follower",
       "following": "Seguiti",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "通知",
       "posts": "投稿",
+      "collections": "コレクション",
       "replies": "返信",
       "followers": "フォロワー",
       "following": "フォロー中",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "Notificações",
       "posts": "Posts",
+      "collections": "Coleções",
       "replies": "Respostas",
       "followers": "Seguidores",
       "following": "Seguindo",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -469,6 +469,7 @@
     "tabs": {
       "notifications": "通知",
       "posts": "帖子",
+      "collections": "收藏",
       "replies": "回复",
       "followers": "粉丝",
       "following": "关注",

--- a/src/app/profile/(own)/collections/page.tsx
+++ b/src/app/profile/(own)/collections/page.tsx
@@ -1,0 +1,1 @@
+export { ProfileCollectionsPage as default } from '@/templates/Profile/Collections/ProfileCollectionsPage';

--- a/src/app/profile/[pubky]/collections/page.tsx
+++ b/src/app/profile/[pubky]/collections/page.tsx
@@ -1,0 +1,1 @@
+export { ProfileCollectionsPage as default } from '@/templates/Profile/Collections/ProfileCollectionsPage';

--- a/src/app/profile/types.ts
+++ b/src/app/profile/types.ts
@@ -7,6 +7,7 @@ export const PROFILE_PAGE_TYPES = {
   FOLLOWING: 'following',
   FRIENDS: 'friends',
   UNIQUE_TAGS: 'unique_tags',
+  COLLECTIONS: 'collections',
 } as const;
 
 export type ProfilePageType =
@@ -17,6 +18,7 @@ export type ProfilePageType =
   | typeof PROFILE_PAGE_TYPES.FOLLOWERS
   | typeof PROFILE_PAGE_TYPES.FOLLOWING
   | typeof PROFILE_PAGE_TYPES.FRIENDS
+  | typeof PROFILE_PAGE_TYPES.COLLECTIONS
   | typeof PROFILE_PAGE_TYPES.UNIQUE_TAGS;
 
 export type FilterBarPageType = Exclude<ProfilePageType, typeof PROFILE_PAGE_TYPES.PROFILE>;

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -42,6 +42,7 @@ export enum PROFILE_ROUTES {
   FRIENDS = '/profile/friends',
   UNIQUE_TAGS = '/profile/tagged',
   PROFILE_PAGE = '/profile/profile',
+  COLLECTIONS = '/profile/collections',
 }
 
 export enum SETTINGS_ROUTES {

--- a/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.test.tsx
+++ b/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.test.tsx
@@ -17,7 +17,7 @@ const mockStats: ProfileStats = {
 
 describe('ProfilePageFilterBar', () => {
   it('renders all filter items with stats', () => {
-    render(
+    const { container } = render(
       <ProfilePageFilterBar
         activePage={PROFILE_PAGE_TYPES.NOTIFICATIONS}
         onPageChangeAction={() => {}}
@@ -28,6 +28,7 @@ describe('ProfilePageFilterBar', () => {
     // The component uses t(item.labelKey) to translate labels
     expect(screen.getByText('Notifications')).toBeInTheDocument();
     expect(screen.getByText('Posts')).toBeInTheDocument();
+    expect(screen.getByText('Collections')).toBeInTheDocument();
     expect(screen.getByText('Replies')).toBeInTheDocument();
     expect(screen.getByText('Followers')).toBeInTheDocument();
     expect(screen.getByText('Following')).toBeInTheDocument();
@@ -37,6 +38,7 @@ describe('ProfilePageFilterBar', () => {
     // Check that counts are rendered
     expect(screen.getByText('2')).toBeInTheDocument(); // notifications
     expect(screen.getByText('4')).toBeInTheDocument(); // posts
+    expect(container.querySelector('[data-cy="profile-filter-item-collections-count"]')).not.toBeInTheDocument();
   });
 
   it('has correct structure with sticky positioning', () => {
@@ -73,7 +75,7 @@ describe('ProfilePageFilterBar', () => {
     expect(screen.getByText('Notifications')).toBeInTheDocument();
     // Should show loading spinners when stats are undefined
     const spinners = screen.getAllByTestId('spinner');
-    expect(spinners.length).toBe(7); // One for each filter item
+    expect(spinners.length).toBe(7); // One for each filter item with a count
   });
 
   it('renders with zero counts when stats are provided but individual values are zero', () => {

--- a/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.test.tsx.snap
+++ b/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.test.tsx.snap
@@ -372,6 +372,52 @@ exports[`ProfilePageFilterBar - Snapshots > matches snapshot with loading state 
         role="status"
       />
     </button>
+    <button
+      aria-pressed="false"
+      class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left text-muted-foreground hover:text-foreground/80 m-0 h-full w-full items-start justify-between px-0 py-1"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      type="button"
+    >
+      <div
+        class="flex items-center gap-2"
+        data-cy="profile-filter-item-collections"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-library h-5 w-5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m16 6 4 14"
+          />
+          <path
+            d="M12 6v14"
+          />
+          <path
+            d="M8 8v12"
+          />
+          <path
+            d="M4 4v16"
+          />
+        </svg>
+        <span
+          class=""
+        >
+          Collections
+        </span>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -712,6 +758,52 @@ exports[`ProfilePageFilterBar - Snapshots > matches snapshot with stats 1`] = `
         5
       </span>
     </button>
+    <button
+      aria-pressed="false"
+      class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left text-muted-foreground hover:text-foreground/80 m-0 h-full w-full items-start justify-between px-0 py-1"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      type="button"
+    >
+      <div
+        class="flex items-center gap-2"
+        data-cy="profile-filter-item-collections"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-library h-5 w-5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m16 6 4 14"
+          />
+          <path
+            d="M12 6v14"
+          />
+          <path
+            d="M8 8v12"
+          />
+          <path
+            d="M4 4v16"
+          />
+        </svg>
+        <span
+          class=""
+        >
+          Collections
+        </span>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -1051,6 +1143,52 @@ exports[`ProfilePageFilterBar - Snapshots > matches snapshot with zero stats 1`]
       >
         0
       </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left text-muted-foreground hover:text-foreground/80 m-0 h-full w-full items-start justify-between px-0 py-1"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      type="button"
+    >
+      <div
+        class="flex items-center gap-2"
+        data-cy="profile-filter-item-collections"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-library h-5 w-5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m16 6 4 14"
+          />
+          <path
+            d="M12 6v14"
+          />
+          <path
+            d="M8 8v12"
+          />
+          <path
+            d="M4 4v16"
+          />
+        </svg>
+        <span
+          class=""
+        >
+          Collections
+        </span>
+      </div>
     </button>
   </div>
 </div>

--- a/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.tsx
+++ b/src/components/molecules/ProfilePageFilterBar/ProfilePageFilterBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Bell, HeartHandshake, MessageCircle, StickyNote, Tag, UsersRound } from 'lucide-react';
+import { Bell, HeartHandshake, Library, MessageCircle, StickyNote, Tag, UsersRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FilterBarPageType, PROFILE_PAGE_TYPES } from '@/app/profile/types';
 import { Container } from '@/atoms/Container/Container';
@@ -22,6 +22,8 @@ export interface ProfilePageFilterBarItem {
   labelKey: string;
   count: number | undefined;
   pageType: FilterBarPageType;
+  /** When false, the tab renders without a count badge (e.g. Collections). */
+  showCount?: boolean;
   /** Whether this item should only be shown for own profile */
   ownProfileOnly?: boolean;
 }
@@ -42,7 +44,7 @@ const FILTER_ITEMS_CONFIG: Array<{
   }>;
   labelKey: string;
   pageType: FilterBarPageType;
-  statKey: keyof ProfileStats;
+  statKey?: keyof ProfileStats;
   /** Whether this item should only be shown for own profile */
   ownProfileOnly?: boolean;
 }> = [
@@ -89,6 +91,11 @@ const FILTER_ITEMS_CONFIG: Array<{
     pageType: PROFILE_PAGE_TYPES.UNIQUE_TAGS,
     statKey: 'uniqueTags',
   },
+  {
+    icon: Library,
+    labelKey: 'collections',
+    pageType: PROFILE_PAGE_TYPES.COLLECTIONS,
+  },
 ];
 export const getDefaultItems = (stats?: ProfileStats, isOwnProfile: boolean = true): ProfilePageFilterBarItem[] => {
   return FILTER_ITEMS_CONFIG.filter((config) => {
@@ -101,9 +108,10 @@ export const getDefaultItems = (stats?: ProfileStats, isOwnProfile: boolean = tr
     icon: config.icon,
     labelKey: config.labelKey,
     pageType: config.pageType,
+    showCount: config.statKey !== undefined,
     // If stats not provided, count is undefined (loading state)
     // If stats provided, use the value or fallback to 0
-    count: stats ? (stats[config.statKey] ?? 0) : undefined,
+    count: config.statKey ? (stats ? (stats[config.statKey] ?? 0) : undefined) : undefined,
     ownProfileOnly: config.ownProfileOnly,
   }));
 };
@@ -155,7 +163,8 @@ export function ProfilePageFilterBar({
         {filterItems.map((item, index) => {
           const Icon = item.icon;
           const isActive = item.pageType === activePage;
-          const isLoading = item.count === undefined;
+          const showCount = item.showCount !== false;
+          const isLoading = showCount && item.count === undefined;
           const label = t(item.labelKey);
           return (
             <FilterItem
@@ -172,17 +181,18 @@ export function ProfilePageFilterBar({
                 <FilterItemIcon icon={Icon} />
                 <FilterItemLabel>{label}</FilterItemLabel>
               </Container>
-              {isLoading ? (
-                <Spinner size="sm" className="size-4" />
-              ) : (
-                <Typography
-                  data-cy={`profile-filter-item-${item.labelKey}-count`}
-                  as="span"
-                  className={`text-base font-medium ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
-                >
-                  {item.count}
-                </Typography>
-              )}
+              {showCount &&
+                (isLoading ? (
+                  <Spinner size="sm" className="size-4" />
+                ) : (
+                  <Typography
+                    data-cy={`profile-filter-item-${item.labelKey}-count`}
+                    as="span"
+                    className={`text-base font-medium ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+                  >
+                    {item.count}
+                  </Typography>
+                ))}
             </FilterItem>
           );
         })}

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx
@@ -60,6 +60,7 @@ describe('ProfilePageMobileMenu', () => {
       'Following',
       'Friends',
       'Tagged',
+      'Collections',
     ]);
   });
 
@@ -74,7 +75,16 @@ describe('ProfilePageMobileMenu', () => {
 
     const labels = Array.from(container.querySelectorAll('button')).map((button) => button.getAttribute('aria-label'));
 
-    expect(labels).toEqual(['Profile', 'Posts', 'Replies', 'Followers', 'Following', 'Friends', 'Tagged']);
+    expect(labels).toEqual([
+      'Profile',
+      'Posts',
+      'Replies',
+      'Followers',
+      'Following',
+      'Friends',
+      'Tagged',
+      'Collections',
+    ]);
   });
 
   it('marks the active item with aria-current="page"', () => {

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx.snap
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.test.tsx.snap
@@ -263,6 +263,43 @@ exports[`ProfilePageMobileMenu - Snapshots > matches snapshot with default props
         </svg>
       </button>
     </div>
+    <div
+      class="flex flex-1 justify-center border-b px-0 py-1.5 border-border"
+      data-testid="container"
+    >
+      <button
+        aria-label="Collections"
+        class="px-2.5 py-2"
+        data-slot="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-library text-muted-foreground"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m16 6 4 14"
+          />
+          <path
+            d="M12 6v14"
+          />
+          <path
+            d="M8 8v12"
+          />
+          <path
+            d="M4 4v16"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.tsx
+++ b/src/components/molecules/ProfilePageMobileMenu/ProfilePageMobileMenu.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import { type ComponentType, forwardRef } from 'react';
-import { Bell, CircleUserRound, HeartHandshake, MessageCircle, StickyNote, Tag, UsersRound } from 'lucide-react';
+import {
+  Bell,
+  CircleUserRound,
+  HeartHandshake,
+  Library,
+  MessageCircle,
+  StickyNote,
+  Tag,
+  UsersRound,
+} from 'lucide-react';
 import { PROFILE_PAGE_TYPES, type ProfilePageType } from '@/app/profile/types';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { UsersRound2 } from '@/icons';
@@ -56,6 +65,11 @@ export const PROFILE_MENU_ITEMS: ProfileMenuItem[] = [
     icon: Tag,
     label: 'Tagged',
     pageType: PROFILE_PAGE_TYPES.UNIQUE_TAGS,
+  },
+  {
+    icon: Library,
+    label: 'Collections',
+    pageType: PROFILE_PAGE_TYPES.COLLECTIONS,
   },
 ];
 export interface ProfilePageMobileMenuProps {

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
@@ -9,7 +9,11 @@ import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeed
 import type { UsePullToRefreshResult } from '@/hooks/usePullToRefresh/usePullToRefresh.types';
 import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStreamIdFromFilters';
 import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
-import { type PostStreamId, PostStreamTypes } from '@/models/stream/post/postStream.types';
+import {
+  buildAuthorCollectionsStreamId,
+  type PostStreamId,
+  PostStreamTypes,
+} from '@/models/stream/post/postStream.types';
 import { ProfileProvider } from '@/providers/ProfileProvider/ProfileProvider';
 import { useHomeStore } from '@/stores/home/home.store';
 import { CONTENT, type ContentType, LAYOUT, REACH, SORT } from '@/stores/home/home.types';
@@ -544,6 +548,33 @@ describe('TimelineFeed', () => {
       // TimelineFeed shows loading state and doesn't call useStreamPagination
       expect(screen.getByTestId('timeline-loading')).toBeInTheDocument();
       expect(mockUseStreamPagination).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Profile Collections Variant', () => {
+    const profilePubky = 'profile-user-pubky';
+
+    it('should show loading when profile context has no pubky', () => {
+      render(
+        <ProfileProvider>
+          <TimelineFeed variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS} />
+        </ProfileProvider>,
+      );
+
+      expect(screen.getByTestId('timeline-loading')).toBeInTheDocument();
+      expect(mockUseStreamPagination).not.toHaveBeenCalled();
+    });
+
+    it('should paginate the author collections stream when pubky is available', () => {
+      render(
+        <ProfileProvider pubky={profilePubky}>
+          <TimelineFeed variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS} />
+        </ProfileProvider>,
+      );
+
+      expect(mockUseStreamPagination).toHaveBeenCalledWith({
+        streamId: buildAuthorCollectionsStreamId(profilePubky),
+      });
     });
   });
 

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -9,7 +9,11 @@ import { useHotStreamId } from '@/hooks/useHotStreamId/useHotStreamId';
 import { useSearchStreamId } from '@/hooks/useSearchStreamId/useSearchStreamId';
 import { useStreamIdFromFilters } from '@/hooks/useStreamIdFromFilters/useStreamIdFromFilters';
 import { useSyncInteractiveVisualContent } from '@/hooks/useSyncInteractiveVisualContent/useSyncInteractiveVisualContent';
-import { type AuthorStreamCompositeId, buildCollectionItemsStreamId } from '@/models/stream/post/postStream.types';
+import {
+  type AuthorStreamCompositeId,
+  buildAuthorCollectionsStreamId,
+  buildCollectionItemsStreamId,
+} from '@/models/stream/post/postStream.types';
 import { TimelineLoading } from '@/molecules/Timeline/TimelineLoading';
 import { getTagsLayoutForSurfaceLayout } from '@/organisms/PostMain/PostMainLayoutRules';
 import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
@@ -38,6 +42,8 @@ export function TimelineFeed({ variant, children, emptyState }: TimelineFeedProp
       return <BookmarksTimelineFeed emptyState={emptyState}>{children}</BookmarksTimelineFeed>;
     case TIMELINE_FEED_VARIANT.PROFILE:
       return <ProfileTimelineFeed>{children}</ProfileTimelineFeed>;
+    case TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS:
+      return <ProfileCollectionsTimelineFeed>{children}</ProfileCollectionsTimelineFeed>;
     case TIMELINE_FEED_VARIANT.HOT:
       return <HotTimelineFeed>{children}</HotTimelineFeed>;
     case TIMELINE_FEED_VARIANT.SEARCH:
@@ -131,6 +137,24 @@ function ProfileTimelineFeed({ children }: { children?: TimelineFeedProps['child
     <TimelineFeedWithStream
       streamId={streamId}
       variant={TIMELINE_FEED_VARIANT.PROFILE}
+      tagsLayout={tagsLayout}
+      layoutResolution={layoutResolution}
+    >
+      {children}
+    </TimelineFeedWithStream>
+  );
+}
+
+function ProfileCollectionsTimelineFeed({ children }: { children?: TimelineFeedProps['children'] }) {
+  const { pubky } = useProfileContext();
+  const streamId = pubky ? buildAuthorCollectionsStreamId(pubky) : undefined;
+  const layoutResolution = useFeedLayoutResolution(TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS);
+  const tagsLayout = getTagsLayoutForSurfaceLayout(layoutResolution.effectiveLayout);
+
+  return (
+    <TimelineFeedWithStream
+      streamId={streamId}
+      variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS}
       tagsLayout={tagsLayout}
       layoutResolution={layoutResolution}
     >

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.types.ts
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.types.ts
@@ -7,7 +7,8 @@ export interface TimelineFeedProps {
    * - 'home': Uses global filters (sort, reach, content)
    * - 'custom': Uses custom filters (sort, reach, layout, content, tags)
    * - 'bookmarks': Uses bookmarks stream with sort/content filters
-   * - 'profile': Uses author stream from ProfileContext
+   * - 'profile': Uses author stream from ProfileContext (all posts except collections)
+   * - 'profile_collections': Uses the author's collection posts stream from ProfileContext
    * - 'hot': Uses engagement sorting with reach from hot store
    * - 'search': Uses tags from URL query params with sort/content filters
    * - 'collection': Uses a single collection's item stream from route params

--- a/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.test.tsx
@@ -7,6 +7,7 @@ import { useMutedUsers } from '@/hooks/useMutedUsers/useMutedUsers';
 import type { UsePullToRefreshResult } from '@/hooks/usePullToRefresh/usePullToRefresh.types';
 import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
 import {
+  buildAuthorCollectionsStreamId,
   buildCollectionItemsStreamId,
   type PostStreamId,
   PostStreamTypes,
@@ -429,6 +430,40 @@ describe('TimelineFeedContent', () => {
         <TimelineFeedWithStream
           streamId={profileStreamId}
           variant={TIMELINE_FEED_VARIANT.PROFILE}
+          tagsLayout="inline"
+        />,
+      );
+
+      expect(mockRefresh).not.toHaveBeenCalled();
+      expect(mockRemovePosts).not.toHaveBeenCalled();
+    });
+
+    it('does not remove or refresh posts for profile collections feeds', () => {
+      let mutedUserIds = ['muted-user'];
+      const profileCollectionsStreamId = buildAuthorCollectionsStreamId('profile-user');
+      mockUseStreamPagination.mockReturnValue({
+        ...defaultPaginationResult,
+        postIds: ['muted-user:collection-1', 'other-user:collection-2'],
+      });
+      mockUseMutedUsers.mockImplementation(() => ({
+        ...defaultMutedUsersResult,
+        mutedUserIds,
+        mutedUserIdSet: new Set(mutedUserIds),
+      }));
+
+      const { rerender } = render(
+        <TimelineFeedWithStream
+          streamId={profileCollectionsStreamId}
+          variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS}
+          tagsLayout="inline"
+        />,
+      );
+
+      mutedUserIds = [];
+      rerender(
+        <TimelineFeedWithStream
+          streamId={profileCollectionsStreamId}
+          variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS}
           tagsLayout="inline"
         />,
       );

--- a/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
@@ -129,7 +129,13 @@ function TimelineFeedContent({
     // Store the latest set before early returns so Strict Mode reruns do not retrigger the same transition.
     previousMutedUserIdSetRef.current = currentMutedUserIdSet;
 
-    if (variant === TIMELINE_FEED_VARIANT.PROFILE || variant === TIMELINE_FEED_VARIANT.BOOKMARKS) return;
+    if (
+      variant === TIMELINE_FEED_VARIANT.PROFILE ||
+      variant === TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS ||
+      variant === TIMELINE_FEED_VARIANT.BOOKMARKS
+    ) {
+      return;
+    }
 
     const hasUnmutedUser = previousMutedUserIdSet
       ? [...previousMutedUserIdSet].some((userId) => !currentMutedUserIdSet.has(userId))

--- a/src/components/templates/Profile/Collections/ProfileCollectionsPage.tsx
+++ b/src/components/templates/Profile/Collections/ProfileCollectionsPage.tsx
@@ -1,0 +1,12 @@
+import { TIMELINE_FEED_VARIANT } from '@/config/feed';
+import { TimelineFeed } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed';
+
+/**
+ * ProfileCollectionsPage Template
+ *
+ * Template for the profile Collections tab. Renders the viewed author's
+ * collection posts via TimelineFeed (`PROFILE_COLLECTIONS` → `<pubky>:author:collection`).
+ */
+export function ProfileCollectionsPage() {
+  return <TimelineFeed variant={TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS} />;
+}

--- a/src/config/feed.ts
+++ b/src/config/feed.ts
@@ -6,6 +6,7 @@ export const TIMELINE_FEED_VARIANT = {
   CUSTOM: 'custom',
   BOOKMARKS: 'bookmarks',
   PROFILE: 'profile',
+  PROFILE_COLLECTIONS: 'profile_collections',
   HOT: 'hot',
   SEARCH: 'search',
   COLLECTION: 'collection',

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -8,7 +8,11 @@ import { PostCountsModel } from '@/models/post/counts/postCounts';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import { DELETED } from '@/models/post/details/postDetails.constants';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
-import { type PostStreamId, PostStreamTypes, buildAuthorCollectionsStreamId } from '@/models/stream/post/postStream.types';
+import {
+  type PostStreamId,
+  PostStreamTypes,
+  buildAuthorCollectionsStreamId,
+} from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';
 import { UserStreamModel } from '@/models/stream/user/userStream';

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -9,9 +9,9 @@ import { PostDetailsModel } from '@/models/post/details/postDetails';
 import { DELETED } from '@/models/post/details/postDetails.constants';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
 import {
+  buildAuthorCollectionsStreamId,
   type PostStreamId,
   PostStreamTypes,
-  buildAuthorCollectionsStreamId,
 } from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -265,6 +265,20 @@ describe('PostStreamApplication', () => {
       expect(result).toEqual([shortPostId]);
     });
 
+    it('keeps collection-kind posts in author collections streams', async () => {
+      const authorCollectionsStreamId = `${DEFAULT_AUTHOR}:author:collection` as PostStreamId;
+      const collectionPostId = `${DEFAULT_AUTHOR}:collection-post`;
+
+      await createPostDetailWithKind(collectionPostId, 'collection');
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: authorCollectionsStreamId,
+        postIds: [collectionPostId],
+      });
+
+      expect(result).toEqual([collectionPostId]);
+    });
+
     it('keeps posts without cached details so cache misses can be resolved', async () => {
       const missingPostId = `${DEFAULT_AUTHOR}:missing-post`;
 

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -8,7 +8,7 @@ import { PostCountsModel } from '@/models/post/counts/postCounts';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import { DELETED } from '@/models/post/details/postDetails.constants';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
-import { type PostStreamId, PostStreamTypes } from '@/models/stream/post/postStream.types';
+import { type PostStreamId, PostStreamTypes, buildAuthorCollectionsStreamId } from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';
 import { UserStreamModel } from '@/models/stream/user/userStream';
@@ -1945,6 +1945,50 @@ describe('PostStreamApplication', () => {
       });
 
       expect(result.nextPageIds).toEqual(['author-1:post-1', 'author-2:post-2', 'author-3:post-3']);
+    });
+
+    it('does not filter author profile stream posts from muted authors', async () => {
+      await setupMutedUsers([DEFAULT_AUTHOR] as Pubky[]);
+
+      const mockNexusPostsKeyStream: NexusPostsKeyStream = {
+        post_keys: [`${DEFAULT_AUTHOR}:post-1`, `${DEFAULT_AUTHOR}:post-2`],
+        last_post_score: BASE_TIMESTAMP + 1,
+      };
+      vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue(mockNexusPostsKeyStream);
+
+      const authorStreamId = `author:${DEFAULT_AUTHOR}` as PostStreamId;
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: authorStreamId,
+        limit: 10,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId,
+      });
+
+      expect(result.nextPageIds).toEqual([`${DEFAULT_AUTHOR}:post-1`, `${DEFAULT_AUTHOR}:post-2`]);
+    });
+
+    it('does not filter author collections stream posts from muted authors', async () => {
+      await setupMutedUsers([DEFAULT_AUTHOR] as Pubky[]);
+
+      const mockNexusPostsKeyStream: NexusPostsKeyStream = {
+        post_keys: [`${DEFAULT_AUTHOR}:collection-1`, `${DEFAULT_AUTHOR}:collection-2`],
+        last_post_score: BASE_TIMESTAMP + 1,
+      };
+      vi.spyOn(NexusPostStreamService, 'fetch').mockResolvedValue(mockNexusPostsKeyStream);
+
+      const authorCollectionsStreamId = buildAuthorCollectionsStreamId(DEFAULT_AUTHOR as Pubky);
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: authorCollectionsStreamId,
+        limit: 10,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId,
+      });
+
+      expect(result.nextPageIds).toEqual([`${DEFAULT_AUTHOR}:collection-1`, `${DEFAULT_AUTHOR}:collection-2`]);
     });
 
     it('should fetch more posts until limit is reached after mute filtering', async () => {

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -20,7 +20,7 @@ import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
-import { isSkipPaginatedStream, type PostStreamId } from '@/models/stream/post/postStream.types';
+import { isSkipPaginatedStream, isAuthorStreamSkippingMuteFilter, type PostStreamId } from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';
 import { UserStreamTypes } from '@/models/stream/user/userStream.types';
@@ -241,7 +241,7 @@ export class PostStreamApplication {
     // Author streams and bookmarks intentionally include posts from muted users:
     // bookmarks are explicit saves (#1804); profile is someone's full timeline.
     const shouldFilterMuted =
-      !streamId.startsWith(`${StreamSource.AUTHOR}:`) && !streamId.includes(`:${StreamSource.BOOKMARKS}:`);
+      !isAuthorStreamSkippingMuteFilter(streamId) && !streamId.includes(`:${StreamSource.BOOKMARKS}:`);
     const mutedUserIds = shouldFilterMuted
       ? new Set((await LocalStreamUsersService.findById(UserStreamTypes.MUTED))?.stream ?? [])
       : new Set<Pubky>();

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -21,8 +21,8 @@ import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import {
-  isSkipPaginatedStream,
   isAuthorStreamSkippingMuteFilter,
+  isSkipPaginatedStream,
   type PostStreamId,
 } from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -20,7 +20,11 @@ import { CompositeIdDomain, type Pubky } from '@/models/models.types';
 import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
-import { isSkipPaginatedStream, isAuthorStreamSkippingMuteFilter, type PostStreamId } from '@/models/stream/post/postStream.types';
+import {
+  isSkipPaginatedStream,
+  isAuthorStreamSkippingMuteFilter,
+  type PostStreamId,
+} from '@/models/stream/post/postStream.types';
 import { PostStreamModel } from '@/models/stream/post/tables/postStream';
 import { UnreadPostStreamModel } from '@/models/stream/post/tables/postStream.unread';
 import { UserStreamTypes } from '@/models/stream/user/userStream.types';

--- a/src/core/models/stream/post/postStream.types.test.ts
+++ b/src/core/models/stream/post/postStream.types.test.ts
@@ -6,6 +6,7 @@ import {
   buildDiscoverCollectionsStreamId,
   buildFollowedCollectionsStreamId,
   buildPostReplyStreamId,
+  isAuthorStreamSkippingMuteFilter,
   isSkipPaginatedStream,
 } from '@/models/stream/post/postStream.types';
 import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
@@ -85,5 +86,19 @@ describe('isSkipPaginatedStream', () => {
     expect(isSkipPaginatedStream('timeline:bookmarks:collection')).toBe(false);
     expect(isSkipPaginatedStream(buildAuthorCollectionsStreamId(TEST_PUBKY))).toBe(false);
     expect(isSkipPaginatedStream(`${TEST_PUBKY}:author`)).toBe(false);
+  });
+});
+
+describe('isAuthorStreamSkippingMuteFilter', () => {
+  it('returns true for author profile streams', () => {
+    expect(isAuthorStreamSkippingMuteFilter(`author:${TEST_PUBKY}`)).toBe(true);
+    expect(isAuthorStreamSkippingMuteFilter(`author_replies:${TEST_PUBKY}`)).toBe(true);
+    expect(isAuthorStreamSkippingMuteFilter(buildAuthorCollectionsStreamId(TEST_PUBKY))).toBe(true);
+  });
+
+  it('returns false for global and discover streams', () => {
+    expect(isAuthorStreamSkippingMuteFilter('timeline:all:all')).toBe(false);
+    expect(isAuthorStreamSkippingMuteFilter(buildDiscoverCollectionsStreamId())).toBe(false);
+    expect(isAuthorStreamSkippingMuteFilter(buildCollectionItemsStreamId(TEST_PUBKY, TEST_POST_ID))).toBe(false);
   });
 });

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -143,6 +143,20 @@ export function buildAuthorCollectionsStreamId(authorPubky: Pubky): AuthorCollec
   return `${authorPubky}:${StreamSource.AUTHOR}:${StreamKind.COLLECTION}`;
 }
 
+/**
+ * Author-scoped profile streams intentionally include posts from muted users
+ * (viewing someone's profile shows their full timeline, same as bookmarks #1804).
+ */
+export function isAuthorStreamSkippingMuteFilter(streamId: string): boolean {
+  if (streamId.startsWith(`${StreamSource.AUTHOR}:`)) {
+    return true;
+  }
+  if (streamId.startsWith(`${StreamSource.AUTHOR_REPLIES}:`)) {
+    return true;
+  }
+  return streamId.endsWith(`:${StreamSource.AUTHOR}:${StreamKind.COLLECTION}`);
+}
+
 export function buildFollowedCollectionsStreamId(): FollowedCollectionsStreamId {
   return `${StreamSorting.TIMELINE}:${StreamSource.BOOKMARKS}:${StreamKind.COLLECTION}`;
 }

--- a/src/hooks/useFeedLayoutResolution/useFeedLayoutResolution.test.ts
+++ b/src/hooks/useFeedLayoutResolution/useFeedLayoutResolution.test.ts
@@ -117,6 +117,7 @@ describe('resolveFeedLayout', () => {
       TIMELINE_FEED_VARIANT.HOME,
       TIMELINE_FEED_VARIANT.CUSTOM,
       TIMELINE_FEED_VARIANT.PROFILE,
+      TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS,
       TIMELINE_FEED_VARIANT.HOT,
       TIMELINE_FEED_VARIANT.SEARCH,
     ])('does not mark the %s variant as grid-active', (variant) => {

--- a/src/hooks/useProfileNavigation/useProfileNavigation.test.tsx
+++ b/src/hooks/useProfileNavigation/useProfileNavigation.test.tsx
@@ -112,6 +112,14 @@ describe('useProfileNavigation', () => {
       expect(result.current.activePage).toBe(PROFILE_PAGE_TYPES.UNIQUE_TAGS);
     });
 
+    it('should return COLLECTIONS for the collections route', () => {
+      mockPathname.mockReturnValue(PROFILE_ROUTES.COLLECTIONS);
+
+      const { result } = renderHook(() => useProfileNavigation());
+
+      expect(result.current.activePage).toBe(PROFILE_PAGE_TYPES.COLLECTIONS);
+    });
+
     it('should return PROFILE for the profile page route', () => {
       mockPathname.mockReturnValue(PROFILE_ROUTES.PROFILE_PAGE);
 
@@ -168,6 +176,7 @@ describe('useProfileNavigation', () => {
         { route: PROFILE_ROUTES.FOLLOWING, type: PROFILE_PAGE_TYPES.FOLLOWING },
         { route: PROFILE_ROUTES.FRIENDS, type: PROFILE_PAGE_TYPES.FRIENDS },
         { route: PROFILE_ROUTES.UNIQUE_TAGS, type: PROFILE_PAGE_TYPES.UNIQUE_TAGS },
+        { route: PROFILE_ROUTES.COLLECTIONS, type: PROFILE_PAGE_TYPES.COLLECTIONS },
       ];
 
       pages.forEach(({ route, type }) => {
@@ -202,6 +211,7 @@ describe('useProfileNavigation', () => {
         { page: PROFILE_PAGE_TYPES.FOLLOWING, route: PROFILE_ROUTES.FOLLOWING },
         { page: PROFILE_PAGE_TYPES.FRIENDS, route: PROFILE_ROUTES.FRIENDS },
         { page: PROFILE_PAGE_TYPES.UNIQUE_TAGS, route: PROFILE_ROUTES.UNIQUE_TAGS },
+        { page: PROFILE_PAGE_TYPES.COLLECTIONS, route: PROFILE_ROUTES.COLLECTIONS },
         { page: PROFILE_PAGE_TYPES.PROFILE, route: PROFILE_ROUTES.PROFILE_PAGE },
       ];
 

--- a/src/hooks/useProfileNavigation/useProfileNavigation.ts
+++ b/src/hooks/useProfileNavigation/useProfileNavigation.ts
@@ -53,6 +53,10 @@ const PROFILE_ROUTES_CONFIG: Record<
     route: PROFILE_ROUTES.UNIQUE_TAGS,
     subPath: '/tagged',
   },
+  [PROFILE_PAGE_TYPES.COLLECTIONS]: {
+    route: PROFILE_ROUTES.COLLECTIONS,
+    subPath: '/collections',
+  },
   [PROFILE_PAGE_TYPES.PROFILE]: {
     route: PROFILE_ROUTES.PROFILE_PAGE,
     subPath: '/profile',


### PR DESCRIPTION
## Summary
- Adds a **Collections** tab to the profile (desktop filter bar + mobile menu, below Tagged) using the `Library` icon
- **Posts** tab shows all author posts **except** collections (`author:<pubky>`)
- **Collections** tab shows only that author’s collections in the timeline (`<pubky>:author:collection`)

## Test plan
- [ ] Open your profile → Collections tab navigates to `/profile/collections`
- [ ] Posts tab does not show collections
- [ ] Collections tab shows only that user’s collections
- [ ] Same behavior on another user’s profile (`/profile/[pubky]/collections`)

Resolves #1966 