### PR TITLE
feat: collections custom feeds

### DIFF
--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx
@@ -709,6 +709,7 @@ describe('CustomFeedDialog', () => {
     expect(within(section).getByText('All')).toBeInTheDocument();
     expect(within(section).getByText('Posts')).toBeInTheDocument();
     expect(within(section).getByText('Articles')).toBeInTheDocument();
+    expect(within(section).getByText('Collections')).toBeInTheDocument();
     expect(within(section).getByText('Images')).toBeInTheDocument();
     expect(within(section).getByText('Videos')).toBeInTheDocument();
     expect(within(section).getByText('Links')).toBeInTheDocument();
@@ -731,6 +732,7 @@ describe('CustomFeedDialog', () => {
       expect(within(section).getByText('Videos')).toBeInTheDocument();
       expect(within(section).queryByText('Posts')).not.toBeInTheDocument();
       expect(within(section).queryByText('Articles')).not.toBeInTheDocument();
+      expect(within(section).queryByText('Collections')).not.toBeInTheDocument();
       expect(within(section).queryByText('Links')).not.toBeInTheDocument();
       expect(within(section).queryByText('Files')).not.toBeInTheDocument();
     });

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx.snap
@@ -548,6 +548,39 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode default
               Articles
             </div>
             <div
+              data-testid="select-item-6"
+              data-value="6"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-library"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6 4 14"
+                />
+                <path
+                  d="M12 6v14"
+                />
+                <path
+                  d="M8 8v12"
+                />
+                <path
+                  d="M4 4v16"
+                />
+              </svg>
+               
+              Collections
+            </div>
+            <div
               data-testid="select-item-2"
               data-value="2"
             >
@@ -1287,6 +1320,39 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for create mode with di
               Articles
             </div>
             <div
+              data-testid="select-item-6"
+              data-value="6"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-library"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6 4 14"
+                />
+                <path
+                  d="M12 6v14"
+                />
+                <path
+                  d="M8 8v12"
+                />
+                <path
+                  d="M4 4v16"
+                />
+              </svg>
+               
+              Collections
+            </div>
+            <div
               data-testid="select-item-2"
               data-value="2"
             >
@@ -2022,6 +2088,39 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with cust
               </svg>
                
               Articles
+            </div>
+            <div
+              data-testid="select-item-6"
+              data-value="6"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-library"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6 4 14"
+                />
+                <path
+                  d="M12 6v14"
+                />
+                <path
+                  d="M8 8v12"
+                />
+                <path
+                  d="M4 4v16"
+                />
+              </svg>
+               
+              Collections
             </div>
             <div
               data-testid="select-item-2"
@@ -2828,6 +2927,39 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode with null
               Articles
             </div>
             <div
+              data-testid="select-item-6"
+              data-value="6"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-library"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6 4 14"
+                />
+                <path
+                  d="M12 6v14"
+                />
+                <path
+                  d="M8 8v12"
+                />
+                <path
+                  d="M4 4v16"
+                />
+              </svg>
+               
+              Collections
+            </div>
+            <div
               data-testid="select-item-2"
               data-value="2"
             >
@@ -3611,6 +3743,39 @@ exports[`CustomFeedDialog - Snapshots > matches snapshot for edit mode without c
               </svg>
                
               Articles
+            </div>
+            <div
+              data-testid="select-item-6"
+              data-value="6"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-library"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6 4 14"
+                />
+                <path
+                  d="M12 6v14"
+                />
+                <path
+                  d="M8 8v12"
+                />
+                <path
+                  d="M4 4v16"
+                />
+              </svg>
+               
+              Collections
             </div>
             <div
               data-testid="select-item-2"

--- a/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
+++ b/src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx
@@ -13,6 +13,7 @@ import {
   Image,
   Layers,
   LayoutGrid,
+  Library,
   Link,
   Menu,
   Newspaper,
@@ -150,6 +151,11 @@ export const CustomFeedDialog = ({ mode, children }: CustomFeedDialogProps) => {
       value: PubkyAppPostKind.Long,
       label: tFilter('content.articles'),
       icon: Newspaper,
+    },
+    {
+      value: PubkyAppPostKind.Collection,
+      label: tFilter('content.collections'),
+      icon: Library,
     },
     {
       value: PubkyAppPostKind.Image,


### PR DESCRIPTION
## ✨ Add Collections support to Custom Feeds

  ### Summary

  Custom Feeds now support **Collections** as a selectable Content type, alongside the existing options (All, Posts,
  Articles, Images, Videos, Links, Files). Selecting Collections produces a feed whose stream renders collection posts
  only.

  ### Why

  A previous PR ([#1964](https://github.com/), `716ccccc2 feat(feeds): add collections content filter`) introduced
  Collections as a CONTENT filter on the global Home feed. That work added the plumbing in the shared stream-ID mapper,
  the PostKind ↔ Home content mapper, the Nexus post-stream service, and translations — so the only place still unaware of
   Collections was the Create/Edit Custom Feed dialog, whose content-type dropdown was hard-coded to the original seven
  options.

  ### What changed

  - **`src/components/organisms/CustomFeedDialog/CustomFeedDialog.tsx`**
    - Imported `Library` from `lucide-react` (matching the icon used by the Home filter).
    - Added a `PubkyAppPostKind.Collection` entry to the `allContentFilters` array, placed between **Articles** and
  **Images** to mirror the order in `FilterContent`.
  - **`src/components/organisms/CustomFeedDialog/CustomFeedDialog.test.tsx`**
    - Asserted that `Collections` is present in `renders all content filter options`.
    - Asserted that `Collections` is hidden in `limits content filter options when layout is Visual`.
  - **`CustomFeedDialog.test.tsx.snap`** — regenerated (5 snapshots updated to include the new option).

  ### Why no other code changes were needed

  Every downstream layer already accepts `PubkyAppPostKind.Collection`:

  - 🗺️  **PostKind → CONTENT mapper** — `pubkyPostKindToHomeContent` already maps `Collection → CONTENT.COLLECTIONS`
  (`src/core/utils/pubky-app-spec-feed-mappers.ts`).
  - 🆔 **Stream-ID assembler** — `getStreamIdFromFilters` already maps `COLLECTIONS → 'collection'`
  (`src/core/stores/home/home.utils.ts`).
  - 🧩 **Custom stream hook** — `useCustomStreamId` already runs `customFeed.content` through
  `pubkyPostKindToHomeContent`, so it generates valid `…:collection:tags` stream IDs automatically.
  - 🪧 **Sidebar filter readout** — `CustomFeedFilters` already uses the same mapper and `FilterContent`, both of which
  know about Collections.
  - 🛰️  **Nexus post-stream service** — `StreamKind.COLLECTION` is already enumerated.
  - 🌐 **Translations** — `filters.content.collections` already exists in `en.json` and `pt-BR.json`.
  - 🚫 **Visual layout** — `isVisualCustomFeedContentSupported` correctly excludes Collections (same treatment as
  Posts/Articles/Links/Files), so no extra logic was required.

  A full sweep of every `feed.content` reference in the codebase (6 callsites) confirmed Collection flows through cleanly
  with no further branches to update.

  ---

  _This pull request summary was generated, for full implementation details please reference the file changes._