### PR TITLE
feat: collection metadata handling

### DIFF
--- a/src/app/collections/[userId]/[postId]/page.tsx
+++ b/src/app/collections/[userId]/[postId]/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata as NextMetadata } from 'next';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
+import { fetchUserAndPostForMetadata } from '@/libs/post/postMetadata';
+import { isPostDeleted } from '@/libs/utils/utils';
 import { buildCompositeId } from '@/models/models.utils';
+import { Metadata } from '@/molecules/Metadata/Metadata';
 import { Collection } from '@/templates/Collection/Collection';
 
 export interface CollectionPageProps {
@@ -6,6 +11,43 @@ export interface CollectionPageProps {
     userId: string;
     postId: string;
   }>;
+}
+
+export async function generateMetadata({ params }: CollectionPageProps): Promise<NextMetadata> {
+  try {
+    const { userId, postId } = await params;
+
+    const result = await fetchUserAndPostForMetadata(userId, postId);
+    if (!result) return {};
+
+    const { user, post } = result;
+    if (post.kind !== 'collection') return {};
+
+    const username = user.name;
+    const { content } = post;
+
+    const description = isPostDeleted(content)
+      ? 'This collection has been deleted by its author.'
+      : (parseCollectionContent(content)?.name ?? content);
+
+    const title = `${username} on Pubky`;
+
+    const { openGraph, twitter } = Metadata({
+      title,
+      description,
+    });
+
+    return username && description
+      ? {
+          title,
+          description,
+          openGraph,
+          twitter,
+        }
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 export default async function CollectionPage({ params }: CollectionPageProps) {

--- a/src/app/post/[userId]/[postId]/page.tsx
+++ b/src/app/post/[userId]/[postId]/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata as NextMetadata } from 'next';
 import type { ArticleJSON } from '@/hooks/usePostArticle/usePostArticle.types';
-import { httpResponseToError } from '@/libs/error/error.http';
-import { ErrorService } from '@/libs/error/error.types';
-import { HttpStatusCode } from '@/libs/http/http.types';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
+import { fetchUserAndPostForMetadata } from '@/libs/post/postMetadata';
 import { isPostDeleted } from '@/libs/utils/utils';
 import { buildCompositeId } from '@/models/models.utils';
 import { Metadata } from '@/molecules/Metadata/Metadata';
-import type { NexusPostDetails, NexusUserDetails } from '@/services/nexus/nexus.types';
-import { postApi } from '@/services/nexus/post/post.api';
-import { userApi } from '@/services/nexus/user/user.api';
 import { SinglePostPage } from '@/templates/Post/SinglePost/SinglePostPage';
 
 export interface PostPageProps {
@@ -16,21 +12,6 @@ export interface PostPageProps {
     userId: string;
     postId: string;
   }>;
-}
-
-/**
- * Server-side fetch with Next.js caching and proper error handling.
- * Used for SSR/ISR metadata generation where client-side services are not available.
- */
-async function fetchWithValidation<T>(url: string, operation: string): Promise<T | null> {
-  const res = await fetch(url, { next: { revalidate: 3600 } });
-  if (res.status === HttpStatusCode.NOT_FOUND) {
-    return null;
-  }
-  if (!res.ok) {
-    throw httpResponseToError(res, ErrorService.Nexus, operation, url);
-  }
-  return res.json();
 }
 
 function parseArticleTitle(content: string): string | null {
@@ -51,28 +32,22 @@ export async function generateMetadata({ params }: PostPageProps): Promise<NextM
   try {
     const { userId, postId } = await params;
 
-    // Fetch user and post information concurrently using Nexus URL builders
-    const [user, post] = await Promise.all([
-      fetchWithValidation<NexusUserDetails>(userApi.details({ user_id: userId }), 'fetchUserDetails'),
-      fetchWithValidation<NexusPostDetails>(
-        postApi.details({ author_id: userId, post_id: postId }),
-        'fetchPostDetails',
-      ),
-    ]);
+    const result = await fetchUserAndPostForMetadata(userId, postId);
+    if (!result) return {};
 
-    if (!user || !post) return {};
-
+    const { user, post } = result;
     const username = user.name;
     const { content, kind } = post;
 
     const isDeleted = isPostDeleted(content);
-    const isArticle = kind === 'long';
 
     const postPreview = isDeleted
       ? 'This post has been deleted by its author.'
-      : isArticle
+      : kind === 'long'
         ? (parseArticleTitle(content) ?? content)
-        : content;
+        : kind === 'collection'
+          ? (parseCollectionContent(content)?.name ?? content)
+          : content;
     // Use Intl.Segmenter to truncate by grapheme clusters, avoiding broken emojis.
     const segments = [...graphemeSegmenter.segment(postPreview)];
     const postPreviewTruncated =

--- a/src/libs/post/postMetadata.ts
+++ b/src/libs/post/postMetadata.ts
@@ -1,0 +1,39 @@
+import { httpResponseToError } from '@/libs/error/error.http';
+import { ErrorService } from '@/libs/error/error.types';
+import { HttpStatusCode } from '@/libs/http/http.types';
+import type { NexusPostDetails, NexusUserDetails } from '@/services/nexus/nexus.types';
+import { postApi } from '@/services/nexus/post/post.api';
+import { userApi } from '@/services/nexus/user/user.api';
+
+/**
+ * Server-side fetch with Next.js caching and proper error handling.
+ * Used for SSR/ISR metadata generation where client-side services are not available.
+ */
+export async function fetchWithValidation<T>(url: string, operation: string): Promise<T | null> {
+  const res = await fetch(url, { next: { revalidate: 3600 } });
+  if (res.status === HttpStatusCode.NOT_FOUND) {
+    return null;
+  }
+  if (!res.ok) {
+    throw httpResponseToError(res, ErrorService.Nexus, operation, url);
+  }
+  return res.json();
+}
+
+/**
+ * Concurrently fetches user and post details for use in `generateMetadata`.
+ * Returns `null` when either resource is missing so callers can fall back to
+ * empty metadata in a single guard.
+ */
+export async function fetchUserAndPostForMetadata(
+  userId: string,
+  postId: string,
+): Promise<{ user: NexusUserDetails; post: NexusPostDetails } | null> {
+  const [user, post] = await Promise.all([
+    fetchWithValidation<NexusUserDetails>(userApi.details({ user_id: userId }), 'fetchUserDetails'),
+    fetchWithValidation<NexusPostDetails>(postApi.details({ author_id: userId, post_id: postId }), 'fetchPostDetails'),
+  ]);
+
+  if (!user || !post) return null;
+  return { user, post };
+}

--- a/src/libs/post/postMetadata.ts
+++ b/src/libs/post/postMetadata.ts
@@ -9,7 +9,7 @@ import { userApi } from '@/services/nexus/user/user.api';
  * Server-side fetch with Next.js caching and proper error handling.
  * Used for SSR/ISR metadata generation where client-side services are not available.
  */
-export async function fetchWithValidation<T>(url: string, operation: string): Promise<T | null> {
+async function fetchWithValidation<T>(url: string, operation: string): Promise<T | null> {
   const res = await fetch(url, { next: { revalidate: 3600 } });
   if (res.status === HttpStatusCode.NOT_FOUND) {
     return null;


### PR DESCRIPTION
## Summary

  Extends Open Graph / Twitter card metadata so link previews render correctly for the new `collection` post kind across
  both surfaces that can host one.

  Previously:
  - `/post/[userId]/[postId]` had `generateMetadata`, but only special-cased `kind === 'long'` (articles). For collection
  posts the raw `content` is a JSON envelope, so previews surfaced unreadable JSON.
  - `/collections/[userId]/[postId]` had no `generateMetadata` at all and fell back to app-default metadata.

  ## Changes

  ### `src/libs/post/postMetadata.ts` (new)

  Extracted the small bit of server-safe metadata plumbing into a single module so both routes share it:

  - `fetchWithValidation<T>(url, operation)` — moved out of the post page. Same `next: { revalidate: 3600 }` cache hint
  and `httpResponseToError` mapping.
  - `fetchUserAndPostForMetadata(userId, postId)` — runs the `userApi.details` + `postApi.details` `Promise.all` and
  returns `{ user, post } | null` so callers can bail with a single guard.

  ### `src/app/post/[userId]/[postId]/page.tsx`

  - Replaced the inline `fetchWithValidation` + concurrent-fetch block with `fetchUserAndPostForMetadata`.
  - Extended the `postPreview` switch with a `kind === 'collection'` branch that reuses the canonical
  `parseCollectionContent` from `src/libs/post/collectionContent.ts` and falls back to raw `content` if parsing fails —
  mirroring how the article branch falls back when `parseArticleTitle` returns null.
  - Existing grapheme-segmenter truncation is preserved (still needed for the raw-content fallback path).
  - Article behavior is unchanged.

  ### `src/app/collections/[userId]/[postId]/page.tsx`

  - Added `generateMetadata` using the same `try { … } catch { return {}; }` shape as the post route.
  - Bails to `{}` when either resource is missing **or** when `post.kind !== 'collection'`, so a misrouted non-collection
  post id doesn't get misrepresented as a collection in link previews.
  - Uses collection-specific deleted copy: `"This collection has been deleted by its author."` (intentionally different
  from the post route's "post" wording — the surface is named "collection" everywhere else in the UI).
  - Skips the grapheme segmenter — collection names are already length-bounded by the create-collection form, so the
  truncation overhead isn't worth it here.
  - Same `${username} on Pubky` title pattern as the post route for visual parity.

  ## Why reuse `parseCollectionContent`

  `parseCollectionContent` is a pure function (JSON parse + type guard, no DOM, no IO, no browser globals), so it's safe
  to call from `generateMetadata` on the server. No duplication needed.

  ## ✅ Verification

  - `tsc --noEmit` passes.
  - `eslint` on the three touched files passes.
  - Existing `src/app/post/[userId]/[postId]/page.test.tsx` (404 fallback) still passes — the shared helper preserves the
  exact `fetch` + 404 short-circuit behavior.

  ## 📝 Notes

  No new tests were added. The new code paths are thin composition of already-unit-tested utilities
  (`parseCollectionContent`, `Metadata`, `isPostDeleted`); a dedicated test would mostly re-assert string literals against
   themselves. The existing route test already guards the meaningful error-fallback path.

  _This pull request summary was generated, for full implementation details please reference the file changes._