### PR TITLE
feat(PostPageShell): add mobile variant for left drawer and update tests

### DIFF
--- a/src/components/organisms/PostPageShell/PostPageShell.test.tsx
+++ b/src/components/organisms/PostPageShell/PostPageShell.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
     leftSidebarContent,
     rightSidebarContent,
     leftDrawerContent,
+    leftDrawerContentMobile,
     rightDrawerContent,
     classNameWrapperContent,
   }: {
@@ -29,6 +30,7 @@ vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
     leftSidebarContent?: React.ReactNode;
     rightSidebarContent?: React.ReactNode;
     leftDrawerContent?: React.ReactNode;
+    leftDrawerContentMobile?: React.ReactNode;
     rightDrawerContent?: React.ReactNode;
     classNameWrapperContent?: string;
   }) => (
@@ -36,6 +38,7 @@ vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
       {leftSidebarContent && <div data-testid="left-sidebar">{leftSidebarContent}</div>}
       {rightSidebarContent && <div data-testid="right-sidebar">{rightSidebarContent}</div>}
       {leftDrawerContent && <div data-testid="left-drawer">{leftDrawerContent}</div>}
+      {leftDrawerContentMobile && <div data-testid="left-drawer-mobile">{leftDrawerContentMobile}</div>}
       {rightDrawerContent && <div data-testid="right-drawer">{rightDrawerContent}</div>}
       {children}
     </div>
@@ -45,6 +48,7 @@ vi.mock('@/organisms/ContentLayout/ContentLayout', () => ({
 vi.mock('@/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar', () => ({
   SinglePostLeftSidebar: () => <div data-testid="single-post-left-sidebar">SinglePostLeftSidebar</div>,
   SinglePostLeftDrawer: () => <div data-testid="single-post-left-drawer">SinglePostLeftDrawer</div>,
+  SinglePostLeftDrawerMobile: () => <div data-testid="single-post-left-drawer-mobile">SinglePostLeftDrawerMobile</div>,
 }));
 
 vi.mock('@/organisms/SinglePostRightPanel/SinglePostRightPanel', () => ({
@@ -85,6 +89,18 @@ describe('PostPageShell', () => {
 
     expect(screen.getByTestId('single-post-left-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('left-sidebar')).toContainElement(screen.getByTestId('single-post-left-sidebar'));
+  });
+
+  it('passes the mobile left drawer variant to ContentLayout', () => {
+    render(
+      <PostPageShell postId={VALID_COMPOSITE_POST_ID}>
+        <div>body</div>
+      </PostPageShell>,
+    );
+
+    expect(screen.getByTestId('left-drawer-mobile')).toContainElement(
+      screen.getByTestId('single-post-left-drawer-mobile'),
+    );
   });
 
   it('renders SinglePostRightPanel in right sidebar with postId', () => {

--- a/src/components/organisms/PostPageShell/PostPageShell.tsx
+++ b/src/components/organisms/PostPageShell/PostPageShell.tsx
@@ -4,7 +4,11 @@ import type { PropsWithChildren } from 'react';
 import { usePostMissing } from '@/hooks/usePostMissing/usePostMissing';
 import { ContentLayout } from '@/organisms/ContentLayout/ContentLayout';
 import { HotDiscoveryContentLayout } from '@/organisms/HotDiscoveryContentLayout/HotDiscoveryContentLayout';
-import { SinglePostLeftDrawer, SinglePostLeftSidebar } from '@/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar';
+import {
+  SinglePostLeftDrawer,
+  SinglePostLeftDrawerMobile,
+  SinglePostLeftSidebar,
+} from '@/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar';
 import { SinglePostRightPanel } from '@/organisms/SinglePostRightPanel/SinglePostRightPanel';
 
 export interface PostPageShellProps extends PropsWithChildren {
@@ -38,6 +42,7 @@ export function PostPageShell({ postId, children }: PostPageShellProps) {
       leftSidebarContent={<SinglePostLeftSidebar />}
       rightSidebarContent={<SinglePostRightPanel postId={postId} />}
       leftDrawerContent={<SinglePostLeftDrawer />}
+      leftDrawerContentMobile={<SinglePostLeftDrawerMobile />}
       rightDrawerContent={<SinglePostRightPanel postId={postId} showFeedback={false} />}
     >
       {children}

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SinglePostLeftDrawer, SinglePostLeftSidebar } from './SinglePostLeftSidebar';
+import { SinglePostLeftDrawer, SinglePostLeftDrawerMobile, SinglePostLeftSidebar } from './SinglePostLeftSidebar';
 
 const mockSetLayout = vi.fn();
 const mockUseHomeStore = vi.fn();
@@ -112,7 +112,7 @@ describe('SinglePostLeftSidebar', () => {
 });
 
 describe('SinglePostLeftDrawer', () => {
-  it('renders only the layout filter', () => {
+  it('renders the layout filter outside mobile drawer contexts', () => {
     render(<SinglePostLeftDrawer />);
 
     expect(screen.getByTestId('filter-layout')).toBeInTheDocument();
@@ -140,6 +140,33 @@ describe('SinglePostLeftDrawer', () => {
 
   it('matches snapshot', () => {
     const { container } = render(<SinglePostLeftDrawer />);
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe('SinglePostLeftDrawerMobile', () => {
+  it('renders post filters without the layout filter', () => {
+    render(<SinglePostLeftDrawerMobile />);
+
+    expect(screen.queryByTestId('filter-layout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('filter-reach')).toBeInTheDocument();
+    expect(screen.queryByTestId('filter-sort')).toBeInTheDocument();
+    expect(screen.queryByTestId('filter-content')).toBeInTheDocument();
+    expect(mockFilterLayout).not.toHaveBeenCalled();
+    expect(mockFilterReach).toHaveBeenCalled();
+    expect(mockFilterSort).toHaveBeenCalled();
+    expect(mockFilterContent).toHaveBeenCalled();
+  });
+
+  it('does not update home layout because layout controls are hidden', () => {
+    render(<SinglePostLeftDrawerMobile />);
+
+    expect(screen.queryByTestId('change-layout')).not.toBeInTheDocument();
+    expect(mockSetLayout).not.toHaveBeenCalled();
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<SinglePostLeftDrawerMobile />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
@@ -36,7 +36,10 @@ const mockFilterLayout = vi.fn(
 );
 
 vi.mock('@/stores/home/home.store', () => ({
-  useHomeStore: () => mockUseHomeStore(),
+  useHomeStore: (selector?: (state: ReturnType<typeof mockUseHomeStore>) => unknown) => {
+    const state = mockUseHomeStore();
+    return selector ? selector(state) : state;
+  },
 }));
 
 vi.mock('@/atoms/Container/Container', () => ({

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx.snap
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx.snap
@@ -38,6 +38,34 @@ exports[`SinglePostLeftDrawer > matches snapshot 1`] = `
 </div>
 `;
 
+exports[`SinglePostLeftDrawerMobile > matches snapshot 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-6"
+    data-testid="container"
+  >
+    <div
+      data-disabled="true"
+      data-testid="filter-reach"
+    >
+      FilterReach
+    </div>
+    <div
+      data-disabled="true"
+      data-testid="filter-sort"
+    >
+      FilterSort
+    </div>
+    <div
+      data-disabled="true"
+      data-testid="filter-content"
+    >
+      FilterContent
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SinglePostLeftSidebar > matches snapshot 1`] = `
 <div>
   <div

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
@@ -10,16 +10,16 @@ import { useHomeStore } from '@/stores/home/home.store';
  * SinglePostFilters
  *
  * Filter set for SinglePost page left panels.
- * Currently supports layout only.
+ * Currently supports layout in desktop sidebar and wide-shell drawer contexts.
  */
-function SinglePostFilters() {
+function SinglePostFilters({ hideLayoutFilter = false }: { hideLayoutFilter?: boolean }) {
   const { layout, setLayout } = useHomeStore();
 
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
       <FilterReach selectedTab={undefined} defaultSelectedTab={undefined} disabled />
       <FilterSort selectedTab={undefined} defaultSelectedTab={undefined} disabled />
-      <FilterLayout selectedTab={layout} onTabChange={setLayout} />
+      {!hideLayoutFilter && <FilterLayout selectedTab={layout} onTabChange={setLayout} />}
       <FilterContent selectedTab={undefined} defaultSelectedTab={undefined} disabled />
     </Container>
   );
@@ -37,8 +37,17 @@ export function SinglePostLeftSidebar() {
 /**
  * SinglePostLeftDrawer
  *
- * Left drawer for SinglePost page (tablet/mobile).
+ * Left drawer for SinglePost page outside mobile drawer contexts.
  */
 export function SinglePostLeftDrawer() {
   return <SinglePostFilters />;
+}
+
+/**
+ * SinglePostLeftDrawerMobile
+ *
+ * Left drawer for SinglePost page on mobile viewports.
+ */
+export function SinglePostLeftDrawerMobile() {
+  return <SinglePostFilters hideLayoutFilter />;
 }

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
@@ -9,20 +9,32 @@ import { useHomeStore } from '@/stores/home/home.store';
 /**
  * SinglePostFilters
  *
- * Filter set for SinglePost page left panels.
- * Currently supports layout in desktop sidebar and wide-shell drawer contexts.
+ * Base filter set for SinglePost page left panels (reach, sort, content).
+ * Layout-aware variants render the layout filter via a separate child so this
+ * shared shell stays free of any store subscription.
  */
-function SinglePostFilters({ hideLayoutFilter = false }: { hideLayoutFilter?: boolean }) {
-  const { layout, setLayout } = useHomeStore();
-
+function SinglePostFilters({ children }: { children?: React.ReactNode }) {
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
       <FilterReach selectedTab={undefined} defaultSelectedTab={undefined} disabled />
       <FilterSort selectedTab={undefined} defaultSelectedTab={undefined} disabled />
-      {!hideLayoutFilter && <FilterLayout selectedTab={layout} onTabChange={setLayout} />}
+      {children}
       <FilterContent selectedTab={undefined} defaultSelectedTab={undefined} disabled />
     </Container>
   );
+}
+
+/**
+ * SinglePostLayoutFilter
+ *
+ * Layout filter bound to the home store. Isolated in its own component so the
+ * store subscription only exists where the layout filter is actually rendered.
+ */
+function SinglePostLayoutFilter() {
+  const layout = useHomeStore((state) => state.layout);
+  const setLayout = useHomeStore((state) => state.setLayout);
+
+  return <FilterLayout selectedTab={layout} onTabChange={setLayout} />;
 }
 
 /**
@@ -31,7 +43,11 @@ function SinglePostFilters({ hideLayoutFilter = false }: { hideLayoutFilter?: bo
  * Left sidebar for SinglePost page (desktop).
  */
 export function SinglePostLeftSidebar() {
-  return <SinglePostFilters />;
+  return (
+    <SinglePostFilters>
+      <SinglePostLayoutFilter />
+    </SinglePostFilters>
+  );
 }
 
 /**
@@ -40,14 +56,19 @@ export function SinglePostLeftSidebar() {
  * Left drawer for SinglePost page outside mobile drawer contexts.
  */
 export function SinglePostLeftDrawer() {
-  return <SinglePostFilters />;
+  return (
+    <SinglePostFilters>
+      <SinglePostLayoutFilter />
+    </SinglePostFilters>
+  );
 }
 
 /**
  * SinglePostLeftDrawerMobile
  *
- * Left drawer for SinglePost page on mobile viewports.
+ * Left drawer for SinglePost page on mobile viewports. Omits the layout filter
+ * entirely, so it never subscribes to the home store.
  */
 export function SinglePostLeftDrawerMobile() {
-  return <SinglePostFilters hideLayoutFilter />;
+  return <SinglePostFilters />;
 }


### PR DESCRIPTION
resolve #1989 


What is the problem?
We show the Layout filters in mobile when the user cannot see any difference.

Solution?
Hide the Layout Filters from the sidebars & drawers


Desktop showing correctly the Filters
<img width="1035" height="812" alt="Screenshot 2026-06-16 at 18 05 02" src="https://github.com/user-attachments/assets/235faeb1-fa35-414d-be1b-cb0e14b53609" />

Video in mobile
https://github.com/user-attachments/assets/e45cc04b-c6d2-4b56-ad36-cc376dec4cf9



## QA Checklist — #1989 Layouts hidden on mobile post page
Mobile
 - [X] **Post page on mobile (< lg)** — open left drawer (top-left button). Confirm Reach, Sort, Content show but **no Layout/Column-Wide** section.
 - [X] **Home Page on Mobile**  — open left drawer (top-left button). Confirm Reach, Sort, Content show but **no Layout/Column-Wide** section.

Desktop
  - [X] **Post page on desktop / wide-shell** — open left drawer (filters button). Confirm the Layout filter still shows and still switches Column ↔ Wide.
  - [X] **Post page desktop left sidebar** — unchanged, still shows the Layout filter.
