### PR TITLE
feat: collection notification support

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -996,6 +996,7 @@
       "attachmentsCleared": "تم ازالة المرفقات",
       "failedToLoadPosts": "تعذر تحميل المنشورات الجديدة",
       "parseError": "تعذر تحليل محتوى المقال",
+      "collectionParseError": "تعذر تحليل محتوى المجموعة",
       "coverImageError": "تعذر تحميل صورة الغلاف",
       "attachmentsLoadFailed": "تعذر تحميل المرفقات",
       "repostSuccessFallback": "أُعيد النشر"

--- a/messages/de.json
+++ b/messages/de.json
@@ -996,6 +996,7 @@
       "attachmentsCleared": "Anhaenge entfernt",
       "failedToLoadPosts": "Neue Beiträge konnten nicht geladen werden",
       "parseError": "Artikelinhalt konnte nicht analysiert werden",
+      "collectionParseError": "Sammlungsinhalt konnte nicht analysiert werden",
       "coverImageError": "Titelbild konnte nicht geladen werden",
       "attachmentsLoadFailed": "Anhänge konnten nicht geladen werden",
       "repostSuccessFallback": "Repostet"

--- a/messages/en.json
+++ b/messages/en.json
@@ -995,6 +995,7 @@
       "attachmentsCleared": "Articles support one cover image",
       "failedToLoadPosts": "Could not load new posts",
       "parseError": "Could not parse article content",
+      "collectionParseError": "Could not parse collection content",
       "coverImageError": "Could not load cover image",
       "attachmentsLoadFailed": "Could not load attachments"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -997,6 +997,7 @@
       "attachmentsCleared": "Los artículos admiten una imagen de portada",
       "failedToLoadPosts": "No se pudieron cargar las publicaciones nuevas",
       "parseError": "No se pudo analizar el contenido del artículo",
+      "collectionParseError": "No se pudo analizar el contenido de la colección",
       "coverImageError": "No se pudo cargar la imagen de portada",
       "attachmentsLoadFailed": "No se pudieron cargar los archivos adjuntos"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -994,6 +994,7 @@
       "attachmentsCleared": "Pieces jointes supprimées",
       "failedToLoadPosts": "Impossible de charger les nouvelles publications",
       "parseError": "Impossible d'analyser le contenu de l'article",
+      "collectionParseError": "Impossible d'analyser le contenu de la collection",
       "coverImageError": "Impossible de charger l'image de couverture",
       "attachmentsLoadFailed": "Impossible de charger les pièces jointes",
       "repostSuccessFallback": "Republié"

--- a/messages/it.json
+++ b/messages/it.json
@@ -994,6 +994,7 @@
       "attachmentsCleared": "Allegati rimossi",
       "failedToLoadPosts": "Impossibile caricare i nuovi post",
       "parseError": "Impossibile analizzare il contenuto dell'articolo",
+      "collectionParseError": "Impossibile analizzare il contenuto della raccolta",
       "coverImageError": "Impossibile caricare l'immagine di copertina",
       "attachmentsLoadFailed": "Impossibile caricare gli allegati",
       "repostSuccessFallback": "Ripubblicato"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -994,6 +994,7 @@
       "attachmentsCleared": "添付ファイルを消去しました",
       "failedToLoadPosts": "新しい投稿を読み込めませんでした",
       "parseError": "記事コンテンツを解析できませんでした",
+      "collectionParseError": "コレクションのコンテンツを解析できませんでした",
       "coverImageError": "カバー画像を読み込めませんでした",
       "attachmentsLoadFailed": "添付ファイルを読み込めませんでした",
       "repostSuccessFallback": "リポストしました"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -994,6 +994,7 @@
       "attachmentsCleared": "Anexos removidos",
       "failedToLoadPosts": "Não foi possível carregar novas publicações",
       "parseError": "Não foi possível analisar o conteúdo do artigo",
+      "collectionParseError": "Não foi possível analisar o conteúdo da coleção",
       "coverImageError": "Não foi possível carregar a imagem de capa",
       "attachmentsLoadFailed": "Não foi possível carregar os anexos",
       "repostSuccessFallback": "Repostado"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -994,6 +994,7 @@
       "attachmentsCleared": "附件已清除",
       "failedToLoadPosts": "无法加载新帖子",
       "parseError": "无法解析文章内容",
+      "collectionParseError": "无法解析合集内容",
       "coverImageError": "无法加载封面图片",
       "attachmentsLoadFailed": "无法加载附件",
       "repostSuccessFallback": "已转发"

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -359,6 +359,59 @@ describe('NotificationItem', () => {
     });
   });
 
+  it('extracts name from collection post content in notifications', async () => {
+    const collectionContent = JSON.stringify({
+      name: 'My Collection',
+      description: 'Some description',
+      items: ['user1:post1'],
+    });
+
+    mockGetOrFetch.mockResolvedValue({
+      kind: 'collection',
+      content: collectionContent,
+    });
+
+    const mentionNotification = {
+      id: 'mention:123:user1',
+      type: NotificationType.Mention,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      mentioned_by: 'user1',
+      post_uri: 'pubky://user1/pub/pubky.app/posts/post123',
+    } as FlatNotification;
+
+    render(<NotificationItem notification={mentionNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("'My Collection'")).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to raw content and shows toast when collection JSON parsing fails', async () => {
+    const invalidJson = 'not valid json content';
+
+    mockGetOrFetch.mockResolvedValue({
+      kind: 'collection',
+      content: invalidJson,
+    });
+
+    const mentionNotification = {
+      id: 'mention:123:user1',
+      type: NotificationType.Mention,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      mentioned_by: 'user1',
+      post_uri: 'pubky://user1/pub/pubky.app/posts/post123',
+    } as FlatNotification;
+
+    render(<NotificationItem notification={mentionNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        variant: 'error',
+        description: 'Could not parse collection content',
+      });
+    });
+  });
+
   it('uses content directly for short posts', async () => {
     mockGetOrFetch.mockResolvedValue({
       kind: 'short',

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -11,6 +11,7 @@ import type { ArticleJSON } from '@/hooks/usePostArticle/usePostArticle.types';
 import { buildSearchUrl } from '@/hooks/useTagSearch/useTagSearch.utils';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { Logger } from '@/libs/logger/logger';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { formatNotificationTime, isPostDeleted } from '@/libs/utils/utils';
 import { NotificationType } from '@/models/notification/notification.types';
 import { NotificationIcon } from '@/molecules/NotificationIcon/NotificationIcon';
@@ -81,6 +82,17 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
               toast({
                 variant: 'error',
                 description: tPostToast('parseError'),
+              });
+            }
+          } else if (post.kind === 'collection') {
+            const parsed = parseCollectionContent(post.content);
+            if (parsed) {
+              setPostContent(parsed.name);
+            } else {
+              setPostContent(post.content);
+              toast({
+                variant: 'error',
+                description: tPostToast('collectionParseError'),
               });
             }
           } else {


### PR DESCRIPTION
## Summary

  Fixes notifications appearing broken for Collection posts. Previously, when a notification referenced a Collection post
  (e.g. a reply, mention, repost, or tag on a collection), the preview displayed the raw JSON envelope
  (`{"name":"…","items":[…]}`) because `NotificationItem` fell through to the default text-handling branch.

  Collections now get the same first-class treatment as articles (`long` posts): the JSON envelope is parsed and the
  collection's `name` is shown as the preview text.

  ## Changes

  ### `src/components/organisms/NotificationItem/NotificationItem.tsx`

  - Imported `parseCollectionContent` from `@/libs/post/collectionContent` (canonical parser already used elsewhere for
  Collection rendering).
  - Added an `else if (post.kind === 'collection')` branch between the existing `long` branch and the default branch.
    - On success: `setPostContent(parsed.name)`.
    - On failure (`parseCollectionContent` returns `null`): falls back to raw content and fires an error toast — mirroring
   the existing article fallback behavior.

  ### `src/components/organisms/NotificationItem/NotificationItem.test.tsx`

  Added two tests modeled after the existing article tests:

  - ✅ Extracts `name` from a valid `collection` post (preview renders as `'My Collection'`).
  - ✅ Falls back to raw content and shows the new toast when collection JSON parsing fails.

  All 30 tests in the suite pass.

  ### Translations

  Added `toast.post.collectionParseError` to all 9 locale files alongside the existing `parseError` key:

  - 🇬🇧 `en`: "Could not parse collection content"
  - 🇸🇦 `ar`: "تعذر تحليل محتوى المجموعة"
  - 🇩🇪 `de`: "Sammlungsinhalt konnte nicht analysiert werden"
  - 🇪🇸 `es`: "No se pudo analizar el contenido de la colección"
  - 🇫🇷 `fr`: "Impossible d'analyser le contenu de la collection"
  - 🇮🇹 `it`: "Impossibile analizzare il contenuto della raccolta"
  - 🇯🇵 `ja`: "コレクションのコンテンツを解析できませんでした"
  - 🇧🇷 `pt-BR`: "Não foi possível analisar o conteúdo da coleção"
  - 🇨🇳 `zh`: "无法解析合集内容"

  ## Reused Code

  - `parseCollectionContent` (`src/libs/post/collectionContent.ts`) — pure parser that returns `PubkyAppCollectionContent
  | null` and handles all shape validation, so no `try`/`catch` was needed at the call site.
  - `tPostToast` (already in scope via `useTranslations('toast.post')`) — no new hook required.
  - `isPostDeleted`, `setPostContent`, `formatPreviewText`, `hasPostPreview` — unchanged; they transparently wrap and
  truncate the new `name`-derived preview.

Closes #1842 

  _This pull request summary was generated, for full implementation details please reference the file changes._