### PR TITLE
fix: hide incorrect total bookmarks count

### DIFF
--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx
@@ -37,7 +37,7 @@ vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
 }));
 
 describe('BookmarksHero', () => {
-  it('renders the system collection title, owner, count, and description', () => {
+  it('renders the system collection title, owner, and description', () => {
     render(
       <BookmarksHero
         avatarName="Alice"
@@ -50,7 +50,10 @@ describe('BookmarksHero', () => {
 
     expect(screen.getByRole('heading', { name: 'collections.bookmarks.title' })).toBeInTheDocument();
     expect(screen.getByText('collections.bookmarks.description')).toBeInTheDocument();
-    expect(screen.getByText('15')).toBeInTheDocument();
+    // TODO: The bookmark count badge is temporarily hidden (the BE total counts
+    // collections + deleted posts, overstating the grid). Re-assert once the
+    // backend exposes an accurate posts-only count and the badge is re-wired.
+    expect(screen.queryByText('15')).not.toBeInTheDocument();
     expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-name', 'Alice');
     expect(screen.getByText('Alice', { selector: 'span' })).toBeInTheDocument();
   });

--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx.snap
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx.snap
@@ -47,37 +47,6 @@ exports[`BookmarksHero - Snapshots > matches the snapshot with count and avatar 
           Alice
         </span>
       </div>
-      <div
-        class="flex items-center gap-1 text-muted-foreground"
-        data-testid="container"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note size-3 shrink-0"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
-          data-testid="typography"
-        >
-          15
-        </span>
-      </div>
     </div>
     <p
       class="max-w-full text-xl leading-7 font-light text-muted-foreground md:text-2xl md:leading-8"

--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.tsx
@@ -4,7 +4,11 @@ import { useTranslations } from 'next-intl';
 import { Card, CardContent } from '@/atoms/Card/Card';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
-import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/CollectionCountBadge';
+// TODO: Re-enable the bookmark count badge once the backend exposes an accurate
+// posts-only bookmark count. The current `userCounts.bookmarks` total also counts
+// bookmarked collections and deleted posts, so it overstates what the grid shows
+// (e.g. 60 total vs 5 visible posts). The BE team will add a dedicated count to rewire here.
+// import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/CollectionCountBadge';
 import { HeroOwner } from '@/organisms/HeroOwner/HeroOwner';
 
 interface BookmarksHeroProps {
@@ -19,7 +23,10 @@ export function BookmarksHero({
   avatarName,
   avatarSeed,
   avatarUrl,
-  bookmarkCount,
+  // TODO: `bookmarkCount` is intentionally not consumed while the count badge is
+  // hidden (see import note above). Kept on the props/interface so re-wiring the
+  // badge later is a one-line change.
+  // bookmarkCount,
   isProfileResolved,
 }: BookmarksHeroProps) {
   const t = useTranslations('collections.bookmarks');
@@ -50,7 +57,9 @@ export function BookmarksHero({
             size="sm"
           />
 
-          {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />}
+          {/* TODO: Bookmark count badge hidden — see import note above. Re-enable once
+              the backend provides an accurate posts-only bookmark count. */}
+          {/* {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />} */}
         </Container>
 
         <Typography

--- a/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx
+++ b/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx
@@ -109,10 +109,13 @@ describe('CollectionBookmarkCard', () => {
     expect(screen.getByText('collections.bookmarks.description')).toBeInTheDocument();
   });
 
-  it('renders the formatted count label from the local bookmarks summary', () => {
+  it('hides the bookmark count label (temporarily, pending an accurate BE count)', () => {
     setup({ bookmarkCount: 42 });
     render(<CollectionBookmarkCard />);
-    expect(screen.getByText('42')).toBeInTheDocument();
+    // TODO: The badge is hidden because the BE total counts collections + deleted
+    // posts, overstating what the grid shows. Re-assert the formatted count once the
+    // backend exposes a posts-only count and the badge is re-wired.
+    expect(screen.queryByText('42')).not.toBeInTheDocument();
   });
 
   it('renders no count label when the bookmark count is undefined', () => {

--- a/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx.snap
@@ -53,37 +53,6 @@ exports[`CollectionBookmarkCard - Snapshots > matches the snapshot for a signed-
           data-testid="container"
         >
           <div
-            class="flex items-center gap-1 text-muted-foreground"
-            data-testid="container"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-sticky-note size-3 shrink-0"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-              />
-              <path
-                d="M15 3v5a1 1 0 0 0 1 1h5"
-              />
-            </svg>
-            <span
-              class="text-xs leading-4 font-medium tracking-[1.2px] uppercase"
-              data-testid="typography"
-            >
-              123
-            </span>
-          </div>
-          <div
             data-alt="Alice"
             data-avatar-url="https://example.com/avatar.png"
             data-fallback-seed="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"

--- a/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.tsx
+++ b/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.tsx
@@ -9,7 +9,11 @@ import { Link } from '@/atoms/Link/Link';
 import { Typography } from '@/atoms/Typography/Typography';
 import { useBookmarksCollectionSummary } from '@/hooks/useBookmarksCollectionSummary/useBookmarksCollectionSummary';
 import { cn } from '@/libs/utils/utils';
-import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/CollectionCountBadge';
+// TODO: Re-enable the bookmark count badge once the backend exposes an accurate
+// posts-only bookmark count. The current `userCounts.bookmarks` total also counts
+// bookmarked collections and deleted posts, so it overstates what the grid shows
+// (e.g. 60 total vs 5 visible posts). The BE team will add a dedicated count to rewire here.
+// import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/CollectionCountBadge';
 import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
 
 interface CollectionBookmarkCardProps {
@@ -33,7 +37,9 @@ interface CollectionBookmarkCardProps {
  */
 export function CollectionBookmarkCard({ className }: CollectionBookmarkCardProps) {
   const t = useTranslations('collections');
-  const { avatarName, avatarSeed, avatarUrl, bookmarkCount } = useBookmarksCollectionSummary();
+  // TODO: `bookmarkCount` is omitted while the count badge is hidden (see import note
+  // above). Pull it back off the summary when re-wiring the badge.
+  const { avatarName, avatarSeed, avatarUrl } = useBookmarksCollectionSummary();
 
   const title = t('bookmarks.title');
   const description = t('bookmarks.description');
@@ -61,7 +67,9 @@ export function CollectionBookmarkCard({ className }: CollectionBookmarkCardProp
             </Container>
 
             <Container overrideDefaults className="flex shrink-0 items-center gap-2 sm:gap-3">
-              {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />}
+              {/* TODO: Bookmark count badge hidden — see import note above. Re-enable once
+                  the backend provides an accurate posts-only bookmark count. */}
+              {/* {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />} */}
               <AvatarWithFallback
                 avatarUrl={avatarUrl}
                 name={avatarName}


### PR DESCRIPTION
  ## 🔖 Hide the misleading total bookmarks count

  ### Summary
  The Bookmarks surface was showing a total count (e.g. **60**) that didn't match the feed below it (only **5** cards).
  After investigating, the count itself is the problem, not the feed — so this PR temporarily hides the count badge until
  the backend can provide an accurate number.

  ### 🔍 Background / Investigation
  - The `60` comes from the backend user-counts field `bookmarks` (`GET /v0/user/{user_id}/counts`).
  - That field counts **every** bookmarked record — including bookmarked **collections** and **deleted posts** — none of
  which are shown in the bookmarks grid (collections are surfaced separately; deleted posts are filtered everywhere).
  - Real breakdown for the reported account: **45 collections + 10 deleted posts + 5 live posts = 60**.
  - The feed correctly displayed those **5 live posts** (including the oldest ones at the very bottom of the list), which
  confirmed pagination/infinite-scroll is **working as designed** — there was no scroll bug. ✅

  So there's nothing to fix in the feed. The only real issue is the count being a different (larger) number than what the
  grid can ever show, which reads as broken to users.

  ### ✅ Changes
  Hidden the bookmark count badge in the two places it renders, both fed by `useBookmarksCollectionSummary` →
  `userCounts.bookmarks`:

  - **`BookmarksHero`** — the count badge in the hero on `/collections/bookmarks`.
  - **`CollectionBookmarkCard`** — the count badge on the pinned "Bookmarks" card in the Collections landing.

  Implementation notes:
  - Commented out the badge render and its `CollectionCountBadge` import in both components, each with a `TODO` explaining
  the backend follow-up.
  - Left the `bookmarkCount` plumbing intact (`useBookmarksCollectionSummary` still returns it; `BookmarksHeroProps` still
  declares it) so re-wiring later is a near one-line change.
  - Avoided `noUnusedLocals` build errors by commenting `bookmarkCount` out of the two destructures rather than leaving
  dead variables.
  - Updated the affected unit tests to assert the badge is now absent (with `TODO`s to restore the real-count assertions)
  and regenerated both snapshots.

  ### 🧰 Backend follow-up (out of scope here)
  Tracked separately with the backend team. The ask: either fix `counts.bookmarks` to exclude `kind=collection` and
  deleted posts, or add a new posts-only count field to rewire to. At minimum, deleted posts should never be counted.

  ### 🧪 Verification
  - `eslint` ✅
  - `tsc --noEmit` ✅
  - Affected unit tests + regenerated snapshots ✅

  _This pull request summary was generated, for full implementation details please reference the file changes._