### PR TITLE
fix(search): treat compact pubky prefix as ambiguous in autocomplete

### DIFF
--- a/src/hooks/useSearchAutocomplete/useSearchAutocomplete.constants.ts
+++ b/src/hooks/useSearchAutocomplete/useSearchAutocomplete.constants.ts
@@ -17,11 +17,8 @@ export const AUTOCOMPLETE_USER_LIMIT = 10;
 /** Minimum character length for user ID searches after "pubky" prefix */
 export const MIN_USER_ID_SEARCH_LENGTH = 3;
 
-/**
- * Prefixes for user ID searches
- * Order matters - longer prefixes should come first to match correctly
- * - pubky: legacy format with colon
- * - pk: legacy format
- * - pubky: new format without colon (must be last to not match 'pubky:' first)
- */
-export const USER_ID_PREFIXES = ['pubky:', 'pk:', 'pubky'] as const;
+/** New compact user ID prefix. It is also valid text in tags and usernames. */
+export const COMPACT_USER_ID_PREFIX = 'pubky';
+
+/** Legacy, unambiguous user ID prefixes that remain ID-only searches. */
+export const DELIMITED_USER_ID_PREFIXES = ['pubky:', 'pk:'] as const;

--- a/src/hooks/useSearchAutocomplete/useSearchAutocomplete.test.ts
+++ b/src/hooks/useSearchAutocomplete/useSearchAutocomplete.test.ts
@@ -71,6 +71,18 @@ vi.mock('lodash-es', () => ({
   }),
 }));
 
+async function flushAutocompleteSearch() {
+  await act(async () => {
+    vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
+    await vi.runOnlyPendingTimersAsync();
+  });
+
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe('useSearchAutocomplete', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -141,17 +153,7 @@ describe('useSearchAutocomplete', () => {
   it('fetches tags and users after debounce', async () => {
     const { result, rerender } = renderHook(() => useSearchAutocomplete({ query: 'tech' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     // Set mock user details map to simulate useLiveQuery returning data
     const userDetailsMap = new Map<Pubky, NexusUserDetails>();
@@ -179,17 +181,7 @@ describe('useSearchAutocomplete', () => {
   it('searches by user ID when query starts with pk:', async () => {
     renderHook(() => useSearchAutocomplete({ query: 'pk:abc' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'abc', limit: 10 });
     // Should not search by name or tags when doing explicit ID search with prefix
@@ -197,20 +189,60 @@ describe('useSearchAutocomplete', () => {
     expect(mockGetTagsByPrefix).not.toHaveBeenCalled();
   });
 
+  it.each(['p', 'pu', 'pub', 'pubk', 'pubky'])('searches tags and usernames but not user IDs for %s', async (query) => {
+    renderHook(() => useSearchAutocomplete({ query }));
+
+    await flushAutocompleteSearch();
+
+    expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: query, limit: 3 });
+    expect(mockGetUsersByName).toHaveBeenCalledWith({ prefix: query, limit: 10 });
+    expect(mockFetchUsersById).not.toHaveBeenCalled();
+  });
+
+  it('keeps compact pubky tag text intact and skips the invalid user ID search', async () => {
+    renderHook(() => useSearchAutocomplete({ query: 'pubky-feedback' }));
+
+    await flushAutocompleteSearch();
+
+    expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: 'pubky-feedback', limit: 3 });
+    expect(mockGetUsersByName).toHaveBeenCalledWith({ prefix: 'pubky-feedback', limit: 10 });
+    expect(mockFetchUsersById).not.toHaveBeenCalled();
+  });
+
+  it('searches compact pubky text by tag and name while stripping only the user ID prefix', async () => {
+    renderHook(() => useSearchAutocomplete({ query: 'pubkyabc' }));
+
+    await flushAutocompleteSearch();
+
+    expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: 'pubkyabc', limit: 3 });
+    expect(mockGetUsersByName).toHaveBeenCalledWith({ prefix: 'pubkyabc', limit: 10 });
+    expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'abc', limit: 10 });
+  });
+
+  it('preserves uppercase raw text while searching user IDs case-insensitively', async () => {
+    renderHook(() => useSearchAutocomplete({ query: 'IH4' }));
+
+    await flushAutocompleteSearch();
+
+    expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: 'IH4', limit: 3 });
+    expect(mockGetUsersByName).toHaveBeenCalledWith({ prefix: 'IH4', limit: 10 });
+    expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'IH4', limit: 10 });
+  });
+
+  it('recognizes a mixed-case compact prefix without changing endpoint query casing', async () => {
+    renderHook(() => useSearchAutocomplete({ query: 'pubkyIH4' }));
+
+    await flushAutocompleteSearch();
+
+    expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: 'pubkyIH4', limit: 3 });
+    expect(mockGetUsersByName).toHaveBeenCalledWith({ prefix: 'pubkyIH4', limit: 10 });
+    expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'IH4', limit: 10 });
+  });
+
   it('searches by user ID AND name AND tags for non-prefixed queries', async () => {
     renderHook(() => useSearchAutocomplete({ query: 'abc123' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     // Should search by ID (using the raw query as prefix)
     expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'abc123', limit: 10 });
@@ -222,17 +254,7 @@ describe('useSearchAutocomplete', () => {
   it('does not search by ID if prefix is too short', async () => {
     renderHook(() => useSearchAutocomplete({ query: 'pk:ab' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(mockFetchUsersById).not.toHaveBeenCalled();
   });
@@ -244,17 +266,7 @@ describe('useSearchAutocomplete', () => {
 
     const { result, rerender } = renderHook(() => useSearchAutocomplete({ query: 'test' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     // Set mock user details map for all users (including user3 from ID search)
     const userDetailsMap = new Map<Pubky, NexusUserDetails>();
@@ -284,17 +296,7 @@ describe('useSearchAutocomplete', () => {
 
     const { result } = renderHook(() => useSearchAutocomplete({ query: 'tech' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(result.current.tags).toEqual([]);
     expect(result.current.users).toEqual([]);
@@ -313,17 +315,7 @@ describe('useSearchAutocomplete', () => {
     // Change query
     rerender({ query: 'test' });
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     // Should have searched with 'test'
     expect(mockGetTagsByPrefix).toHaveBeenLastCalledWith({ prefix: 'test', limit: 3 });
@@ -332,17 +324,7 @@ describe('useSearchAutocomplete', () => {
   it('trims whitespace from query', async () => {
     renderHook(() => useSearchAutocomplete({ query: '  tech  ' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: 'tech', limit: 3 });
   });
@@ -350,17 +332,7 @@ describe('useSearchAutocomplete', () => {
   it('searches by user ID when query starts with pubky: (with colon)', async () => {
     renderHook(() => useSearchAutocomplete({ query: 'pubky:abc123' }));
 
-    // Fast-forward past debounce and run all pending timers
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    // Wait for promises to resolve
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     // Should strip the 'pubky:' prefix (including colon) and search with just the z32 part
     expect(mockFetchUsersById).toHaveBeenCalledWith({ prefix: 'abc123', limit: 10 });
@@ -373,15 +345,7 @@ describe('useSearchAutocomplete', () => {
     const longQuery = 'a'.repeat(21);
     renderHook(() => useSearchAutocomplete({ query: longQuery }));
 
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(mockGetTagsByPrefix).not.toHaveBeenCalled();
     // User searches should still proceed
@@ -393,15 +357,7 @@ describe('useSearchAutocomplete', () => {
     const exactQuery = 'a'.repeat(20);
     renderHook(() => useSearchAutocomplete({ query: exactQuery }));
 
-    await act(async () => {
-      vi.advanceTimersByTime(AUTOCOMPLETE_DEBOUNCE_MS);
-      await vi.runOnlyPendingTimersAsync();
-    });
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushAutocompleteSearch();
 
     expect(mockGetTagsByPrefix).toHaveBeenCalledWith({ prefix: exactQuery, limit: 3 });
   });

--- a/src/hooks/useSearchAutocomplete/useSearchAutocomplete.ts
+++ b/src/hooks/useSearchAutocomplete/useSearchAutocomplete.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash-es';
-import { TAG_MAX_LENGTH } from '@/config/posts';
 import { SearchController } from '@/controllers/search/search';
 import { useUserDetailsFromIds } from '@/hooks/useUserDetailsFromIds/useUserDetailsFromIds';
 import { Logger } from '@/libs/logger/logger';
@@ -11,14 +10,13 @@ import {
   AUTOCOMPLETE_DEBOUNCE_MS,
   AUTOCOMPLETE_TAG_LIMIT,
   AUTOCOMPLETE_USER_LIMIT,
-  MIN_USER_ID_SEARCH_LENGTH,
-  USER_ID_PREFIXES,
 } from './useSearchAutocomplete.constants';
 import type {
   AutocompleteTag,
   UseSearchAutocompleteParams,
   UseSearchAutocompleteResult,
 } from './useSearchAutocomplete.types';
+import { resolveSearchAutocompletePlan } from './useSearchAutocomplete.utils';
 
 export function useSearchAutocomplete({
   query,
@@ -40,24 +38,16 @@ export function useSearchAutocomplete({
       setIsSearching(true);
 
       try {
-        // Determine if this is an explicit user ID search (has pk: or pubky prefix)
-        const matchedPrefix = USER_ID_PREFIXES.find((prefix) => searchQuery.startsWith(prefix));
-        const isExplicitIdSearch = Boolean(matchedPrefix);
-        const userIdPrefix = matchedPrefix ? searchQuery.slice(matchedPrefix.length) : searchQuery;
-
-        // Search by user ID if the query (stripped of prefix) is long enough
-        // This works for both explicit prefix searches AND raw pubky input
-        const shouldSearchUserId = userIdPrefix.length >= MIN_USER_ID_SEARCH_LENGTH;
+        const { tagPrefix, userNamePrefix, userIdPrefix } = resolveSearchAutocompletePlan(searchQuery);
 
         // Prepare parallel API calls
         let tagPromise: Promise<string[]> | null = null;
         let userByNamePromise: Promise<string[]> | null = null;
         let userByIdPromise: Promise<string[]> | null = null;
 
-        // Search tags (skip for explicit user ID searches and over-length queries)
-        if (!isExplicitIdSearch && searchQuery.length <= TAG_MAX_LENGTH) {
+        if (tagPrefix !== null) {
           tagPromise = SearchController.getTagsByPrefix({
-            prefix: searchQuery,
+            prefix: tagPrefix,
             limit: AUTOCOMPLETE_TAG_LIMIT,
           }).catch((error) => {
             Logger.error('[useSearchAutocomplete] Failed to fetch tags:', error);
@@ -65,10 +55,9 @@ export function useSearchAutocomplete({
           });
         }
 
-        // Search users by name (skip for explicit user ID searches)
-        if (!isExplicitIdSearch) {
+        if (userNamePrefix !== null) {
           userByNamePromise = SearchController.getUsersByName({
-            prefix: searchQuery,
+            prefix: userNamePrefix,
             limit: AUTOCOMPLETE_USER_LIMIT,
           }).catch((error) => {
             Logger.error('[useSearchAutocomplete] Failed to fetch users by name:', error);
@@ -76,8 +65,7 @@ export function useSearchAutocomplete({
           });
         }
 
-        // Search users by ID (works for explicit prefix or raw pubky input)
-        if (shouldSearchUserId) {
+        if (userIdPrefix !== null) {
           userByIdPromise = SearchController.fetchUsersById({
             prefix: userIdPrefix,
             limit: AUTOCOMPLETE_USER_LIMIT,

--- a/src/hooks/useSearchAutocomplete/useSearchAutocomplete.utils.test.ts
+++ b/src/hooks/useSearchAutocomplete/useSearchAutocomplete.utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { TAG_MAX_LENGTH } from '@/config/posts';
+import { resolveSearchAutocompletePlan } from './useSearchAutocomplete.utils';
+
+describe('resolveSearchAutocompletePlan', () => {
+  it.each([
+    {
+      query: '',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: null },
+    },
+    {
+      query: 'p',
+      expected: { tagPrefix: 'p', userNamePrefix: 'p', userIdPrefix: null },
+    },
+    {
+      query: 'pu',
+      expected: { tagPrefix: 'pu', userNamePrefix: 'pu', userIdPrefix: null },
+    },
+    {
+      query: 'pub',
+      expected: { tagPrefix: 'pub', userNamePrefix: 'pub', userIdPrefix: null },
+    },
+    {
+      query: 'pubk',
+      expected: { tagPrefix: 'pubk', userNamePrefix: 'pubk', userIdPrefix: null },
+    },
+    {
+      query: 'pubky',
+      expected: { tagPrefix: 'pubky', userNamePrefix: 'pubky', userIdPrefix: null },
+    },
+    {
+      query: 'pubky-fee',
+      expected: { tagPrefix: 'pubky-fee', userNamePrefix: 'pubky-fee', userIdPrefix: null },
+    },
+    {
+      query: 'pubkyab',
+      expected: { tagPrefix: 'pubkyab', userNamePrefix: 'pubkyab', userIdPrefix: null },
+    },
+    {
+      query: 'pubkyabc',
+      expected: { tagPrefix: 'pubkyabc', userNamePrefix: 'pubkyabc', userIdPrefix: 'abc' },
+    },
+    {
+      query: 'pubkyABC',
+      expected: { tagPrefix: 'pubkyABC', userNamePrefix: 'pubkyABC', userIdPrefix: 'ABC' },
+    },
+    {
+      query: 'PUBKYIH4',
+      expected: { tagPrefix: 'PUBKYIH4', userNamePrefix: 'PUBKYIH4', userIdPrefix: 'IH4' },
+    },
+    {
+      query: 'PUBKY',
+      expected: { tagPrefix: 'PUBKY', userNamePrefix: 'PUBKY', userIdPrefix: null },
+    },
+    {
+      query: 'PUB',
+      expected: { tagPrefix: 'PUB', userNamePrefix: 'PUB', userIdPrefix: null },
+    },
+    {
+      query: 'ab',
+      expected: { tagPrefix: 'ab', userNamePrefix: 'ab', userIdPrefix: null },
+    },
+    {
+      query: 'abc',
+      expected: { tagPrefix: 'abc', userNamePrefix: 'abc', userIdPrefix: 'abc' },
+    },
+    {
+      query: 'abc123',
+      expected: { tagPrefix: 'abc123', userNamePrefix: 'abc123', userIdPrefix: 'abc123' },
+    },
+    {
+      query: 'ABC123',
+      expected: { tagPrefix: 'ABC123', userNamePrefix: 'ABC123', userIdPrefix: 'ABC123' },
+    },
+    {
+      query: 'IH4',
+      expected: { tagPrefix: 'IH4', userNamePrefix: 'IH4', userIdPrefix: 'IH4' },
+    },
+    {
+      query: 'abc-123',
+      expected: { tagPrefix: 'abc-123', userNamePrefix: 'abc-123', userIdPrefix: null },
+    },
+    {
+      query: 'pk:abc',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: 'abc' },
+    },
+    {
+      query: 'pubky:abc',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: 'abc' },
+    },
+    {
+      query: 'PK:IH4',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: 'IH4' },
+    },
+    {
+      query: 'PUBKY:IH4',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: 'IH4' },
+    },
+    {
+      query: 'pk:ab',
+      expected: { tagPrefix: null, userNamePrefix: null, userIdPrefix: null },
+    },
+  ])('resolves endpoint prefixes for "$query"', ({ query, expected }) => {
+    expect(resolveSearchAutocompletePlan(query)).toEqual(expected);
+  });
+
+  it('preserves user searches while skipping tags over the tag length limit', () => {
+    const query = 'a'.repeat(TAG_MAX_LENGTH + 1);
+
+    expect(resolveSearchAutocompletePlan(query)).toEqual({
+      tagPrefix: null,
+      userNamePrefix: query,
+      userIdPrefix: query,
+    });
+  });
+});

--- a/src/hooks/useSearchAutocomplete/useSearchAutocomplete.utils.ts
+++ b/src/hooks/useSearchAutocomplete/useSearchAutocomplete.utils.ts
@@ -1,0 +1,56 @@
+import { TAG_MAX_LENGTH } from '@/config/posts';
+import {
+  COMPACT_USER_ID_PREFIX,
+  DELIMITED_USER_ID_PREFIXES,
+  MIN_USER_ID_SEARCH_LENGTH,
+} from './useSearchAutocomplete.constants';
+
+interface SearchAutocompletePlan {
+  tagPrefix: string | null;
+  userNamePrefix: string | null;
+  userIdPrefix: string | null;
+}
+
+const USER_ID_PREFIX_PATTERN = /^[a-z0-9]+$/i;
+
+function getValidUserIdPrefix(candidate: string): string | null {
+  if (candidate.length < MIN_USER_ID_SEARCH_LENGTH || !USER_ID_PREFIX_PATTERN.test(candidate)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+/**
+ * Resolves the independent Nexus autocomplete queries for a search term.
+ *
+ * Delimited legacy prefixes are unambiguous ID searches. The compact `pubky`
+ * prefix is ambiguous with normal tag and username text, so those endpoints
+ * keep the raw query while only the ID endpoint receives the stripped suffix.
+ */
+export function resolveSearchAutocompletePlan(searchQuery: string): SearchAutocompletePlan {
+  if (!searchQuery) {
+    return { tagPrefix: null, userNamePrefix: null, userIdPrefix: null };
+  }
+
+  const normalizedSearchQuery = searchQuery.toLowerCase();
+  const delimitedPrefix = DELIMITED_USER_ID_PREFIXES.find((prefix) => normalizedSearchQuery.startsWith(prefix));
+  if (delimitedPrefix) {
+    return {
+      tagPrefix: null,
+      userNamePrefix: null,
+      userIdPrefix: getValidUserIdPrefix(searchQuery.slice(delimitedPrefix.length)),
+    };
+  }
+
+  const userIdCandidate = normalizedSearchQuery.startsWith(COMPACT_USER_ID_PREFIX)
+    ? searchQuery.slice(COMPACT_USER_ID_PREFIX.length)
+    : searchQuery;
+  const isProgressiveCompactPrefix = COMPACT_USER_ID_PREFIX.startsWith(normalizedSearchQuery);
+
+  return {
+    tagPrefix: searchQuery.length <= TAG_MAX_LENGTH ? searchQuery : null,
+    userNamePrefix: searchQuery,
+    userIdPrefix: isProgressiveCompactPrefix ? null : getValidUserIdPrefix(userIdCandidate),
+  };
+}


### PR DESCRIPTION
## Summary
- fix #1909
- Search autocomplete no longer treats partial `pubky` typing or tag-like text (e.g. `pubky-feedback`) as an explicit user ID search
- Tags and usernames continue to resolve for compact `pubky` input while user ID lookup only runs when the stripped suffix is a valid z32 prefix

## Changes
- Extract `resolveSearchAutocompletePlan` to decide tag, username, and user ID queries independently
- Split legacy delimited prefixes (`pubky:`, `pk:`) from the ambiguous compact `pubky` prefix
- Skip user ID search while the query is still a progressive prefix of `pubky` (`p`, `pu`, `pub`, `pubk`)
- Preserve raw query casing for tag/username endpoints; normalize only for compact prefix detection

## Test plan
- [x] `npm run test -- src/hooks/useSearchAutocomplete/` (48 tests passed)
- [ ] Type `pubky-feedback` in search autocomplete — expect tag/username results, no ID-only search
- [ ] Type `pubkyabc` — expect tag, username, and user ID searches (ID prefix `abc`)
- [ ] Type `pk:abc` or `pubky:abc123` — expect ID-only search with prefix stripped

## Notes
- Legacy delimited prefixes remain unambiguous ID-only searches; behavior for `pk:` / `pubky:` is unchanged