### PR TITLE
refactor(useFollowUser): enhance error handling and return values

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1008,9 +1008,10 @@
       "copyFailedDesc": "تعذر النسخ إلى الحافظة"
     },
     "follow": {
-      "failed": "تعذر تحديث حالة المتابعة",
       "followed": "تتابع {username}",
-      "unfollowed": "ألغيت متابعة {username}"
+      "unfollowed": "ألغيت متابعة {username}",
+      "followFailed": "تعذر متابعة {username}",
+      "unfollowFailed": "تعذر إلغاء متابعة {username}"
     },
     "mute": {
       "muted": "تم كتم {username}",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1008,9 +1008,10 @@
       "copyFailedDesc": "Kopieren in Zwischenablage nicht möglich"
     },
     "follow": {
-      "failed": "Folgestatus konnte nicht aktualisiert werden",
       "followed": "Folge {username}",
-      "unfollowed": "{username} entfolgt"
+      "unfollowed": "{username} entfolgt",
+      "followFailed": "{username} konnte nicht gefolgt werden",
+      "unfollowFailed": "{username} konnte nicht entfolgt werden"
     },
     "mute": {
       "muted": "{username} stummgeschaltet",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1008,7 +1008,8 @@
     "follow": {
       "followed": "Following {username}",
       "unfollowed": "Unfollowed {username}",
-      "failed": "Could not update follow status"
+      "followFailed": "Failed to follow {username}",
+      "unfollowFailed": "Failed to unfollow {username}"
     },
     "mute": {
       "muted": "{username} muted",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1010,7 +1010,8 @@
     "follow": {
       "followed": "Siguiendo a {username}",
       "unfollowed": "Dejaste de seguir a {username}",
-      "failed": "No se pudo actualizar el estado de seguimiento"
+      "followFailed": "No se pudo seguir a {username}",
+      "unfollowFailed": "No se pudo dejar de seguir a {username}"
     },
     "mute": {
       "muted": "{username} silenciado",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1006,9 +1006,10 @@
       "copyFailedDesc": "Impossible de copier dans le presse-papiers"
     },
     "follow": {
-      "failed": "Impossible de mettre à jour le statut d'abonnement",
       "followed": "Vous suivez {username}",
-      "unfollowed": "Vous ne suivez plus {username}"
+      "unfollowed": "Vous ne suivez plus {username}",
+      "followFailed": "Impossible de suivre {username}",
+      "unfollowFailed": "Impossible de ne plus suivre {username}"
     },
     "mute": {
       "muted": "{username} masqué",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1006,9 +1006,10 @@
       "copyFailedDesc": "Impossibile copiare negli appunti"
     },
     "follow": {
-      "failed": "Impossibile aggiornare lo stato di follow",
       "followed": "Stai seguendo {username}",
-      "unfollowed": "Hai smesso di seguire {username}"
+      "unfollowed": "Hai smesso di seguire {username}",
+      "followFailed": "Impossibile seguire {username}",
+      "unfollowFailed": "Impossibile smettere di seguire {username}"
     },
     "mute": {
       "muted": "{username} silenziato",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1006,9 +1006,10 @@
       "copyFailedDesc": "クリップボードにコピーできませんでした"
     },
     "follow": {
-      "failed": "フォロー状態を更新できませんでした",
       "followed": "{username}をフォロー中",
-      "unfollowed": "{username}のフォローを解除しました"
+      "unfollowed": "{username}のフォローを解除しました",
+      "followFailed": "{username}をフォローできませんでした",
+      "unfollowFailed": "{username}のフォローを解除できませんでした"
     },
     "mute": {
       "muted": "{username}をミュートしました",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1006,9 +1006,10 @@
       "copyFailedDesc": "Não foi possível copiar para a área de transferência"
     },
     "follow": {
-      "failed": "Não foi possível atualizar o status de seguimento",
       "followed": "Seguindo {username}",
-      "unfollowed": "Deixou de seguir {username}"
+      "unfollowed": "Deixou de seguir {username}",
+      "followFailed": "Não foi possível seguir {username}",
+      "unfollowFailed": "Não foi possível deixar de seguir {username}"
     },
     "mute": {
       "muted": "{username} silenciado",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1006,9 +1006,10 @@
       "copyFailedDesc": "无法复制到剪贴板"
     },
     "follow": {
-      "failed": "无法更新关注状态",
       "followed": "正在关注 {username}",
-      "unfollowed": "已取消关注 {username}"
+      "unfollowed": "已取消关注 {username}",
+      "followFailed": "无法关注 {username}",
+      "unfollowFailed": "无法取消关注 {username}"
     },
     "mute": {
       "muted": "已静音 {username}",

--- a/src/components/organisms/WhoToFollowSidebar/WhoToFollowSidebar.test.tsx
+++ b/src/components/organisms/WhoToFollowSidebar/WhoToFollowSidebar.test.tsx
@@ -129,7 +129,7 @@ describe('WhoToFollowSidebar', () => {
   });
 
   it('rolls back preserved users when follow fails', async () => {
-    hooksMocks.toggleFollow.mockRejectedValue(new Error('follow failed'));
+    hooksMocks.toggleFollow.mockResolvedValue(false);
     hooksMocks.useUserStream.mockReturnValue({
       users: [{ id: 'user-1', name: 'User One', image: null, avatarUrl: null, isFollowing: false }],
       userIds: ['user-1'],

--- a/src/hooks/useFollowUser/useFollowUser.test.tsx
+++ b/src/hooks/useFollowUser/useFollowUser.test.tsx
@@ -3,7 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMethod } from '@/libs/http/http.types';
 import { useFollowUser } from './useFollowUser';
 
-const { mockUseAuthStore, mockCommitFollow, mockGetDetails, mockLogger, mockToast } = vi.hoisted(() => ({
+const {
+  mockUseAuthStore,
+  mockCommitFollow,
+  mockGetDetails,
+  mockLogger,
+  mockToast,
+  mockIsAppError,
+  mockIsNetworkError,
+} = vi.hoisted(() => ({
   mockUseAuthStore: vi.fn(),
   mockCommitFollow: vi.fn(),
   mockGetDetails: vi.fn(),
@@ -12,6 +20,13 @@ const { mockUseAuthStore, mockCommitFollow, mockGetDetails, mockLogger, mockToas
     error: vi.fn(),
   },
   mockToast: vi.fn(),
+  mockIsAppError: vi.fn(),
+  mockIsNetworkError: vi.fn(),
+}));
+
+vi.mock('@/libs/error/error.utils', () => ({
+  isAppError: (...args: unknown[]) => mockIsAppError(...args),
+  isNetworkError: (...args: unknown[]) => mockIsNetworkError(...args),
 }));
 
 vi.mock('@/stores/auth/auth.store', () => ({
@@ -48,6 +63,8 @@ describe('useFollowUser', () => {
     mockUseAuthStore.mockReturnValue({ currentUserPubky: 'current-user' });
     mockCommitFollow.mockResolvedValue(undefined);
     mockGetDetails.mockResolvedValue(null);
+    mockIsAppError.mockReturnValue(false);
+    mockIsNetworkError.mockReturnValue(false);
   });
 
   it('sets error when user not authenticated', async () => {
@@ -123,20 +140,18 @@ describe('useFollowUser', () => {
     });
   });
 
-  it('shows error toast and rethrows on failure', async () => {
+  it('shows generic error toast and resolves false on a non-AppError failure', async () => {
     const error = new Error('Follow failed');
     mockCommitFollow.mockRejectedValue(error);
 
     const { result } = renderHook(() => useFollowUser());
 
+    let returned: boolean | undefined;
     await act(async () => {
-      try {
-        await result.current.toggleFollow('user-1', false, 'Alice');
-      } catch {
-        // swallow to allow state update assertions
-      }
+      returned = await result.current.toggleFollow('user-1', false, 'Alice');
     });
 
+    expect(returned).toBe(false);
     await waitFor(() => {
       expect(result.current.error).toBe('Could not update follow status');
     });
@@ -145,5 +160,48 @@ describe('useFollowUser', () => {
       description: 'Could not update follow status',
     });
     expect(mockLogger.error).toHaveBeenCalledWith('[useFollowUser] Failed to toggle follow:', error);
+  });
+
+  it('surfaces the real message for a non-network AppError', async () => {
+    const error = new Error('Homeserver rejected the request');
+    mockCommitFollow.mockRejectedValue(error);
+    mockIsAppError.mockReturnValue(true);
+    mockIsNetworkError.mockReturnValue(false);
+
+    const { result } = renderHook(() => useFollowUser());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.toggleFollow('user-1', false, 'Alice');
+    });
+
+    expect(returned).toBe(false);
+    await waitFor(() => {
+      expect(result.current.error).toBe('Homeserver rejected the request');
+    });
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'error',
+      description: 'Homeserver rejected the request',
+    });
+  });
+
+  it('falls back to the generic message for a network AppError', async () => {
+    const error = new Error('fetch failed: ECONNREFUSED');
+    mockCommitFollow.mockRejectedValue(error);
+    mockIsAppError.mockReturnValue(true);
+    mockIsNetworkError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useFollowUser());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.toggleFollow('user-1', false, 'Alice');
+    });
+
+    expect(returned).toBe(false);
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'error',
+      description: 'Could not update follow status',
+    });
   });
 });

--- a/src/hooks/useFollowUser/useFollowUser.test.tsx
+++ b/src/hooks/useFollowUser/useFollowUser.test.tsx
@@ -3,15 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMethod } from '@/libs/http/http.types';
 import { useFollowUser } from './useFollowUser';
 
-const {
-  mockUseAuthStore,
-  mockCommitFollow,
-  mockGetDetails,
-  mockLogger,
-  mockToast,
-  mockIsAppError,
-  mockIsNetworkError,
-} = vi.hoisted(() => ({
+const { mockUseAuthStore, mockCommitFollow, mockGetDetails, mockLogger, mockToast } = vi.hoisted(() => ({
   mockUseAuthStore: vi.fn(),
   mockCommitFollow: vi.fn(),
   mockGetDetails: vi.fn(),
@@ -20,13 +12,6 @@ const {
     error: vi.fn(),
   },
   mockToast: vi.fn(),
-  mockIsAppError: vi.fn(),
-  mockIsNetworkError: vi.fn(),
-}));
-
-vi.mock('@/libs/error/error.utils', () => ({
-  isAppError: (...args: unknown[]) => mockIsAppError(...args),
-  isNetworkError: (...args: unknown[]) => mockIsNetworkError(...args),
 }));
 
 vi.mock('@/stores/auth/auth.store', () => ({
@@ -52,7 +37,8 @@ vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, values?: { username?: string }) => {
     if (key === 'followed') return `Following ${values?.username ?? ''}`;
     if (key === 'unfollowed') return `Unfollowed ${values?.username ?? ''}`;
-    if (key === 'failed') return 'Could not update follow status';
+    if (key === 'followFailed') return `Failed to follow ${values?.username ?? ''}`;
+    if (key === 'unfollowFailed') return `Failed to unfollow ${values?.username ?? ''}`;
     return key;
   },
 }));
@@ -63,8 +49,6 @@ describe('useFollowUser', () => {
     mockUseAuthStore.mockReturnValue({ currentUserPubky: 'current-user' });
     mockCommitFollow.mockResolvedValue(undefined);
     mockGetDetails.mockResolvedValue(null);
-    mockIsAppError.mockReturnValue(false);
-    mockIsNetworkError.mockReturnValue(false);
   });
 
   it('sets error when user not authenticated', async () => {
@@ -140,8 +124,9 @@ describe('useFollowUser', () => {
     });
   });
 
-  it('shows generic error toast and resolves false on a non-AppError failure', async () => {
-    const error = new Error('Follow failed');
+  it('shows a friendly named error toast and resolves false when following fails', async () => {
+    // A raw transport error must never reach the user.
+    const error = new Error('Request failed: HTTP transport error: error sending request');
     mockCommitFollow.mockRejectedValue(error);
 
     const { result } = renderHook(() => useFollowUser());
@@ -153,55 +138,29 @@ describe('useFollowUser', () => {
 
     expect(returned).toBe(false);
     await waitFor(() => {
-      expect(result.current.error).toBe('Could not update follow status');
+      expect(result.current.error).toBe('Failed to follow Alice');
     });
     expect(mockToast).toHaveBeenCalledWith({
       variant: 'error',
-      description: 'Could not update follow status',
+      description: 'Failed to follow Alice',
     });
     expect(mockLogger.error).toHaveBeenCalledWith('[useFollowUser] Failed to toggle follow:', error);
   });
 
-  it('surfaces the real message for a non-network AppError', async () => {
-    const error = new Error('Homeserver rejected the request');
-    mockCommitFollow.mockRejectedValue(error);
-    mockIsAppError.mockReturnValue(true);
-    mockIsNetworkError.mockReturnValue(false);
+  it('shows the unfollow-specific friendly error when unfollowing fails', async () => {
+    mockCommitFollow.mockRejectedValue(new Error('boom'));
 
     const { result } = renderHook(() => useFollowUser());
 
     let returned: boolean | undefined;
     await act(async () => {
-      returned = await result.current.toggleFollow('user-1', false, 'Alice');
-    });
-
-    expect(returned).toBe(false);
-    await waitFor(() => {
-      expect(result.current.error).toBe('Homeserver rejected the request');
-    });
-    expect(mockToast).toHaveBeenCalledWith({
-      variant: 'error',
-      description: 'Homeserver rejected the request',
-    });
-  });
-
-  it('falls back to the generic message for a network AppError', async () => {
-    const error = new Error('fetch failed: ECONNREFUSED');
-    mockCommitFollow.mockRejectedValue(error);
-    mockIsAppError.mockReturnValue(true);
-    mockIsNetworkError.mockReturnValue(true);
-
-    const { result } = renderHook(() => useFollowUser());
-
-    let returned: boolean | undefined;
-    await act(async () => {
-      returned = await result.current.toggleFollow('user-1', false, 'Alice');
+      returned = await result.current.toggleFollow('user-1', true, 'Alice');
     });
 
     expect(returned).toBe(false);
     expect(mockToast).toHaveBeenCalledWith({
       variant: 'error',
-      description: 'Could not update follow status',
+      description: 'Failed to unfollow Alice',
     });
   });
 });

--- a/src/hooks/useFollowUser/useFollowUser.tsx
+++ b/src/hooks/useFollowUser/useFollowUser.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { UserController } from '@/controllers/user/user';
-import { isAppError, isNetworkError } from '@/libs/error/error.utils';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import type { Pubky } from '@/models/models.types';
@@ -58,6 +57,9 @@ export function useFollowUser(): UseFollowUserResult {
       setLoadingUserId(userId);
       setError(null);
 
+      // Resolved up front so the failure toast can name the user too.
+      const username = await resolveFollowToastDisplayName(userId, displayName);
+
       try {
         const action = isCurrentlyFollowing ? HttpMethod.DELETE : HttpMethod.PUT;
 
@@ -66,7 +68,6 @@ export function useFollowUser(): UseFollowUserResult {
           followee: userId,
         });
 
-        const username = await resolveFollowToastDisplayName(userId, displayName);
         toast({
           title: isCurrentlyFollowing ? t('unfollowed', { username }) : t('followed', { username }),
         });
@@ -77,9 +78,8 @@ export function useFollowUser(): UseFollowUserResult {
 
         return true;
       } catch (err) {
-        // Network errors are noisy/transient — show a neutral message, not the raw network text.
-        // Any other AppError carries a meaningful message worth surfacing.
-        const message = isAppError(err) && !isNetworkError(err) ? err.message : t('failed');
+        // Always a friendly, named message — raw transport/server text never reaches the user.
+        const message = isCurrentlyFollowing ? t('unfollowFailed', { username }) : t('followFailed', { username });
         setError(message);
         toast({
           variant: 'error',

--- a/src/hooks/useFollowUser/useFollowUser.tsx
+++ b/src/hooks/useFollowUser/useFollowUser.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { UserController } from '@/controllers/user/user';
+import { isAppError, isNetworkError } from '@/libs/error/error.utils';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import type { Pubky } from '@/models/models.types';
@@ -44,12 +45,12 @@ export function useFollowUser(): UseFollowUserResult {
     async (userId: Pubky, isCurrentlyFollowing: boolean, displayName?: string) => {
       if (!currentUserPubky) {
         setError('User not authenticated');
-        return;
+        return false;
       }
 
       if (userId === currentUserPubky) {
         setError('Cannot follow yourself');
-        return;
+        return false;
       }
 
       setLoadingAction(isCurrentlyFollowing ? 'unfollow' : 'follow');
@@ -73,15 +74,19 @@ export function useFollowUser(): UseFollowUserResult {
         Logger.debug(`[useFollowUser] Successfully ${isCurrentlyFollowing ? 'unfollowed' : 'followed'} user`, {
           userId,
         });
+
+        return true;
       } catch (err) {
-        const friendlyMessage = t('failed');
-        setError(friendlyMessage);
+        // Network errors are noisy/transient — show a neutral message, not the raw network text.
+        // Any other AppError carries a meaningful message worth surfacing.
+        const message = isAppError(err) && !isNetworkError(err) ? err.message : t('failed');
+        setError(message);
         toast({
           variant: 'error',
-          description: friendlyMessage,
+          description: message,
         });
         Logger.error('[useFollowUser] Failed to toggle follow:', err);
-        throw err;
+        return false;
       } finally {
         setIsLoading(false);
         setLoadingAction(null);

--- a/src/hooks/useFollowUser/useFollowUser.types.ts
+++ b/src/hooks/useFollowUser/useFollowUser.types.ts
@@ -8,8 +8,8 @@ export const FOLLOW_ACTIONS = {
 export type FollowAction = (typeof FOLLOW_ACTIONS)[keyof typeof FOLLOW_ACTIONS];
 
 export interface UseFollowUserResult {
-  /** Toggles follow status for a user */
-  toggleFollow: (userId: Pubky, isCurrentlyFollowing: boolean, displayName?: string) => Promise<void>;
+  /** Toggles follow status for a user. Resolves `true` on success, `false` on failure (feedback is handled internally). */
+  toggleFollow: (userId: Pubky, isCurrentlyFollowing: boolean, displayName?: string) => Promise<boolean>;
   /** Whether a follow/unfollow action is in progress */
   isLoading: boolean;
   /** Current action in progress (follow/unfollow), null if idle */

--- a/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
+++ b/src/hooks/usePostMenuActions/usePostMenuActions.test.tsx
@@ -251,10 +251,9 @@ describe('usePostMenuActions', () => {
       expect(defaultMocks.toggleFollow).toHaveBeenCalledWith(mockAuthorId, true, 'Test Author');
     });
 
-    it('swallows follow rejection after useFollowUser handles the error', async () => {
-      const followError = new Error('Follow failed');
+    it('does not throw when the follow fails (useFollowUser handles feedback)', async () => {
       mockUseFollowUser.mockReturnValue({
-        toggleFollow: vi.fn().mockRejectedValue(followError),
+        toggleFollow: vi.fn().mockResolvedValue(false),
         isLoading: false,
         isUserLoading: defaultMocks.isUserLoading,
       });

--- a/src/hooks/usePostMenuActions/usePostMenuActions.tsx
+++ b/src/hooks/usePostMenuActions/usePostMenuActions.tsx
@@ -91,11 +91,8 @@ export function usePostMenuActions(postId: string, options: UsePostMenuActionsOp
           }),
       icon: isFollowing ? UserRoundMinus : UserRoundPlus,
       onClick: async () => {
-        try {
-          await toggleFollow(postAuthorId, isFollowing, authorProfile?.name);
-        } catch {
-          // Error already handled by useFollowUser (toast + state)
-        }
+        // useFollowUser handles all feedback (toast + state) and never throws.
+        await toggleFollow(postAuthorId, isFollowing, authorProfile?.name);
       },
       variant: POST_MENU_ACTION_VARIANTS.DEFAULT,
       disabled: isFollowLoading || isUserLoading(postAuthorId),

--- a/src/hooks/useProfileMenuActions/useProfileMenuActions.test.tsx
+++ b/src/hooks/useProfileMenuActions/useProfileMenuActions.test.tsx
@@ -239,10 +239,9 @@ describe('useProfileMenuActions', () => {
       expect(defaultMocks.toggleFollow).toHaveBeenCalledWith(mockUserId, true, 'Test User');
     });
 
-    it('swallows follow rejection after useFollowUser handles the error', async () => {
-      const followError = new Error('Follow failed');
+    it('does not throw when the follow fails (useFollowUser handles feedback)', async () => {
       mockUseFollowUser.mockReturnValue({
-        toggleFollow: vi.fn().mockRejectedValue(followError),
+        toggleFollow: vi.fn().mockResolvedValue(false),
         isLoading: false,
         isUserLoading: defaultMocks.isUserLoading,
       });

--- a/src/hooks/useProfileMenuActions/useProfileMenuActions.tsx
+++ b/src/hooks/useProfileMenuActions/useProfileMenuActions.tsx
@@ -58,11 +58,8 @@ export function useProfileMenuActions(userId: string): UseProfileMenuActionsResu
         }),
     icon: isFollowing ? UserRoundMinus : UserRoundPlus,
     onClick: async () => {
-      try {
-        await toggleFollow(userId, isFollowing, profile?.name);
-      } catch {
-        // Error already handled by useFollowUser (toast + state)
-      }
+      // useFollowUser handles all feedback (toast + state) and never throws.
+      await toggleFollow(userId, isFollowing, profile?.name);
     },
     disabled: isFollowLoading || isUserLoading(userId),
   });

--- a/src/hooks/useUserInfoPopoverActions/useUserInfoPopoverActions.ts
+++ b/src/hooks/useUserInfoPopoverActions/useUserInfoPopoverActions.ts
@@ -42,11 +42,8 @@ export function useUserInfoPopoverActions({
     e.stopPropagation();
     if (isCurrentUser) return;
     requireAuth(async () => {
-      try {
-        await toggleFollow(userId, isFollowing, resolveFollowDisplayName(userId, userName));
-      } catch {
-        // Error already handled by useFollowUser (logged + state updated)
-      }
+      // useFollowUser handles all feedback (toast + state) and never throws.
+      await toggleFollow(userId, isFollowing, resolveFollowDisplayName(userId, userName));
     });
   };
 

--- a/src/hooks/useWhoToFollowFollowPreservation/useWhoToFollowFollowPreservation.test.tsx
+++ b/src/hooks/useWhoToFollowFollowPreservation/useWhoToFollowFollowPreservation.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/hooks/useFollowUser/useFollowUser', () => ({
 describe('useWhoToFollowFollowPreservation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockToggleFollow.mockResolvedValue(undefined);
+    mockToggleFollow.mockResolvedValue(true);
     mockIsUserLoading.mockReturnValue(false);
   });
 
@@ -47,7 +47,7 @@ describe('useWhoToFollowFollowPreservation', () => {
   });
 
   it('rolls back optimistic preservation when follow fails', async () => {
-    mockToggleFollow.mockRejectedValue(new Error('follow failed'));
+    mockToggleFollow.mockResolvedValue(false);
     const { result } = renderHook(() => useWhoToFollowFollowPreservation());
 
     await act(async () => {

--- a/src/hooks/useWhoToFollowFollowPreservation/useWhoToFollowFollowPreservation.ts
+++ b/src/hooks/useWhoToFollowFollowPreservation/useWhoToFollowFollowPreservation.ts
@@ -37,9 +37,8 @@ export function useWhoToFollowFollowPreservation({ resetKey }: UseWhoToFollowFol
   const handleFollowClick = async (userId: Pubky, isCurrentlyFollowing: boolean, displayName: string) => {
     updatePreservedUserIds(userId, isCurrentlyFollowing);
 
-    try {
-      await toggleFollow(userId, isCurrentlyFollowing, displayName);
-    } catch {
+    const ok = await toggleFollow(userId, isCurrentlyFollowing, displayName);
+    if (!ok) {
       rollbackPreservedUserIds(userId, isCurrentlyFollowing);
     }
   };


### PR DESCRIPTION
resolve #1981 


Clean up the interactions of following/unfollowing when we follow and unfollow messages

Demo:
https://github.com/user-attachments/assets/2751bee9-1b52-40c3-b686-568a3e6617a4


Decision:
No need to remove the translation because we removed them in another PR but here we improve mostly how we give feedback to users related to success and fail request in follow.



How to test:

- Interact with a following user normally and you need to block the requests in your Network tab by URL so this way you're not available to unfollow or follow anymore and you can see the error