### PR TITLE
fix(notifications): improve tagged notification readability

### DIFF
--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -118,6 +118,21 @@ describe('notifications', () => {
   });
 
   it('can be notified for tagged post and profile', () => {
+    // helper function to verify the tag is visible on desktop and not on mobile
+    const expectLatestNotificationTag = (tagLabel: string) => {
+      const isMobile = Cypress.expose('isMobile');
+      cy.get('[data-cy="notifications-list"]')
+        .children()
+        .first()
+        .find('[data-cy="post-tag"]')
+        .should(isMobile ? 'not.be.visible' : 'be.visible')
+        .then(($tag) => {
+          if (!isMobile) {
+            cy.wrap($tag).should('contain', tagLabel);
+          }
+        });
+    };
+
     // * profile 1 creates a post
     const postContent = `I will be notified when this post is tagged! ${Date.now()}`;
     createQuickPost(postContent);
@@ -140,7 +155,9 @@ describe('notifications', () => {
     goToProfilePageFromHeader();
     verifyNotificationCounter(0);
     // check latest notification on profile page
-    checkLatestNotification([profile1.username, 'tagged your profile', profileTag], LatestNotificationReadState.Unread);
+    checkLatestNotification([profile1.username, 'tagged your profile'], LatestNotificationReadState.Unread);
+
+    expectLatestNotificationTag(profileTag);
 
     // * profile 2 tags profile 1's post (from their profile page)
     cy.get(`@${profile1.pubkyAlias}`).then((pubky) => {
@@ -161,25 +178,17 @@ describe('notifications', () => {
     verifyNotificationCounter(1);
     goToProfilePageFromHeader();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile2.username, 'tagged your post', postTag], LatestNotificationReadState.Unread);
+    checkLatestNotification([profile2.username, 'tagged your post'], LatestNotificationReadState.Unread);
 
     // * toggle tabs to check unread dot disappears
     causeNotificationsToBeRead();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile2.username, 'tagged your post', postTag], LatestNotificationReadState.Read);
+    checkLatestNotification([profile2.username, 'tagged your post'], LatestNotificationReadState.Read);
 
-    cy.get('[data-cy="notifications-list"]')
-      .children()
-      .first()
-      .within(() => {
-        cy.contains('a', 'tagged your post')
-          .should('be.visible')
-          .parent()
-          .should('have.css', 'white-space', Cypress.expose('isMobile') ? 'normal' : 'nowrap');
+    // verify post tag is visible on desktop and not on mobile
+    expectLatestNotificationTag(postTag);
 
-        cy.get('[data-cy="post-tag"]').should(Cypress.expose('isMobile') ? 'not.be.visible' : 'be.visible');
-      });
-
+    // verify navigation to search page with tag on desktop post page on mobile
     if (Cypress.expose('isMobile')) {
       cy.get('[data-cy="notifications-list"]').children().first().contains('a', 'tagged your post').click();
       cy.location('pathname').should('match', /^\/post\/[^/]+\/[^/]+$/);

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -150,7 +150,7 @@ describe('notifications', () => {
     // click Posts tab to show profile 1's posts
     cy.get('[data-cy="profile-filter-item-posts"]').click();
     cy.get('[data-cy="profile-filter-item-posts"]').closest('[data-selected="true"]').should('exist');
-    const postTag = 'ilike';
+    const postTag = 'first-world-problem';
     // tag the first post on profile 1's profile
     fastTagPostInFeed([postTag], postContent);
 
@@ -167,6 +167,27 @@ describe('notifications', () => {
     causeNotificationsToBeRead();
     verifyNotificationCounter(0);
     checkLatestNotification([profile2.username, 'tagged your post', postTag], LatestNotificationReadState.Read);
+
+    cy.get('[data-cy="notifications-list"]')
+      .children()
+      .first()
+      .within(() => {
+        cy.contains('a', 'tagged your post')
+          .should('be.visible')
+          .parent()
+          .should('have.css', 'white-space', Cypress.expose('isMobile') ? 'normal' : 'nowrap');
+
+        cy.get('[data-cy="post-tag"]').should(Cypress.expose('isMobile') ? 'not.be.visible' : 'be.visible');
+      });
+
+    if (Cypress.expose('isMobile')) {
+      cy.get('[data-cy="notifications-list"]').children().first().contains('a', 'tagged your post').click();
+      cy.location('pathname').should('match', /^\/post\/[^/]+\/[^/]+$/);
+    } else {
+      cy.get('[data-cy="notifications-list"]').children().first().find('[data-cy="post-tag"]').click();
+      cy.location('pathname').should('eq', '/search');
+      cy.location('search').should('eq', '?tags=first-world-problem');
+    }
 
     // TODO: add checks for disabled notifications
     // * profile 1 disables notifications for tagged profile

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { USER_NAME_MAX_LENGTH } from '@/config/user';
+import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { type FlatNotification, NotificationType } from '@/models/notification/notification.types';
 import { NotificationItem } from './NotificationItem';
 
@@ -165,6 +167,10 @@ describe('NotificationItem', () => {
     mockToast.mockClear();
     mockGetOrFetch.mockClear();
     mockGetOrFetch.mockResolvedValue(null);
+    vi.mocked(useUserProfile).mockReturnValue({
+      profile: { name: 'User', avatarUrl: undefined },
+      isLoading: false,
+    } as ReturnType<typeof useUserProfile>);
   });
 
   const baseNotification = {
@@ -236,7 +242,7 @@ describe('NotificationItem', () => {
     expect(tag).toHaveClass('hidden', 'shrink-0', 'lg:inline-flex');
   });
 
-  it('allows long tagged-post copy to wrap on mobile and truncates only on desktop', () => {
+  it('allows long tagged-post copy to wrap on mobile and uses a single-line flex layout on desktop', () => {
     const tagNotification = {
       id: 'tagpost:123:user1',
       type: NotificationType.TagPost,
@@ -248,9 +254,36 @@ describe('NotificationItem', () => {
     render(<NotificationItem notification={tagNotification} isUnread={false} />);
 
     const notificationCopy = screen.getByText('tagged your post').closest('p');
-    expect(notificationCopy).toHaveClass('whitespace-normal', 'leading-normal', 'lg:truncate');
+    expect(notificationCopy).toHaveClass(
+      'whitespace-normal',
+      'leading-normal',
+      'lg:flex',
+      'lg:items-baseline',
+      'lg:gap-1',
+      'lg:whitespace-nowrap',
+    );
     expect(notificationCopy).not.toHaveClass('truncate');
+    expect(notificationCopy).not.toHaveClass('lg:truncate');
     expect(notificationCopy).not.toHaveClass('leading-none');
+  });
+
+  it('truncates maximum-length unbroken usernames while keeping action text and navigation links', () => {
+    const longUsername = 'B'.repeat(USER_NAME_MAX_LENGTH);
+    vi.mocked(useUserProfile).mockReturnValue({
+      profile: { name: longUsername, avatarUrl: undefined },
+      isLoading: false,
+    } as ReturnType<typeof useUserProfile>);
+
+    render(<NotificationItem notification={baseNotification} isUnread={false} />);
+
+    const usernameLink = screen.getByText(longUsername);
+    expect(usernameLink).toHaveClass('inline-block', 'max-w-full', 'min-w-0', 'truncate', 'align-bottom');
+    expect(usernameLink.closest('a')).toHaveAttribute('href', '/profile/user1');
+
+    const actionLink = screen.getByText('followed you');
+    expect(actionLink).toBeInTheDocument();
+    expect(actionLink).toHaveClass('lg:shrink-0');
+    expect(actionLink.closest('a')).toHaveAttribute('href', '/profile/user1');
   });
 
   it('renders Mention notification without preview when post not loaded', () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -100,8 +100,16 @@ vi.mock('@/molecules/NotificationIcon/NotificationIcon', () => {
 
 vi.mock('@/molecules/PostTag/PostTag', () => {
   return {
-    PostTag: ({ label, onClick }: { label: string; onClick?: (e: React.MouseEvent) => void }) => (
-      <span data-testid="post-tag" onClick={onClick}>
+    PostTag: ({
+      label,
+      className,
+      onClick,
+    }: {
+      label: string;
+      className?: string;
+      onClick?: (e: React.MouseEvent) => void;
+    }) => (
+      <span data-testid="post-tag" className={className} onClick={onClick}>
         {label}
       </span>
     ),
@@ -212,18 +220,37 @@ describe('NotificationItem', () => {
     expect(icon).toHaveAttribute('data-badge', 'false');
   });
 
-  it('renders tag badge for TagPost notifications', () => {
+  it('hides the tag badge on mobile and keeps it visible on desktop for TagPost notifications', () => {
     const tagNotification = {
       id: 'tagpost:123:user1',
       type: NotificationType.TagPost,
       timestamp: Date.now() - 1000 * 60 * 30,
       tagged_by: 'user1',
-      tag_label: 'bitcoin',
+      tag_label: 'first-world-problem',
       post_uri: 'user1:post123',
     } as FlatNotification;
     render(<NotificationItem notification={tagNotification} isUnread={false} />);
-    expect(screen.getByTestId('post-tag')).toBeInTheDocument();
-    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+
+    const tag = screen.getByTestId('post-tag');
+    expect(tag).toHaveTextContent('first-world-problem');
+    expect(tag).toHaveClass('hidden', 'shrink-0', 'lg:inline-flex');
+  });
+
+  it('allows long tagged-post copy to wrap on mobile and truncates only on desktop', () => {
+    const tagNotification = {
+      id: 'tagpost:123:user1',
+      type: NotificationType.TagPost,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      tagged_by: 'user1',
+      tag_label: 'first-world-problem',
+      post_uri: 'user1:post123',
+    } as FlatNotification;
+    render(<NotificationItem notification={tagNotification} isUnread={false} />);
+
+    const notificationCopy = screen.getByText('tagged your post').closest('p');
+    expect(notificationCopy).toHaveClass('whitespace-normal', 'leading-normal', 'lg:truncate');
+    expect(notificationCopy).not.toHaveClass('truncate');
+    expect(notificationCopy).not.toHaveClass('leading-none');
   });
 
   it('renders Mention notification without preview when post not loaded', () => {
@@ -285,6 +312,9 @@ describe('NotificationItem', () => {
     fireEvent.click(tag);
 
     expect(mockPush).toHaveBeenCalledWith('/search?tags=developer');
+    expect(tag).toHaveClass('hidden', 'shrink-0', 'lg:inline-flex');
+    expect(screen.getByText('tagged your profile').closest('a')).toHaveAttribute('href', '/profile/tagged');
+    expect(screen.getByText('User').closest('a')).toHaveAttribute('href', '/profile/user1');
   });
 
   it('encodes special characters in tag when navigating to search', () => {
@@ -439,6 +469,25 @@ describe('NotificationItem', () => {
 
     // Follow notification links to user profile
     expect(mockPush).toHaveBeenCalledWith('/profile/user1');
+  });
+
+  it('navigates to the tagged post from its action or empty row space', () => {
+    const tagNotification = {
+      id: 'tagpost:123:user1',
+      type: NotificationType.TagPost,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      tagged_by: 'user1',
+      tag_label: 'first-world-problem',
+      post_uri: 'user1:post123',
+    } as FlatNotification;
+    render(<NotificationItem notification={tagNotification} isUnread={false} />);
+
+    expect(screen.getByText('tagged your post').closest('a')).toHaveAttribute('href', '/post/user1/post123');
+    expect(screen.getByText('User').closest('a')).toHaveAttribute('href', '/profile/user1');
+
+    fireEvent.click(screen.getAllByTestId('container')[0]);
+
+    expect(mockPush).toHaveBeenCalledWith('/post/user1/post123');
   });
 
   it('does not navigate when clicking on a link inside the row', () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for Follow notification
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
         data-testid="typography"
       >
         <a
@@ -102,7 +102,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for Mention notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
         data-testid="typography"
       >
         <a
@@ -176,7 +176,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for TagPost notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
         data-testid="typography"
       >
         <a

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
@@ -28,18 +28,18 @@ exports[`NotificationItem - Snapshots > matches snapshot for Follow notification
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
         data-testid="typography"
       >
         <a
-          class="no-underline hover:no-underline"
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
           href="/profile/user1"
         >
           User
         </a>
          
         <a
-          class="text-foreground hover:underline"
+          class="text-foreground hover:underline lg:shrink-0"
           href="/profile/user1"
         >
           followed you
@@ -102,18 +102,18 @@ exports[`NotificationItem - Snapshots > matches snapshot for Mention notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
         data-testid="typography"
       >
         <a
-          class="no-underline hover:no-underline"
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
           href="/profile/user1"
         >
           User
         </a>
          
         <a
-          class="text-foreground hover:underline"
+          class="text-foreground hover:underline lg:shrink-0"
           href="/post/user1/post123"
         >
           mentioned you in post
@@ -176,18 +176,18 @@ exports[`NotificationItem - Snapshots > matches snapshot for TagPost notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:whitespace-nowrap lg:text-base"
         data-testid="typography"
       >
         <a
-          class="no-underline hover:no-underline"
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
           href="/profile/user1"
         >
           User
         </a>
          
         <a
-          class="text-foreground hover:underline"
+          class="text-foreground hover:underline lg:shrink-0"
           href="/post/user1/post123"
         >
           tagged your post

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for Follow notification
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink truncate text-sm leading-none font-medium text-foreground lg:text-base lg:leading-normal"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
         data-testid="typography"
       >
         <a
@@ -102,7 +102,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for Mention notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink truncate text-sm leading-none font-medium text-foreground lg:text-base lg:leading-normal"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
         data-testid="typography"
       >
         <a
@@ -176,7 +176,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for TagPost notificatio
       data-testid="container"
     >
       <p
-        class="min-w-0 shrink truncate text-sm leading-none font-medium text-foreground lg:text-base lg:leading-normal"
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
         data-testid="typography"
       >
         <a
@@ -194,6 +194,7 @@ exports[`NotificationItem - Snapshots > matches snapshot for TagPost notificatio
         </a>
       </p>
       <span
+        class="hidden shrink-0 lg:inline-flex"
         data-testid="post-tag"
       >
         bitcoin

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -166,23 +166,26 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
         <Container overrideDefaults={true} className="flex min-w-0 flex-1 items-center gap-2">
           <Typography
             as="p"
-            className="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
+            className="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
           >
-            {/* Username - links to user profile without underline on hover */}
+            {/* Username - truncated independently so long names do not overlap timestamp/icon */}
             {userProfileLink ? (
-              <Link href={userProfileLink} className="no-underline hover:no-underline">
+              <Link
+                href={userProfileLink}
+                className="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+              >
                 {userName}
               </Link>
             ) : (
-              userName
+              <span className="inline-block max-w-full min-w-0 truncate align-bottom">{userName}</span>
             )}{' '}
             {/* Action text - links to notification target (post or profile) */}
             {notificationLink ? (
-              <Link href={notificationLink} className="text-foreground hover:underline">
+              <Link href={notificationLink} className="text-foreground hover:underline lg:shrink-0">
                 {actionText}
               </Link>
             ) : (
-              <span className="text-foreground">{actionText}</span>
+              <span className="text-foreground lg:shrink-0">{actionText}</span>
             )}
           </Typography>
 

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -166,7 +166,7 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
         <Container overrideDefaults={true} className="flex min-w-0 flex-1 items-center gap-2">
           <Typography
             as="p"
-            className="min-w-0 shrink truncate text-sm leading-none font-medium text-foreground lg:text-base lg:leading-normal"
+            className="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:truncate lg:text-base"
           >
             {/* Username - links to user profile without underline on hover */}
             {userProfileLink ? (
@@ -201,13 +201,13 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
               </Typography>
             ))}
 
-          {/* Tag badge for tagged notifications - click navigates to search */}
+          {/* Desktop tag badge for tagged notifications - click navigates to search */}
           {(notification.type === NotificationType.TagPost || notification.type === NotificationType.TagProfile) &&
             'tag_label' in notification && (
               <PostTag
                 label={notification.tag_label}
                 showClose={false}
-                className="shrink-0"
+                className="hidden shrink-0 lg:inline-flex"
                 onClick={handleTagClick(notification.tag_label)}
               />
             )}


### PR DESCRIPTION
## Summary
- fix #1793
- Tagged notifications rendered their interactive tag badge at every viewport size. On mobile, long labels consumed the available row width and truncated the actor/action copy, making the notification difficult to understand and the post target difficult to discover.
- Mobile tagged notifications now match the design: the tag badge is hidden, the actor/action copy can wrap naturally, and the existing post/profile navigation remains intact.

## Changes
- Allow notification actor/action copy to wrap with normal line height below the `lg` breakpoint while retaining single-line truncation on desktop.
- Hide `PostTag` below `lg`; preserve the desktop tag-search interaction for post and profile tag notifications.
- Add focused unit coverage for responsive classes, tagged-post routing, actor-profile routing, and tagged-profile routing; refresh snapshots.
- Update the Cypress notification scenario to use the near-limit `first-world-problem` tag and assert mobile/desktop visibility plus their respective navigation targets.

## Test plan
- [ ] Desktop/mobile Cypress notification flow — not run locally per request

## Notes
- Notification payloads and route resolution are unchanged: the actor avatar/name still opens the actor profile; the action, timestamp/icon, and non-interactive row area still open the tagged post; tagged-profile actions still open `/profile/tagged`.
- The existing `lg` breakpoint remains the mobile/desktop boundary.