### PR TITLE
feat: collection moderation

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1417,5 +1417,9 @@
     "updateCollectionFailed": "فشل تحديث المجموعة.",
     "collectionCreated": "تم إنشاء المجموعة وحفظ المنشور.",
     "createCollectionFailed": "فشل إنشاء المجموعة."
+  },
+  "moderation": {
+    "postContentModerated": "تم حظر محتوى المنشور.",
+    "collectionContentModerated": "تم حظر محتوى المجموعة."
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1423,5 +1423,9 @@
     "updateCollectionFailed": "Sammlung konnte nicht aktualisiert werden.",
     "collectionCreated": "Sammlung erstellt und Beitrag gespeichert.",
     "createCollectionFailed": "Sammlung konnte nicht erstellt werden."
+  },
+  "moderation": {
+    "postContentModerated": "Beitragsinhalt zensiert.",
+    "collectionContentModerated": "Sammlungsinhalt zensiert."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1421,5 +1421,9 @@
     "updateCollectionFailed": "Failed to update collection.",
     "collectionCreated": "Collection created and post saved.",
     "createCollectionFailed": "Failed to create collection."
+  },
+  "moderation": {
+    "postContentModerated": "Post content moderated.",
+    "collectionContentModerated": "Collection content moderated."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1425,5 +1425,9 @@
     "updateCollectionFailed": "No se pudo actualizar la colección.",
     "collectionCreated": "Colección creada y publicación guardada.",
     "createCollectionFailed": "No se pudo crear la colección."
+  },
+  "moderation": {
+    "postContentModerated": "Contenido de la publicación censurado.",
+    "collectionContentModerated": "Contenido de la colección censurado."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1421,5 +1421,9 @@
     "updateCollectionFailed": "Échec de la mise à jour de la collection.",
     "collectionCreated": "Collection créée et publication enregistrée.",
     "createCollectionFailed": "Échec de la création de la collection."
+  },
+  "moderation": {
+    "postContentModerated": "Contenu de la publication censuré.",
+    "collectionContentModerated": "Contenu de la collection censuré."
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1421,5 +1421,9 @@
     "updateCollectionFailed": "Impossibile aggiornare la collezione.",
     "collectionCreated": "Collezione creata e post salvato.",
     "createCollectionFailed": "Impossibile creare la collezione."
+  },
+  "moderation": {
+    "postContentModerated": "Contenuto del post censurato.",
+    "collectionContentModerated": "Contenuto della collezione censurato."
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1421,5 +1421,9 @@
     "updateCollectionFailed": "コレクションの更新に失敗しました。",
     "collectionCreated": "コレクションを作成し、投稿を保存しました。",
     "createCollectionFailed": "コレクションの作成に失敗しました。"
+  },
+  "moderation": {
+    "postContentModerated": "投稿内容は検閲されました。",
+    "collectionContentModerated": "コレクションの内容は検閲されました。"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1421,5 +1421,9 @@
     "updateCollectionFailed": "Falha ao atualizar a coleção.",
     "collectionCreated": "Coleção criada e publicação salva.",
     "createCollectionFailed": "Falha ao criar a coleção."
+  },
+  "moderation": {
+    "postContentModerated": "Conteúdo do post censurado.",
+    "collectionContentModerated": "Conteúdo da coleção censurado."
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1415,5 +1415,9 @@
     "updateCollectionFailed": "更新收藏集失败。",
     "collectionCreated": "收藏集已创建并保存帖子。",
     "createCollectionFailed": "创建收藏集失败。"
+  },
+  "moderation": {
+    "postContentModerated": "帖子内容已被审核。",
+    "collectionContentModerated": "收藏集内容已被审核。"
   }
 }

--- a/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.test.tsx
+++ b/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ModerationBlurOverlay } from './ModerationBlurOverlay';
+
+describe('ModerationBlurOverlay', () => {
+  it('renders the provided label', () => {
+    render(<ModerationBlurOverlay label="Collection content moderated." />);
+
+    expect(screen.getByText('Collection content moderated.')).toBeInTheDocument();
+  });
+
+  it('renders the eye-off icon', () => {
+    const { container } = render(<ModerationBlurOverlay label="Post content moderated." />);
+
+    expect(container.querySelector('.lucide-eye-off')).toBeInTheDocument();
+  });
+
+  it('fills its positioned parent so it overlays the blurred content', () => {
+    const { container } = render(<ModerationBlurOverlay label="Moderated." />);
+
+    // The overlay is the root element; `absolute inset-0` is what makes it sit
+    // on top of the blurred placeholder behind it.
+    const overlay = container.firstChild as HTMLElement;
+    expect(overlay).toHaveClass('absolute', 'inset-0');
+  });
+
+  it('merges a custom className onto the base classes', () => {
+    const { container } = render(<ModerationBlurOverlay label="Moderated." className="z-10" />);
+
+    const overlay = container.firstChild as HTMLElement;
+    expect(overlay).toHaveClass('z-10');
+    expect(overlay).toHaveClass('absolute', 'inset-0');
+  });
+});
+
+describe('ModerationBlurOverlay - Snapshots', () => {
+  it('matches the snapshot', () => {
+    const { container } = render(<ModerationBlurOverlay label="Collection content moderated." />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.test.tsx.snap
+++ b/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.test.tsx.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ModerationBlurOverlay - Snapshots > matches the snapshot 1`] = `
+<div
+  class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground transition-colors group-hover:text-secondary-foreground"
+  data-testid="container"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-eye-off size-6"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"
+    />
+    <path
+      d="M14.084 14.158a3 3 0 0 1-4.242-4.242"
+    />
+    <path
+      d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"
+    />
+    <path
+      d="m2 2 20 20"
+    />
+  </svg>
+  <p
+    class="text-sm"
+    data-testid="typography"
+  >
+    Collection content moderated.
+  </p>
+</div>
+`;

--- a/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.tsx
+++ b/src/components/molecules/ModerationBlurOverlay/ModerationBlurOverlay.tsx
@@ -1,0 +1,36 @@
+import { EyeOff } from 'lucide-react';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { cn } from '@/libs/utils/utils';
+
+interface ModerationBlurOverlayProps {
+  /** Message shown under the icon, e.g. "Collection content moderated." */
+  label: string;
+  className?: string;
+}
+
+/**
+ * Centered "content moderated" overlay (eye-off icon + label) layered over a
+ * blurred placeholder. Absolutely fills its positioned parent. Shared by the
+ * blurred collection card / hero (and any other moderated-content placeholder)
+ * so the unblur affordance stays visually consistent.
+ *
+ * Expects a `group` ancestor for the hover color transition, and a `relative`
+ * (positioned) parent so the `inset-0` fill lands correctly.
+ */
+export function ModerationBlurOverlay({ label, className }: ModerationBlurOverlayProps) {
+  return (
+    <Container
+      overrideDefaults
+      className={cn(
+        'absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground transition-colors group-hover:text-secondary-foreground',
+        className,
+      )}
+    >
+      <EyeOff className="size-6" />
+      <Typography overrideDefaults as="p" className="text-sm">
+        {label}
+      </Typography>
+    </Container>
+  );
+}

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
@@ -63,6 +63,13 @@ vi.mock('@/molecules/CollectionDeleted/CollectionDeleted', () => ({
   CollectionDeleted: () => <div data-testid="collection-deleted" />,
 }));
 
+const mockUnBlur = vi.fn();
+vi.mock('@/controllers/moderation/moderation', () => ({
+  ModerationController: {
+    unBlur: (...args: unknown[]) => mockUnBlur(...args),
+  },
+}));
+
 vi.mock('@/stores/auth/auth.store', () => ({
   useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) => mockUseAuthStore(selector),
 }));
@@ -149,7 +156,7 @@ function setAuthStore(currentUserPubky: string | null) {
   );
 }
 
-function setPostDetails(content: string | null) {
+function setPostDetails(content: string | null, { isBlurred = false }: { isBlurred?: boolean } = {}) {
   mockUsePostDetails.mockReturnValue({
     postDetails: content
       ? asOpaque<EnrichedPostDetails>({
@@ -159,8 +166,8 @@ function setPostDetails(content: string | null) {
           indexed_at: 0,
           uri: '',
           attachments: null,
-          is_moderated: false,
-          is_blurred: false,
+          is_moderated: isBlurred,
+          is_blurred: isBlurred,
         })
       : null,
     isLoading: false,
@@ -407,6 +414,45 @@ describe('CollectionCard', () => {
       expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.unfollow')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('moderation — blurred state', () => {
+    it('renders the blurred placeholder instead of the card when the collection is moderated', () => {
+      setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      // Overlay copy is shown; the real title / navigable link are not rendered.
+      expect(screen.getByText('moderation.collectionContentModerated')).toBeInTheDocument();
+      expect(screen.queryByText('Based Bitcoin')).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Based Bitcoin' })).not.toBeInTheDocument();
+    });
+
+    it('unblurs (via the composite id) and stops propagation when the placeholder is clicked', () => {
+      setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
+      const parentClick = vi.fn();
+
+      render(
+        <div onClick={parentClick}>
+          <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />
+        </div>,
+      );
+
+      fireEvent.click(screen.getByText('moderation.collectionContentModerated'));
+
+      expect(mockUnBlur).toHaveBeenCalledTimes(1);
+      expect(mockUnBlur).toHaveBeenCalledWith(COMPOSITE_ID);
+      expect(parentClick).not.toHaveBeenCalled();
+    });
+
+    it('renders the deleted fallback (not the blur placeholder) when a moderated collection is also deleted', () => {
+      setPostDetails('[DELETED]', { isBlurred: true });
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      expect(screen.getByTestId('collection-deleted')).toBeInTheDocument();
+      expect(screen.queryByText('moderation.collectionContentModerated')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -25,6 +25,7 @@ import { DialogConfirmDelete } from '@/molecules/DialogConfirmDelete/DialogConfi
 import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
 import { ClickableTagsList } from '@/organisms/ClickableTagsList/ClickableTagsList';
 import { CollectionCardSkeleton } from '@/organisms/Collections/CollectionCard/CollectionCard.skeleton';
+import { CollectionCardBlurred } from '@/organisms/Collections/CollectionCard/CollectionCardBlurred';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 
@@ -95,6 +96,14 @@ export function CollectionCard({
   // `CollectionDeleted` owns its full card shell — no wrappers needed here.
   if (isPostDeleted(postDetails.content)) {
     return <CollectionDeleted className={className} />;
+  }
+
+  // Moderated collections render a blurred, same-footprint placeholder instead
+  // of their content. Checked after the deleted guard (a deleted collection
+  // wins) and mirrors `PostContentBase`'s blur intercept — direct-render
+  // surfaces (landing sections) need their own check since they bypass it.
+  if (postDetails.is_blurred) {
+    return <CollectionCardBlurred compositeId={compositeId} className={className} />;
   }
 
   return (

--- a/src/components/organisms/Collections/CollectionCard/CollectionCardBlurred.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCardBlurred.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Library } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/atoms/Button/Button';
+import { Card, CardContent } from '@/atoms/Card/Card';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { ModerationController } from '@/controllers/moderation/moderation';
+import { cn } from '@/libs/utils/utils';
+import { ModerationBlurOverlay } from '@/molecules/ModerationBlurOverlay/ModerationBlurOverlay';
+
+interface CollectionCardBlurredProps {
+  /** `author:postId` composite id — the moderation record key passed to `unBlur`. */
+  compositeId: string;
+  className?: string;
+}
+
+/**
+ * Blurred placeholder for a moderated `CollectionCard`.
+ *
+ * Mirrors `CollectionCard`'s outer shape (rounded card, `p-6` body, header +
+ * description + tag/action rows) so the moderated state occupies the same
+ * footprint as the real card — only blurred, with an unblur overlay. The whole
+ * card is a single click-to-unblur button (no navigation), matching how
+ * `PostContentBlurred` handles moderated posts.
+ */
+export function CollectionCardBlurred({ compositeId, className }: CollectionCardBlurredProps) {
+  const t = useTranslations('moderation');
+  return (
+    <Button
+      overrideDefaults
+      onClick={(e) => {
+        e.stopPropagation();
+        ModerationController.unBlur(compositeId);
+      }}
+      className={cn('group relative block h-full w-full cursor-pointer text-left lg:max-w-187', className)}
+    >
+      <Card className="relative isolate h-full gap-0 overflow-hidden rounded-md py-0">
+        {/* Blurred mock of the real card layout */}
+        <CardContent aria-hidden="true" className="flex h-full flex-col gap-3 p-6 blur-lg select-none">
+          {/* Header row: icon + title (left) | count + avatar (right) */}
+          <Container overrideDefaults className="flex w-full flex-wrap items-center gap-3 sm:flex-nowrap">
+            <Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2">
+              <Library className="size-6 shrink-0 text-white" />
+              <Typography
+                as="span"
+                overrideDefaults
+                className="min-w-0 flex-1 truncate text-xl leading-7 font-bold text-white"
+              >
+                Collection title placeholder
+              </Typography>
+            </Container>
+
+            <Container overrideDefaults className="flex shrink-0 items-center justify-end gap-3">
+              <Container overrideDefaults className="h-3 w-6 rounded-md bg-white/30" />
+              <Container overrideDefaults className="size-9 shrink-0 rounded-full bg-white/30" />
+            </Container>
+          </Container>
+
+          {/* Description */}
+          <Typography
+            overrideDefaults
+            className="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-white"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.
+          </Typography>
+
+          {/* Bottom row: tag chips (left) | action button (right). `mt-auto`
+              pins it to the bottom when the card stretches to match a taller
+              sibling in the same row (mirrors how the real cards align). */}
+          <Container
+            overrideDefaults
+            className="mt-auto flex w-full flex-wrap items-center justify-between gap-3 sm:flex-nowrap"
+          >
+            <Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2">
+              <Container overrideDefaults className="h-7 w-20 rounded-md bg-white/30" />
+              <Container overrideDefaults className="h-7 w-24 rounded-md bg-white/30" />
+            </Container>
+            <Container overrideDefaults className="h-8 w-28 shrink-0 rounded-md bg-white/30" />
+          </Container>
+        </CardContent>
+
+        {/* Unblur overlay */}
+        <ModerationBlurOverlay label={t('collectionContentModerated')} />
+      </Card>
+    </Button>
+  );
+}

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
@@ -69,6 +69,13 @@ vi.mock('@/molecules/DialogConfirmDelete/DialogConfirmDelete', () => ({
     ) : null,
 }));
 
+const mockUnBlur = vi.fn();
+vi.mock('@/controllers/moderation/moderation', () => ({
+  ModerationController: {
+    unBlur: (...args: unknown[]) => mockUnBlur(...args),
+  },
+}));
+
 vi.mock('@/stores/auth/auth.store', () => ({
   useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) => mockUseAuthStore(selector),
 }));
@@ -173,7 +180,7 @@ function setAuthStore(currentUserPubky: string | null) {
   );
 }
 
-function setPostDetails(content: string | null) {
+function setPostDetails(content: string | null, { isBlurred = false }: { isBlurred?: boolean } = {}) {
   mockUsePostDetails.mockReturnValue({
     postDetails: content
       ? asOpaque<EnrichedPostDetails>({
@@ -183,8 +190,8 @@ function setPostDetails(content: string | null) {
           indexed_at: 0,
           uri: '',
           attachments: null,
-          is_moderated: false,
-          is_blurred: false,
+          is_moderated: isBlurred,
+          is_blurred: isBlurred,
         })
       : null,
     isLoading: false,
@@ -297,6 +304,30 @@ describe('CollectionHero', () => {
     const matches = screen.getAllByText(AUTHOR_PUBKY);
     expect(matches).toHaveLength(1);
     expect(matches[0]).toHaveAttribute('data-testid', 'avatar-with-fallback');
+  });
+
+  describe('moderation — blurred state', () => {
+    it('renders the blurred placeholder instead of the hero when the collection is moderated', () => {
+      setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
+
+      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      expect(screen.getByText('moderation.collectionContentModerated')).toBeInTheDocument();
+      expect(screen.queryByText('Based Bitcoin')).not.toBeInTheDocument();
+      // Action buttons belong to the real hero, not the placeholder.
+      expect(screen.queryByLabelText('collections.single.follow')).not.toBeInTheDocument();
+    });
+
+    it('unblurs (via the composite id) when the placeholder is clicked', () => {
+      setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
+
+      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      fireEvent.click(screen.getByText('moderation.collectionContentModerated'));
+
+      expect(mockUnBlur).toHaveBeenCalledTimes(1);
+      expect(mockUnBlur).toHaveBeenCalledWith(COMPOSITE_ID);
+    });
   });
 
   describe('CTA — owner', () => {

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
@@ -22,6 +22,7 @@ import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/Collectio
 import { DialogConfirmDelete } from '@/molecules/DialogConfirmDelete/DialogConfirmDelete';
 import { ClickableTagsList } from '@/organisms/ClickableTagsList/ClickableTagsList';
 import { CollectionHeroSkeleton } from '@/organisms/Collections/CollectionHero/CollectionHero.skeleton';
+import { CollectionHeroBlurred } from '@/organisms/Collections/CollectionHero/CollectionHeroBlurred';
 import { EditCollectionDialog } from '@/organisms/EditCollectionDialog/EditCollectionDialog';
 import { HeroOwner } from '@/organisms/HeroOwner/HeroOwner';
 import { FileVariant } from '@/services/nexus/file/file.types';
@@ -49,6 +50,13 @@ export function CollectionHero({ authorPubky, postId, className }: CollectionHer
 
   if (!postDetails) {
     return <CollectionHeroSkeleton className={className} />;
+  }
+
+  // Moderated collections render a blurred, same-footprint placeholder instead
+  // of their content. Mirrors `PostContentBase`'s blur intercept; the single
+  // collection page renders the hero directly so it needs its own check.
+  if (postDetails.is_blurred) {
+    return <CollectionHeroBlurred compositeId={compositeId} className={className} />;
   }
 
   return (

--- a/src/components/organisms/Collections/CollectionHero/CollectionHeroBlurred.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHeroBlurred.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Button } from '@/atoms/Button/Button';
+import { Card, CardContent } from '@/atoms/Card/Card';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { ModerationController } from '@/controllers/moderation/moderation';
+import { cn } from '@/libs/utils/utils';
+import { ModerationBlurOverlay } from '@/molecules/ModerationBlurOverlay/ModerationBlurOverlay';
+
+interface CollectionHeroBlurredProps {
+  /** `author:postId` composite id — the moderation record key passed to `unBlur`. */
+  compositeId: string;
+  className?: string;
+}
+
+/**
+ * Blurred placeholder for a moderated `CollectionHero`.
+ *
+ * Mirrors `CollectionHero`'s outer shape (tall rounded banner, `p-8 lg:p-12`
+ * body, title → owner → description → tags → actions stack) so the moderated
+ * state occupies the same footprint as the real hero — only blurred, with an
+ * unblur overlay. The whole banner is a single click-to-unblur button, matching
+ * how `PostContentBlurred` handles moderated posts.
+ */
+export function CollectionHeroBlurred({ compositeId, className }: CollectionHeroBlurredProps) {
+  const t = useTranslations('moderation');
+  return (
+    <Button
+      overrideDefaults
+      onClick={(e) => {
+        e.stopPropagation();
+        ModerationController.unBlur(compositeId);
+      }}
+      className={cn('group relative block w-full cursor-pointer text-left', className)}
+    >
+      <Card className="relative gap-0 overflow-hidden rounded-md py-0">
+        {/* Blurred mock of the real hero layout */}
+        <CardContent aria-hidden="true" className="flex flex-col justify-center gap-4 p-8 blur-lg select-none lg:p-12">
+          {/* Title */}
+          <Typography
+            as="h1"
+            overrideDefaults
+            className="text-5xl leading-tight font-bold wrap-anywhere text-white lg:text-6xl"
+          >
+            Collection title placeholder
+          </Typography>
+
+          {/* Owner + item count */}
+          <Container overrideDefaults className="flex w-full items-center gap-6">
+            <Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2 lg:flex-none">
+              <Container overrideDefaults className="size-8 shrink-0 rounded-full bg-white/30" />
+              <Container overrideDefaults className="h-5 w-32 rounded-md bg-white/30" />
+            </Container>
+            <Container overrideDefaults className="h-4 w-10 shrink-0 rounded-md bg-white/30" />
+          </Container>
+
+          {/* Description */}
+          <Typography
+            overrideDefaults
+            className="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-white lg:text-2xl"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua.
+          </Typography>
+
+          {/* Tags */}
+          <Container overrideDefaults className="flex flex-wrap items-center gap-2">
+            <Container overrideDefaults className="h-7 w-20 rounded-md bg-white/30" />
+            <Container overrideDefaults className="h-7 w-16 rounded-md bg-white/30" />
+          </Container>
+
+          {/* Actions */}
+          <Container overrideDefaults className="flex flex-wrap items-center gap-3">
+            <Container overrideDefaults className="h-8 w-24 rounded-full bg-white/30" />
+            <Container overrideDefaults className="h-8 w-20 rounded-full bg-white/30" />
+          </Container>
+        </CardContent>
+
+        {/* Unblur overlay */}
+        <ModerationBlurOverlay label={t('collectionContentModerated')} />
+      </Card>
+    </Button>
+  );
+}

--- a/src/components/organisms/PostContentBlurred/PostContentBlurred.test.tsx
+++ b/src/components/organisms/PostContentBlurred/PostContentBlurred.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/controllers/moderation/moderation', () => ({
   },
 }));
 
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace?: string) => (key: string) => `${namespace ?? ''}.${key}`,
+}));
+
 // Mock Atoms
 vi.mock('@/atoms/Button/Button', () => {
   return {
@@ -104,7 +108,7 @@ describe('PostContentBlurred', () => {
   it('displays the moderated post message', () => {
     render(<PostContentBlurred {...defaultProps} />);
 
-    expect(screen.getByText('Post content moderated.')).toBeInTheDocument();
+    expect(screen.getByText('moderation.postContentModerated')).toBeInTheDocument();
   });
 
   it('displays blurred placeholder text', () => {

--- a/src/components/organisms/PostContentBlurred/PostContentBlurred.test.tsx.snap
+++ b/src/components/organisms/PostContentBlurred/PostContentBlurred.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`PostContentBlurred - Snapshots > matches snapshot with custom className
       data-override-defaults="true"
       data-testid="typography"
     >
-      Post content moderated.
+      moderation.postContentModerated
     </p>
   </div>
 </button>
@@ -106,7 +106,7 @@ exports[`PostContentBlurred - Snapshots > matches snapshot with default props 1`
       data-override-defaults="true"
       data-testid="typography"
     >
-      Post content moderated.
+      moderation.postContentModerated
     </p>
   </div>
 </button>

--- a/src/components/organisms/PostContentBlurred/PostContentBlurred.tsx
+++ b/src/components/organisms/PostContentBlurred/PostContentBlurred.tsx
@@ -1,15 +1,16 @@
-import { EyeOff } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { Button } from '@/atoms/Button/Button';
-import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
 import { ModerationController } from '@/controllers/moderation/moderation';
 import { cn } from '@/libs/utils/utils';
+import { ModerationBlurOverlay } from '@/molecules/ModerationBlurOverlay/ModerationBlurOverlay';
 
 interface PostContentBlurredProps {
   postId: string;
   className?: string;
 }
 export const PostContentBlurred = ({ postId, className }: PostContentBlurredProps) => {
+  const t = useTranslations('moderation');
   return (
     <Button
       overrideDefaults
@@ -32,16 +33,7 @@ export const PostContentBlurred = ({ postId, className }: PostContentBlurredProp
       </Typography>
 
       {/* Overlay with icon and message */}
-      <Container
-        overrideDefaults
-        className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground transition-colors group-hover:text-secondary-foreground"
-      >
-        <EyeOff className="size-6" />
-
-        <Typography overrideDefaults as="p" className="text-sm">
-          Post content moderated.
-        </Typography>
-      </Container>
+      <ModerationBlurOverlay label={t('postContentModerated')} />
     </Button>
   );
 };


### PR DESCRIPTION
  ## 🙈 Add moderation (blur) to Collections

  ### Context

  Collections are just posts with `kind === 'collection'`, and the moderation/blur plumbing already exists end-to-end —
  `usePostDetails` returns an `EnrichedPostDetails` with an `is_blurred` flag, and
  `ModerationController.unBlur(compositeId)` clears it. `PostContentBase` already intercepts blur and renders
  `PostContentBlurred`.

  The gap: `CollectionCard` (landing sections) and `CollectionHero` (single-collection page) are rendered **directly**,
  bypassing that interception — so a moderated collection rendered in full. This PR adds the render path so those surfaces
  blur correctly, with a click-to-unblur placeholder that matches the real card/hero footprint.

  No moderation plumbing changes were needed — this is purely a render path plus presentational components.

  ### ✨ What changed

  **New blurred placeholders** (one per surface, since the card and hero have different dimensions):
  - `CollectionCardBlurred` — mirrors the card shell (`p-6`, header/description/tag-action rows, `lg:max-w-187`).
  - `CollectionHeroBlurred` — mirrors the hero shell (`p-8 lg:p-12`, large title → owner → description → tags → actions
  stack).
  - Each is a single click-to-unblur `Button` (no navigation) wrapping a `Card` whose mock content is rendered under
  `blur-2xl select-none`, with an `EyeOff` + "content moderated" overlay — matching how `PostContentBlurred` handles
  moderated posts.

  **Render-path wiring:**
  - `CollectionCard`: `skeleton → deleted → blurred → content` (deleted wins, matching `PostContentBase`'s ordering).
  - `CollectionHero`: `skeleton → blurred → content`.
  - Both pass the **composite id** to `unBlur`, consistent with `PostContentBlurred`.

  **🎨 White placeholders:** The mock placeholders (title, description, icon, bars) are intentionally **white**
  (`text-white` / `bg-white/30`) rather than reusing the real colors — colored elements bled through the blur as invisible
  color blobs, whereas white blurs into a clean light redaction.

  **📐 Bottom-aligned action row:** The card's tag/action row uses `mt-auto` so it pins to the bottom when a card
  stretches to match a taller sibling in the same row (matching the alignment behavior the real cards will adopt in an
  upcoming refactor).

  **♻️  Shared overlay extraction:** The "content moderated" overlay was identical across the two new collection components
  and near-identical in `PostContentBlurred`, so it's extracted into a presentational molecule, `ModerationBlurOverlay`,
  that takes a `label` prop. All three components now consume it. The `PostContentBlurred` DOM output is byte-for-byte
  unchanged by this extraction.

  **🌍 Internationalization:** The previously-hardcoded English strings are now translated. Added a new `moderation`
  namespace with `postContentModerated` and `collectionContentModerated` to **all 9 locale files** (`en`, `de`, `es`,
  `fr`, `it`, `ja`, `pt-BR`, `zh`, `ar`), with wording aligned to each locale's existing `blurCensored` / collection
  vocabulary. Each component now resolves its label via `useTranslations('moderation')`.

  ### ✅ Tests

  - Added `moderation — blurred state` cases to the `CollectionCard` and `CollectionHero` suites: the blurred placeholder
  renders instead of the real content, clicking it calls `unBlur` with the composite id (and stops propagation), and a
  deleted-and-moderated collection still shows the deleted fallback.
  - Added a dedicated suite for the new `ModerationBlurOverlay` molecule (label, icon, overlay positioning, `className`
  merge, snapshot).
  - Updated `PostContentBlurred` tests for the i18n change (added `next-intl` mock; the one snapshot change is the label
  text node now resolving to the translation key — expected, structure otherwise unchanged).

  ### 🗂️  Notable files

  - **New:** `ModerationBlurOverlay.tsx`, `CollectionCardBlurred.tsx`, `CollectionHeroBlurred.tsx` (+ tests/snapshots)
  - **Modified:** `CollectionCard.tsx`, `CollectionHero.tsx`, `PostContentBlurred.tsx`, all 9 `messages/*.json`

  ### 👀 Reviewer notes

  - Blurred collection posts that flow through `PostContentBase` (feeds/timelines) were already handled by its existing
  blur intercept — this PR covers only the direct-render surfaces that bypass it.
  - The non-English moderation strings are aligned to existing in-app vocabulary but may warrant a later native review.

  _This pull request summary was generated, for full implementation details please reference the file changes._