### PR TITLE
feat(collections): add hero Content button, grid trailing CTAs, and new-collection card

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1373,6 +1373,7 @@
       "delete": "حذف",
       "follow": "متابعة",
       "unfollow": "إلغاء المتابعة",
+      "content": "محتوى",
       "addContent": "إضافة محتوى",
       "empty": "هذه المجموعة فارغة.",
       "notFound": {
@@ -1385,7 +1386,7 @@
       }
     },
     "addContentDialog": {
-      "title": "إضافة محتوى",
+      "title": "محتوى",
       "description": "أضف منشورًا أو مقالًا من خلاصتك أو الصق رابطًا مباشرة.",
       "fromFeedTitle": "إضافة من الخلاصة",
       "fromFeedLead": "ابحث عن منشور",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1379,6 +1379,7 @@
       "delete": "Löschen",
       "follow": "Folgen",
       "unfollow": "Entfolgen",
+      "content": "Inhalt",
       "addContent": "Inhalt hinzufügen",
       "empty": "Diese Sammlung ist leer.",
       "notFound": {
@@ -1391,7 +1392,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Inhalt hinzufügen",
+      "title": "Inhalt",
       "description": "Füge einen Beitrag oder Artikel aus deinem Feed hinzu oder füge direkt eine URL ein.",
       "fromFeedTitle": "Aus Feed hinzufügen",
       "fromFeedLead": "Finde einen Beitrag",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1377,6 +1377,7 @@
       "delete": "Delete",
       "follow": "Follow",
       "unfollow": "Unfollow",
+      "content": "Content",
       "addContent": "Add Content",
       "empty": "This collection is empty.",
       "notFound": {
@@ -1389,7 +1390,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Add Content",
+      "title": "Content",
       "description": "Add a post or article from your feed or paste a url directly.",
       "fromFeedTitle": "Add from feed",
       "fromFeedLead": "Find a post",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1381,6 +1381,7 @@
       "delete": "Eliminar",
       "follow": "Seguir",
       "unfollow": "Dejar de seguir",
+      "content": "Contenido",
       "addContent": "Añadir contenido",
       "empty": "Esta colección está vacía.",
       "notFound": {
@@ -1393,7 +1394,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Añadir contenido",
+      "title": "Contenido",
       "description": "Añade una publicación o artículo desde tu feed o pega una URL directamente.",
       "fromFeedTitle": "Añadir desde el feed",
       "fromFeedLead": "Busca una publicación",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1377,6 +1377,7 @@
       "delete": "Supprimer",
       "follow": "Suivre",
       "unfollow": "Ne plus suivre",
+      "content": "Contenu",
       "addContent": "Ajouter du contenu",
       "empty": "Cette collection est vide.",
       "notFound": {
@@ -1389,7 +1390,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Ajouter du contenu",
+      "title": "Contenu",
       "description": "Ajoutez une publication ou un article depuis votre fil ou collez directement une URL.",
       "fromFeedTitle": "Ajouter depuis le fil",
       "fromFeedLead": "Trouvez une publication",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1377,6 +1377,7 @@
       "delete": "Elimina",
       "follow": "Segui",
       "unfollow": "Smetti di seguire",
+      "content": "Contenuto",
       "addContent": "Aggiungi contenuto",
       "empty": "Questa raccolta è vuota.",
       "notFound": {
@@ -1389,7 +1390,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Aggiungi contenuto",
+      "title": "Contenuto",
       "description": "Aggiungi un post o un articolo dal tuo feed oppure incolla direttamente un URL.",
       "fromFeedTitle": "Aggiungi dal feed",
       "fromFeedLead": "Trova un post",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1377,6 +1377,7 @@
       "delete": "削除",
       "follow": "フォロー",
       "unfollow": "フォロー解除",
+      "content": "コンテンツ",
       "addContent": "コンテンツを追加",
       "empty": "このコレクションは空です。",
       "notFound": {
@@ -1389,7 +1390,7 @@
       }
     },
     "addContentDialog": {
-      "title": "コンテンツを追加",
+      "title": "コンテンツ",
       "description": "フィードから投稿または記事を追加するか、URLを直接貼り付けます。",
       "fromFeedTitle": "フィードから追加",
       "fromFeedLead": "投稿を見つけて",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1377,6 +1377,7 @@
       "delete": "Excluir",
       "follow": "Seguir",
       "unfollow": "Deixar de seguir",
+      "content": "Conteúdo",
       "addContent": "Adicionar conteúdo",
       "empty": "Esta coleção está vazia.",
       "notFound": {
@@ -1389,7 +1390,7 @@
       }
     },
     "addContentDialog": {
-      "title": "Adicionar conteúdo",
+      "title": "Conteúdo",
       "description": "Adicione uma publicação ou artigo do seu feed ou cole uma URL diretamente.",
       "fromFeedTitle": "Adicionar do feed",
       "fromFeedLead": "Encontre uma publicação",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1371,6 +1371,7 @@
       "delete": "删除",
       "follow": "关注",
       "unfollow": "取消关注",
+      "content": "内容",
       "addContent": "添加内容",
       "empty": "此收藏为空。",
       "notFound": {
@@ -1383,7 +1384,7 @@
       }
     },
     "addContentDialog": {
-      "title": "添加内容",
+      "title": "内容",
       "description": "从你的信息流添加帖子或文章，或直接粘贴 URL。",
       "fromFeedTitle": "从信息流添加",
       "fromFeedLead": "找到一个帖子",

--- a/src/components/organisms/AddContentDialog/AddContentDialog.test.tsx
+++ b/src/components/organisms/AddContentDialog/AddContentDialog.test.tsx
@@ -94,16 +94,28 @@ describe('AddContentDialog', () => {
     mocks.prependOptimisticPosts.mockReturnValue(undefined);
   });
 
-  it('renders the Add Content trigger', () => {
+  it('renders the Content trigger', () => {
     render(<AddContentDialog />);
 
-    expect(screen.getByRole('button', { name: 'collections.single.addContent' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'collections.single.content' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'collections.single.content' })).toHaveAttribute(
+      'data-cy',
+      'add-content',
+    );
+  });
+
+  it('renders the Add Content grid trigger when triggerVariant is grid', () => {
+    render(<AddContentDialog triggerVariant="grid" dataCy="bookmarks-add-content-grid" />);
+
+    const trigger = screen.getByRole('button', { name: 'collections.single.addContent' });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('data-cy', 'bookmarks-add-content-grid');
   });
 
   it('opens the desktop dialog with feed and URL placeholder options', () => {
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
 
     expect(screen.getByRole('dialog')).toHaveClass('outline-none', 'focus:outline-none', 'focus-visible:outline-none');
     expect(screen.getByTestId('dialog-title')).toHaveTextContent('collections.addContentDialog.title');
@@ -115,7 +127,7 @@ describe('AddContentDialog', () => {
   it('stacks URL validation messages below the input', () => {
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
 
     const footer = screen.getByPlaceholderText('https://').closest('[data-slot="card-footer"]');
     expect(footer).toHaveClass('flex-col', 'items-stretch');
@@ -124,7 +136,7 @@ describe('AddContentDialog', () => {
   it('shows a red dashed border when the pasted URL is invalid', async () => {
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
     fireEvent.paste(screen.getByPlaceholderText('https://'), {
       clipboardData: {
         getData: () => 'not a post url',
@@ -141,7 +153,7 @@ describe('AddContentDialog', () => {
   it('adds pasted bookmark content, prepends it, and closes the dialog', async () => {
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
     fireEvent.paste(screen.getByPlaceholderText('https://'), {
       clipboardData: {
         getData: () => POST_URL,
@@ -162,7 +174,7 @@ describe('AddContentDialog', () => {
 
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
     fireEvent.paste(screen.getByPlaceholderText('https://'), {
       clipboardData: {
         getData: () => POST_URL,
@@ -182,7 +194,7 @@ describe('AddContentDialog', () => {
   it('adds pasted content to a collection and closes the dialog', async () => {
     render(<AddContentDialog target={{ type: 'collection', collectionId: COLLECTION_ID }} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
     fireEvent.paste(screen.getByPlaceholderText('https://'), {
       clipboardData: {
         getData: () => POST_URL,
@@ -209,10 +221,16 @@ describe('AddContentDialog - Snapshots', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('matches the closed grid trigger snapshot', () => {
+    const { container } = render(<AddContentDialog triggerVariant="grid" />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('matches the opened desktop dialog snapshot', () => {
     render(<AddContentDialog />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'collections.single.addContent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'collections.single.content' }));
 
     expect(document.body).toMatchSnapshot();
   });

--- a/src/components/organisms/AddContentDialog/AddContentDialog.test.tsx.snap
+++ b/src/components/organisms/AddContentDialog/AddContentDialog.test.tsx.snap
@@ -1,14 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AddContentDialog - Snapshots > matches the closed trigger snapshot 1`] = `
+exports[`AddContentDialog - Snapshots > matches the closed grid trigger snapshot 1`] = `
 <button
   aria-controls="radix-normalized"
   aria-expanded="false"
   aria-haspopup="dialog"
   aria-label="collections.single.addContent"
-  class="flex h-39 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
+  class="flex h-full w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
   data-as-child="true"
-  data-cy="add-content-cta"
+  data-cy="add-content"
   data-slot="dialog-trigger"
   data-state="closed"
   data-testid="dialog-trigger"
@@ -43,6 +43,58 @@ exports[`AddContentDialog - Snapshots > matches the closed trigger snapshot 1`] 
 </button>
 `;
 
+exports[`AddContentDialog - Snapshots > matches the closed trigger snapshot 1`] = `
+<button
+  aria-controls="radix-normalized"
+  aria-expanded="false"
+  aria-haspopup="dialog"
+  aria-label="collections.single.content"
+  class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent size-9 lg:h-8 lg:w-auto lg:gap-1.5 lg:px-3.5 lg:text-xs"
+  data-as-child="true"
+  data-cy="add-content"
+  data-size="icon"
+  data-slot="dialog-trigger"
+  data-state="closed"
+  data-testid="dialog-trigger"
+  data-variant="secondary"
+  type="button"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-square-plus size-4"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      height="18"
+      rx="2"
+      width="18"
+      x="3"
+      y="3"
+    />
+    <path
+      d="M8 12h8"
+    />
+    <path
+      d="M12 8v8"
+    />
+  </svg>
+  <span
+    class="hidden lg:inline"
+    data-testid="typography"
+  >
+    collections.single.content
+  </span>
+</button>
+`;
+
 exports[`AddContentDialog - Snapshots > matches the opened desktop dialog snapshot 1`] = `
 <body
   data-scroll-locked="1"
@@ -63,18 +115,20 @@ exports[`AddContentDialog - Snapshots > matches the opened desktop dialog snapsh
       aria-controls="radix-normalized"
       aria-expanded="true"
       aria-haspopup="dialog"
-      aria-label="collections.single.addContent"
-      class="flex h-39 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
+      aria-label="collections.single.content"
+      class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent size-9 lg:h-8 lg:w-auto lg:gap-1.5 lg:px-3.5 lg:text-xs"
       data-as-child="true"
-      data-cy="add-content-cta"
+      data-cy="add-content"
+      data-size="icon"
       data-slot="dialog-trigger"
       data-state="open"
       data-testid="dialog-trigger"
+      data-variant="secondary"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="lucide lucide-plus size-3 shrink-0"
+        class="lucide lucide-square-plus size-4"
         fill="none"
         height="24"
         stroke="currentColor"
@@ -85,18 +139,25 @@ exports[`AddContentDialog - Snapshots > matches the opened desktop dialog snapsh
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M5 12h14"
+        <rect
+          height="18"
+          rx="2"
+          width="18"
+          x="3"
+          y="3"
         />
         <path
-          d="M12 5v14"
+          d="M8 12h8"
+        />
+        <path
+          d="M12 8v8"
         />
       </svg>
       <span
-        class="text-sm font-bold"
+        class="hidden lg:inline"
         data-testid="typography"
       >
-        collections.single.addContent
+        collections.single.content
       </span>
     </button>
   </div>

--- a/src/components/organisms/AddContentDialog/AddContentDialog.tsx
+++ b/src/components/organisms/AddContentDialog/AddContentDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef, type SyntheticEvent, useState } from 'react';
-import { Library, MessageCircle, Plus, Repeat } from 'lucide-react';
+import { Library, MessageCircle, Plus, Repeat, SquarePlus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/atoms/Button/Button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/atoms/Card/Card';
@@ -16,21 +16,42 @@ import {
 } from '@/atoms/Dialog/Dialog';
 import { Typography } from '@/atoms/Typography/Typography';
 import { useAddContentForm } from '@/hooks/useAddContentForm/useAddContentForm';
-import { ADD_CONTENT_FORM_FIELDS, type AddContentTarget } from '@/hooks/useAddContentForm/useAddContentForm.types';
+import { ADD_CONTENT_FORM_FIELDS } from '@/hooks/useAddContentForm/useAddContentForm.types';
 import { cn } from '@/libs/utils/utils';
 import { ControlledInputField } from '@/molecules/ControlledInputField/ControlledInputField';
+import { GRID_DASHED_CTA_TRIGGER_CLASS } from '@/organisms/Collections/gridDashedCta.const';
 import { useTimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed';
+import type { AddContentDialogProps } from './AddContentDialog.types';
 
-interface AddContentDialogProps {
-  className?: string;
-  dataCy?: string;
-  target?: AddContentTarget;
-}
-
-const AddContentTrigger = forwardRef<
+const AddContentHeroTrigger = forwardRef<
   ComponentRef<typeof Button>,
-  ComponentPropsWithoutRef<typeof Button> & AddContentDialogProps
->(function AddContentTrigger({ className, dataCy, ...props }, ref) {
+  ComponentPropsWithoutRef<typeof Button> & Pick<AddContentDialogProps, 'dataCy'>
+>(function AddContentHeroTrigger({ className, dataCy, ...props }, ref) {
+  const t = useTranslations('collections.single');
+
+  return (
+    <Button
+      ref={ref}
+      variant="secondary"
+      size="icon"
+      type="button"
+      aria-label={t('content')}
+      data-cy={dataCy}
+      className={cn('lg:h-8 lg:w-auto lg:gap-1.5 lg:px-3.5 lg:text-xs', className)}
+      {...props}
+    >
+      <SquarePlus className="size-4" />
+      <Typography as="span" overrideDefaults className="hidden lg:inline">
+        {t('content')}
+      </Typography>
+    </Button>
+  );
+});
+
+const AddContentGridTrigger = forwardRef<
+  ComponentRef<typeof Button>,
+  ComponentPropsWithoutRef<typeof Button> & Pick<AddContentDialogProps, 'dataCy'>
+>(function AddContentGridTrigger({ className, dataCy, ...props }, ref) {
   const t = useTranslations('collections.single');
 
   return (
@@ -40,10 +61,7 @@ const AddContentTrigger = forwardRef<
       type="button"
       aria-label={t('addContent')}
       data-cy={dataCy}
-      className={cn(
-        'flex h-39 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none',
-        className,
-      )}
+      className={cn(GRID_DASHED_CTA_TRIGGER_CLASS, className)}
       {...props}
     >
       <Plus className="size-3 shrink-0" />
@@ -181,9 +199,9 @@ function AddContentDialogBody({
 }
 
 export function AddContentDialog({
-  className,
-  dataCy = 'add-content-cta',
+  dataCy = 'add-content',
   target = { type: 'bookmarks' },
+  triggerVariant = 'hero',
 }: AddContentDialogProps) {
   const t = useTranslations('collections.addContentDialog');
   const [open, setOpen] = useState(false);
@@ -194,11 +212,12 @@ export function AddContentDialog({
     setOpen(false);
   };
 
+  const trigger =
+    triggerVariant === 'grid' ? <AddContentGridTrigger dataCy={dataCy} /> : <AddContentHeroTrigger dataCy={dataCy} />;
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <AddContentTrigger className={className} dataCy={dataCy} />
-      </DialogTrigger>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
         className="flex max-w-xl flex-col overflow-hidden bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
         hiddenTitle={t('title')}

--- a/src/components/organisms/AddContentDialog/AddContentDialog.types.ts
+++ b/src/components/organisms/AddContentDialog/AddContentDialog.types.ts
@@ -1,0 +1,13 @@
+import type { AddContentTarget } from '@/hooks/useAddContentForm/useAddContentForm.types';
+
+export type AddContentTriggerVariant = 'hero' | 'grid';
+
+export interface AddContentDialogProps {
+  dataCy?: string;
+  target?: AddContentTarget;
+  /**
+   * `hero` — pill button for collection/bookmarks hero actions.
+   * `grid` — dashed tile for the last cell in bookmarks/collection grids.
+   */
+  triggerVariant?: AddContentTriggerVariant;
+}

--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx
@@ -23,30 +23,38 @@ vi.mock('next-intl', () => ({
   }),
 }));
 
-vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
-  AvatarWithFallback: ({
-    avatarUrl,
+vi.mock('@/organisms/HeroOwner/HeroOwner', () => ({
+  HeroOwner: ({
     name,
     fallbackSeed,
+    avatarUrl,
     size,
-    alt,
+    isResolved,
   }: {
-    avatarUrl?: string;
     name: string;
-    fallbackSeed?: string;
+    fallbackSeed: string;
+    avatarUrl?: string;
     size?: string;
-    alt?: string;
+    isResolved: boolean;
   }) => (
     <div
-      data-testid="avatar-with-fallback"
-      data-avatar-url={avatarUrl ?? ''}
+      data-testid="hero-owner"
       data-name={name}
       data-fallback-seed={fallbackSeed}
+      data-avatar-url={avatarUrl ?? ''}
       data-size={size}
-      data-alt={alt}
+      data-resolved={String(isResolved)}
     >
-      {name}
+      {isResolved ? name : 'skeleton'}
     </div>
+  ),
+}));
+
+vi.mock('@/organisms/AddContentDialog/AddContentDialog', () => ({
+  AddContentDialog: ({ dataCy }: { dataCy?: string }) => (
+    <button type="button" data-testid={dataCy ?? 'add-content-dialog'} aria-label="collections.single.content">
+      collections.single.content
+    </button>
   ),
 }));
 
@@ -68,8 +76,15 @@ describe('BookmarksHero', () => {
     // collections + deleted posts, overstating the grid). Re-assert once the
     // backend exposes an accurate posts-only count and the badge is re-wired.
     expect(screen.queryByText('15')).not.toBeInTheDocument();
-    expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-name', 'Alice');
-    expect(screen.getByText('Alice', { selector: 'span' })).toBeInTheDocument();
+    expect(screen.getByTestId('hero-owner')).toHaveAttribute('data-name', 'Alice');
+    expect(screen.getByText('Alice', { selector: 'div' })).toBeInTheDocument();
+  });
+
+  it('renders the Content action in the hero', () => {
+    render(<BookmarksHero avatarName="Alice" avatarSeed="alice-pubky" bookmarkCount={15} isProfileResolved={true} />);
+
+    expect(screen.getByTestId('bookmarks-add-content')).toBeInTheDocument();
+    expect(screen.getByLabelText('collections.single.content')).toBeInTheDocument();
   });
 
   it('does not render custom-collection management actions for the system collection', () => {
@@ -90,8 +105,8 @@ describe('BookmarksHero', () => {
     render(<BookmarksHero avatarName="U" avatarSeed="alice-pubky" bookmarkCount={15} isProfileResolved={false} />);
 
     // The avatar still renders, but the username text must not appear yet.
-    expect(screen.getByTestId('avatar-with-fallback')).toBeInTheDocument();
-    expect(screen.queryByText('U', { selector: 'span' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('hero-owner')).toBeInTheDocument();
+    expect(screen.queryByText('U', { selector: 'div' })).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx.snap
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.test.tsx.snap
@@ -27,25 +27,14 @@ exports[`BookmarksHero - Snapshots > matches the snapshot with count and avatar 
       data-testid="container"
     >
       <div
-        class="flex min-w-0 items-center gap-3"
-        data-testid="container"
+        data-avatar-url="https://example.com/avatar.png"
+        data-fallback-seed="alice-pubky"
+        data-name="Alice"
+        data-resolved="true"
+        data-size="sm"
+        data-testid="hero-owner"
       >
-        <div
-          data-alt="Alice"
-          data-avatar-url="https://example.com/avatar.png"
-          data-fallback-seed="alice-pubky"
-          data-name="Alice"
-          data-size="sm"
-          data-testid="avatar-with-fallback"
-        >
-          Alice
-        </div>
-        <span
-          class="min-w-0 truncate text-xl leading-7 font-bold text-foreground"
-          data-testid="typography"
-        >
-          Alice
-        </span>
+        Alice
       </div>
     </div>
     <p
@@ -54,6 +43,18 @@ exports[`BookmarksHero - Snapshots > matches the snapshot with count and avatar 
     >
       Everything you saved for later.
     </p>
+    <div
+      class="flex flex-wrap items-center gap-3"
+      data-testid="container"
+    >
+      <button
+        aria-label="collections.single.content"
+        data-testid="bookmarks-add-content"
+        type="button"
+      >
+        collections.single.content
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksHero/BookmarksHero.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { Card, CardContent } from '@/atoms/Card/Card';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
+import { AddContentDialog } from '@/organisms/AddContentDialog/AddContentDialog';
 // TODO: Re-enable the bookmark count badge once the backend exposes an accurate
 // posts-only bookmark count. The current `userCounts.bookmarks` total also counts
 // bookmarked collections and deleted posts, so it overstates what the grid shows
@@ -68,6 +69,10 @@ export function BookmarksHero({
         >
           {t('bookmarks.description')}
         </Typography>
+
+        <Container overrideDefaults className="flex flex-wrap items-center gap-3">
+          <AddContentDialog target={{ type: 'bookmarks' }} dataCy="bookmarks-add-content" />
+        </Container>
       </CardContent>
     </Card>
   );

--- a/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.test.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { BookmarksItems } from './BookmarksItems';
@@ -7,42 +7,53 @@ vi.mock('next-intl', () => ({
   useTranslations: (namespace?: string) => (key: string) => `${namespace ?? ''}.${key}`,
 }));
 
+vi.mock('@/organisms/AddContentDialog/AddContentDialog', () => ({
+  AddContentDialog: ({ dataCy, triggerVariant }: { dataCy?: string; triggerVariant?: string }) => (
+    <div data-testid="add-content-dialog" data-cy={dataCy} data-trigger-variant={triggerVariant ?? 'hero'} />
+  ),
+}));
+
 vi.mock('@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed', () => ({
   TimelineFeed: ({
     variant,
     children,
     emptyState,
+    gridTrailingSlot,
   }: {
     variant: string;
     children?: ReactNode;
     emptyState?: ReactNode;
+    gridTrailingSlot?: ReactNode;
   }) => (
-    <div data-testid="timeline-feed" data-variant={variant} data-has-empty-state={String(Boolean(emptyState))}>
+    <div
+      data-testid="timeline-feed"
+      data-variant={variant}
+      data-has-empty-state={String(Boolean(emptyState))}
+      data-has-grid-trailing-slot={String(Boolean(gridTrailingSlot))}
+    >
       {children}
+      {gridTrailingSlot}
     </div>
   ),
-  useTimelineFeedContext: () => null,
 }));
 
 describe('BookmarksItems', () => {
-  it('renders the BOOKMARKS TimelineFeed', () => {
-    render(<BookmarksItems />);
-
-    expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-variant', 'bookmarks');
-    expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-empty-state', 'true');
-  });
-
-  it('renders the add-content CTA above the feed', () => {
-    render(<BookmarksItems />);
+  it('renders the BOOKMARKS TimelineFeed with the header inside the feed context scope', () => {
+    render(<BookmarksItems header={<div data-testid="bookmarks-header">header</div>} />);
 
     const feed = screen.getByTestId('timeline-feed');
-    expect(within(feed).getByRole('button', { name: 'collections.single.addContent' })).toBeInTheDocument();
+    expect(feed).toHaveAttribute('data-variant', 'bookmarks');
+    expect(feed).toHaveAttribute('data-has-empty-state', 'true');
+    expect(feed).toHaveAttribute('data-has-grid-trailing-slot', 'true');
+    expect(screen.getByTestId('bookmarks-header')).toBeInTheDocument();
+    expect(screen.getByTestId('add-content-dialog')).toHaveAttribute('data-cy', 'bookmarks-add-content-grid');
+    expect(screen.getByTestId('add-content-dialog')).toHaveAttribute('data-trigger-variant', 'grid');
   });
 });
 
 describe('BookmarksItems - Snapshots', () => {
   it('matches the snapshot', () => {
-    const { container } = render(<BookmarksItems />);
+    const { container } = render(<BookmarksItems header={<div>Bookmarks header</div>} />);
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.test.tsx.snap
+++ b/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.test.tsx.snap
@@ -2,60 +2,23 @@
 
 exports[`BookmarksItems - Snapshots > matches the snapshot 1`] = `
 <div
-  class="flex w-full flex-col gap-6"
-  data-testid="container"
+  data-has-empty-state="true"
+  data-has-grid-trailing-slot="true"
+  data-testid="timeline-feed"
+  data-variant="bookmarks"
 >
   <div
-    data-has-empty-state="true"
-    data-testid="timeline-feed"
-    data-variant="bookmarks"
+    class="mb-6"
+    data-testid="container"
   >
-    <div
-      class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 lg:gap-6"
-      data-cy="bookmarks-add-content"
-      data-testid="container"
-    >
-      <button
-        aria-controls="radix-normalized"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        aria-label="collections.single.addContent"
-        class="flex h-39 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
-        data-as-child="true"
-        data-cy="add-content-cta"
-        data-slot="dialog-trigger"
-        data-state="closed"
-        data-testid="dialog-trigger"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-plus size-3 shrink-0"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5 12h14"
-          />
-          <path
-            d="M12 5v14"
-          />
-        </svg>
-        <span
-          class="text-sm font-bold"
-          data-testid="typography"
-        >
-          collections.single.addContent
-        </span>
-      </button>
+    <div>
+      Bookmarks header
     </div>
   </div>
+  <div
+    data-cy="bookmarks-add-content-grid"
+    data-testid="add-content-dialog"
+    data-trigger-variant="grid"
+  />
 </div>
 `;

--- a/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.tsx
+++ b/src/components/organisms/Bookmarks/BookmarksItems/BookmarksItems.tsx
@@ -1,26 +1,28 @@
 'use client';
 
-import { Container } from '@/atoms/Container/Container';
-import { GRID_FEED_COLUMNS_CLASS, GRID_FEED_GAP_CLASS, TIMELINE_FEED_VARIANT } from '@/config/feed';
-import { cn } from '@/libs/utils/utils';
+import type { ReactNode } from 'react';
+import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { AddContentDialog } from '@/organisms/AddContentDialog/AddContentDialog';
 import { CollectionItemsEmpty } from '@/organisms/Collections/CollectionItemsEmpty/CollectionItemsEmpty';
 import { TimelineFeed } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed';
+import { TimelineFeedHeaderSlot } from '@/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot';
 
-export function BookmarksItems() {
+interface BookmarksItemsProps {
+  header: ReactNode;
+}
+
+export function BookmarksItems({ header }: BookmarksItemsProps) {
   const emptyState = <CollectionItemsEmpty dataCy="bookmarks-items-empty" />;
 
   return (
-    <Container overrideDefaults className="flex w-full flex-col gap-6">
-      <TimelineFeed variant={TIMELINE_FEED_VARIANT.BOOKMARKS} emptyState={emptyState}>
-        <Container
-          overrideDefaults
-          data-cy="bookmarks-add-content"
-          className={cn('grid', GRID_FEED_COLUMNS_CLASS, GRID_FEED_GAP_CLASS)}
-        >
-          <AddContentDialog target={{ type: 'bookmarks' }} />
-        </Container>
-      </TimelineFeed>
-    </Container>
+    <TimelineFeed
+      variant={TIMELINE_FEED_VARIANT.BOOKMARKS}
+      emptyState={emptyState}
+      gridTrailingSlot={
+        <AddContentDialog triggerVariant="grid" target={{ type: 'bookmarks' }} dataCy="bookmarks-add-content-grid" />
+      }
+    >
+      <TimelineFeedHeaderSlot>{header}</TimelineFeedHeaderSlot>
+    </TimelineFeed>
   );
 }

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import { TagKind } from '@/application/tag/tag.types';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
-import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { usePostReplyRepostDialogs } from '@/hooks/usePostReplyRepostDialogs/usePostReplyRepostDialogs';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { CollectionHero } from './CollectionHero';
+import type { CollectionHeroProps } from './CollectionHero.types';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -21,10 +21,6 @@ vi.mock('next-intl', () => ({
   useFormatter: () => ({
     number: (value: number, _options?: Intl.NumberFormatOptions) => String(value),
   }),
-}));
-
-vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
-  usePostDetails: vi.fn(),
 }));
 
 vi.mock('@/hooks/useUserProfile/useUserProfile', () => ({
@@ -101,6 +97,14 @@ vi.mock('@/organisms/EditCollectionDialog/EditCollectionDialog', () => ({
     ) : null,
 }));
 
+vi.mock('@/organisms/AddContentDialog/AddContentDialog', () => ({
+  AddContentDialog: ({ dataCy }: { dataCy?: string; target?: { type: string; collectionId?: string } }) => (
+    <button type="button" data-testid={dataCy ?? 'add-content-dialog'} aria-label="collections.single.content">
+      collections.single.content
+    </button>
+  ),
+}));
+
 vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
   AvatarWithFallback: ({
     avatarUrl,
@@ -169,10 +173,24 @@ const COLLECTION_CONTENT_NO_COVER = JSON.stringify({
   items: [],
 });
 
-const mockUsePostDetails = vi.mocked(usePostDetails);
 const mockUseUserProfile = vi.mocked(useUserProfile);
 const mockUseBookmark = vi.mocked(useBookmark);
 const mockUsePostReplyRepostDialogs = vi.mocked(usePostReplyRepostDialogs);
+
+let currentPostDetails: EnrichedPostDetails | null | undefined;
+
+function buildPostDetails(content: string, isBlurred = false): EnrichedPostDetails {
+  return asOpaque<EnrichedPostDetails>({
+    id: COMPOSITE_ID,
+    content,
+    kind: 'collection',
+    indexed_at: 0,
+    uri: '',
+    attachments: null,
+    is_moderated: isBlurred,
+    is_blurred: isBlurred,
+  });
+}
 
 function setAuthStore(currentUserPubky: string | null) {
   mockUseAuthStore.mockImplementation((selector: (state: { currentUserPubky: string | null }) => unknown) =>
@@ -181,21 +199,18 @@ function setAuthStore(currentUserPubky: string | null) {
 }
 
 function setPostDetails(content: string | null, { isBlurred = false }: { isBlurred?: boolean } = {}) {
-  mockUsePostDetails.mockReturnValue({
-    postDetails: content
-      ? asOpaque<EnrichedPostDetails>({
-          id: COMPOSITE_ID,
-          content,
-          kind: 'collection',
-          indexed_at: 0,
-          uri: '',
-          attachments: null,
-          is_moderated: isBlurred,
-          is_blurred: isBlurred,
-        })
-      : null,
-    isLoading: false,
-  });
+  currentPostDetails = content ? buildPostDetails(content, isBlurred) : null;
+}
+
+function renderHero(overrides: Partial<CollectionHeroProps> = {}) {
+  return render(
+    <CollectionHero
+      authorPubky={AUTHOR_PUBKY}
+      postId={POST_ID}
+      postDetails={overrides.postDetails ?? currentPostDetails}
+      {...overrides}
+    />,
+  );
 }
 
 function setOwnerProfile(name: string | null, avatarUrl?: string) {
@@ -254,7 +269,7 @@ beforeEach(() => {
 
 describe('CollectionHero', () => {
   it('renders title, description, item count, and owner avatar from the parsed envelope', () => {
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero();
 
     expect(screen.getByText('Based Bitcoin')).toBeInTheDocument();
     expect(screen.getByText('A bit of Bitcoin purity amidst all of the madness.')).toBeInTheDocument();
@@ -266,7 +281,7 @@ describe('CollectionHero', () => {
   });
 
   it('wires ClickableTagsList to the composite id with POST kind and the add button enabled', () => {
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero();
 
     const tags = screen.getByTestId('clickable-tags-list');
     expect(tags).toHaveAttribute('data-tagged-id', COMPOSITE_ID);
@@ -277,16 +292,14 @@ describe('CollectionHero', () => {
   it('omits the description block when the envelope description is empty / nullish', () => {
     setPostDetails(COLLECTION_CONTENT_NO_COVER);
 
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero();
 
     expect(screen.queryByText('A bit of Bitcoin purity amidst all of the madness.')).not.toBeInTheDocument();
     expect(screen.getByText('0')).toBeInTheDocument(); // empty items count still renders
   });
 
   it('renders the hero skeleton while post details have not loaded yet', () => {
-    mockUsePostDetails.mockReturnValue({ postDetails: undefined, isLoading: true });
-
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero({ postDetails: undefined });
 
     expect(screen.getByTestId('collection-hero-skeleton')).toBeInTheDocument();
     expect(screen.queryByText('Based Bitcoin')).not.toBeInTheDocument();
@@ -295,7 +308,7 @@ describe('CollectionHero', () => {
   it('shows a skeleton (not the raw pubky) for the owner name while the profile is null', () => {
     setOwnerProfile(null);
 
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero();
 
     // The owner name is gated on the resolved profile: while it's null the hero
     // renders a Skeleton rather than flashing the raw pubky as a visible name.
@@ -310,7 +323,7 @@ describe('CollectionHero', () => {
     it('renders the blurred placeholder instead of the hero when the collection is moderated', () => {
       setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       expect(screen.getByText('moderation.collectionContentModerated')).toBeInTheDocument();
       expect(screen.queryByText('Based Bitcoin')).not.toBeInTheDocument();
@@ -321,7 +334,7 @@ describe('CollectionHero', () => {
     it('unblurs (via the composite id) when the placeholder is clicked', () => {
       setPostDetails(COLLECTION_CONTENT, { isBlurred: true });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       fireEvent.click(screen.getByText('moderation.collectionContentModerated'));
 
@@ -331,11 +344,13 @@ describe('CollectionHero', () => {
   });
 
   describe('CTA — owner', () => {
-    it('renders Share / Edit / Delete and no Follow / Unfollow', () => {
+    it('renders Content / Share / Edit / Delete and no Follow / Unfollow', () => {
       setAuthStore(AUTHOR_PUBKY);
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
+      expect(screen.getByLabelText('collections.single.content')).toBeInTheDocument();
+      expect(screen.getByTestId('collection-add-content')).toBeInTheDocument();
       expect(screen.getByLabelText('collections.single.share')).toBeInTheDocument();
       expect(screen.getByLabelText('collections.single.edit')).toBeInTheDocument();
       expect(screen.getByLabelText('collections.single.delete')).toBeInTheDocument();
@@ -350,7 +365,7 @@ describe('CollectionHero', () => {
       setAuthStore(AUTHOR_PUBKY);
       const toggle = setBookmark({ isBookmarked: false });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       fireEvent.click(screen.getByLabelText('collections.single.edit'));
       fireEvent.click(screen.getByLabelText('collections.single.delete'));
@@ -361,7 +376,7 @@ describe('CollectionHero', () => {
     it('opens the EditCollectionDialog (controlled, with the composite id) when the owner clicks Edit', () => {
       setAuthStore(AUTHOR_PUBKY);
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       // Dialog is mounted but `open=false` until the user clicks Edit.
       expect(screen.queryByTestId('edit-collection-dialog')).not.toBeInTheDocument();
@@ -376,7 +391,7 @@ describe('CollectionHero', () => {
     it("does not mount the EditCollectionDialog for non-owners (the Edit button isn't shown either)", () => {
       setAuthStore('some-other-user');
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       expect(screen.queryByLabelText('collections.single.edit')).not.toBeInTheDocument();
       expect(screen.queryByTestId('edit-collection-dialog')).not.toBeInTheDocument();
@@ -386,7 +401,7 @@ describe('CollectionHero', () => {
       setAuthStore(AUTHOR_PUBKY);
       const { openRepostDialog } = setRepostDialogs();
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       fireEvent.click(screen.getByLabelText('collections.single.share'));
 
@@ -398,7 +413,7 @@ describe('CollectionHero', () => {
     describe('delete flow', () => {
       it('opens the confirmation dialog with the collection-specific i18n namespace on Delete click', () => {
         setAuthStore(AUTHOR_PUBKY);
-        render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+        renderHero();
 
         // Dialog mounts in closed state.
         expect(screen.queryByTestId('dialog-confirm-delete')).not.toBeInTheDocument();
@@ -415,7 +430,7 @@ describe('CollectionHero', () => {
         setAuthStore(AUTHOR_PUBKY);
         mockDeletePost.mockClear();
         mockRouterReplace.mockClear();
-        render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+        renderHero();
 
         fireEvent.click(screen.getByLabelText('collections.single.delete'));
         fireEvent.click(screen.getByTestId('dialog-confirm-delete-btn'));
@@ -433,7 +448,7 @@ describe('CollectionHero', () => {
 
       it('does not mount the confirm dialog for non-owners (Delete button absent)', () => {
         setAuthStore('some-other-user');
-        render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+        renderHero();
 
         expect(screen.queryByLabelText('collections.single.delete')).not.toBeInTheDocument();
         expect(screen.queryByTestId('dialog-confirm-delete')).not.toBeInTheDocument();
@@ -446,7 +461,7 @@ describe('CollectionHero', () => {
       setAuthStore('some-other-user');
       setBookmark({ isBookmarked: false });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       expect(screen.getByLabelText('collections.single.follow')).toBeInTheDocument();
       expect(screen.queryByLabelText('collections.single.unfollow')).not.toBeInTheDocument();
@@ -456,7 +471,7 @@ describe('CollectionHero', () => {
       setAuthStore('some-other-user');
       setBookmark({ isBookmarked: true });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       expect(screen.getByLabelText('collections.single.unfollow')).toBeInTheDocument();
     });
@@ -465,7 +480,7 @@ describe('CollectionHero', () => {
       setAuthStore('some-other-user');
       const toggle = setBookmark({ isBookmarked: false });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       fireEvent.click(screen.getByLabelText('collections.single.follow'));
 
@@ -476,7 +491,7 @@ describe('CollectionHero', () => {
       setAuthStore('some-other-user');
       const toggle = setBookmark({ isBookmarked: false, isToggling: true });
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       const button = screen.getByLabelText('collections.single.follow') as HTMLButtonElement;
       expect(button).toBeDisabled();
@@ -488,7 +503,7 @@ describe('CollectionHero', () => {
       setAuthStore('some-other-user');
       const { openRepostDialog } = setRepostDialogs();
 
-      render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      renderHero();
 
       expect(screen.getByText('collections.single.share', { selector: 'span' })).toHaveClass('hidden', 'lg:inline');
       fireEvent.click(screen.getByLabelText('collections.single.share'));
@@ -500,7 +515,7 @@ describe('CollectionHero', () => {
   it('passes the collection-flavored toast copy to useBookmark', () => {
     setAuthStore('some-other-user');
 
-    render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderHero();
 
     expect(mockUseBookmark).toHaveBeenCalledWith(
       COMPOSITE_ID,
@@ -512,7 +527,7 @@ describe('CollectionHero', () => {
 
   describe('cover image', () => {
     it('renders a background-image element when an absolute cover URL is present', () => {
-      const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      const { container } = renderHero();
 
       expect(container.querySelector(`[style*="${COVER_URL}"]`)).not.toBeNull();
     });
@@ -520,7 +535,7 @@ describe('CollectionHero', () => {
     it('does not render a cover background when the envelope has no cover_image', () => {
       setPostDetails(COLLECTION_CONTENT_NO_COVER);
 
-      const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      const { container } = renderHero();
 
       expect(container.querySelector(`[style*="${COVER_URL}"]`)).toBeNull();
     });
@@ -528,7 +543,7 @@ describe('CollectionHero', () => {
     it('prefers a recently-uploaded blob URL from the local-files store over the envelope cover', () => {
       mockLocalCollections[COMPOSITE_ID] = 'blob:mock-fresh-cover';
 
-      const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      const { container } = renderHero();
 
       expect(container.querySelector('[style*="blob:mock-fresh-cover"]')).not.toBeNull();
       expect(container.querySelector(`[style*="${COVER_URL}"]`)).toBeNull();
@@ -538,7 +553,7 @@ describe('CollectionHero', () => {
       setPostDetails(COLLECTION_CONTENT_NO_COVER);
       mockLocalCollections[COMPOSITE_ID] = 'blob:mock-fresh-cover';
 
-      const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      const { container } = renderHero();
 
       expect(container.querySelector('[style*="blob:mock-fresh-cover"]')).not.toBeNull();
     });
@@ -549,7 +564,7 @@ describe('CollectionHero - Snapshots', () => {
   it('matches the snapshot for the owner state', () => {
     setAuthStore(AUTHOR_PUBKY);
 
-    const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = renderHero();
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -557,7 +572,7 @@ describe('CollectionHero - Snapshots', () => {
     setAuthStore('viewer-pubky');
     setBookmark({ isBookmarked: false });
 
-    const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = renderHero();
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -565,7 +580,7 @@ describe('CollectionHero - Snapshots', () => {
     setPostDetails(COLLECTION_CONTENT_NO_COVER);
     setAuthStore('viewer-pubky');
 
-    const { container } = render(<CollectionHero authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = renderHero();
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
@@ -264,6 +264,13 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
       data-testid="container"
     >
       <button
+        aria-label="collections.single.content"
+        data-testid="collection-add-content"
+        type="button"
+      >
+        collections.single.content
+      </button>
+      <button
         aria-label="collections.single.share"
         class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent size-9 lg:h-8 lg:w-auto lg:gap-1.5 lg:px-3.5 lg:text-xs"
         data-size="icon"

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
@@ -12,7 +12,6 @@ import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { useDeletePost } from '@/hooks/useDeletePost/useDeletePost';
-import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { usePostReplyRepostDialogs } from '@/hooks/usePostReplyRepostDialogs/usePostReplyRepostDialogs';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { parseCollectionContent, resolveCollectionCoverImage } from '@/libs/post/collectionContent';
@@ -20,6 +19,7 @@ import { cn } from '@/libs/utils/utils';
 import { buildCompositeId } from '@/models/models.utils';
 import { CollectionCountBadge } from '@/molecules/CollectionCountBadge/CollectionCountBadge';
 import { DialogConfirmDelete } from '@/molecules/DialogConfirmDelete/DialogConfirmDelete';
+import { AddContentDialog } from '@/organisms/AddContentDialog/AddContentDialog';
 import { ClickableTagsList } from '@/organisms/ClickableTagsList/ClickableTagsList';
 import { CollectionHeroSkeleton } from '@/organisms/Collections/CollectionHero/CollectionHero.skeleton';
 import { CollectionHeroBlurred } from '@/organisms/Collections/CollectionHero/CollectionHeroBlurred';
@@ -34,19 +34,18 @@ import type { CollectionHeroContentProps, CollectionHeroProps } from './Collecti
  * CollectionHero
  *
  * Top region of the single-collection view (`/collections/[userId]/[postId]`).
- * Mirrors `CollectionCard`'s two-stage data approach: while `usePostDetails`
- * resolves (`undefined`) we render `CollectionHeroSkeleton`; once the envelope
- * lands we delegate to `CollectionHeroContent` (which owns the hooks that read
- * the parsed envelope — `useBookmark` toast copy, etc.).
+ * While the shared `postDetails` envelope is still resolving (`undefined`) we
+ * render `CollectionHeroSkeleton`; once the envelope lands we delegate to
+ * `CollectionHeroContent` (which owns the hooks that read the parsed envelope
+ * — `useBookmark` toast copy, etc.).
  *
  * The Hero → feed → Sections structure is identical for both owner and
  * other-user views; only the action buttons differ:
- *   - owner   → Share / Edit / Delete (visual placeholders this slice).
+ *   - owner   → Content / Share / Edit / Delete.
  *   - other   → real Follow / Unfollow (via `useBookmark`) + Share placeholder.
  */
-export function CollectionHero({ authorPubky, postId, className }: CollectionHeroProps) {
+export function CollectionHero({ authorPubky, postId, postDetails, className }: CollectionHeroProps) {
   const compositeId = buildCompositeId({ pubky: authorPubky, id: postId });
-  const { postDetails } = usePostDetails(compositeId);
 
   if (!postDetails) {
     return <CollectionHeroSkeleton className={className} />;
@@ -214,9 +213,13 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
         <Container overrideDefaults className="flex flex-wrap items-center gap-3">
           {isOwn ? (
             <>
-              {/* While a delete is in flight, disable every owner action.
-                  Lets the user know something's happening and prevents racing
-                  Share / Edit against an imminent route replace. */}
+              <AddContentDialog
+                target={{ type: 'collection', collectionId: compositeId }}
+                dataCy="collection-add-content"
+              />
+              {/* While a delete is in flight, disable Share / Edit / Delete so the
+                  user knows something is happening and those actions cannot race
+                  an imminent route replace. */}
               <Button
                 variant="secondary"
                 size="icon"

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.types.ts
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.types.ts
@@ -6,6 +6,8 @@ export interface CollectionHeroProps {
   authorPubky: Pubky;
   /** Collection post id (raw, not composite). */
   postId: string;
+  /** Loaded collection envelope from the page shell (avoids a duplicate `usePostDetails` fetch). */
+  postDetails: EnrichedPostDetails | null | undefined;
   className?: string;
 }
 

--- a/src/components/organisms/Collections/CollectionItems/CollectionItems.test.tsx
+++ b/src/components/organisms/Collections/CollectionItems/CollectionItems.test.tsx
@@ -2,7 +2,6 @@ import { createRef, type ReactNode, type RefObject } from 'react';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
-import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { CollectionItems } from './CollectionItems';
 
@@ -20,12 +19,33 @@ vi.mock('next-intl', () => ({
   }),
 }));
 
-vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
-  usePostDetails: vi.fn(),
-}));
-
 vi.mock('@/stores/auth/auth.store', () => ({
   useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) => mockUseAuthStore(selector),
+}));
+
+vi.mock('@/organisms/Collections/CollectionHero/CollectionHero', () => ({
+  CollectionHero: ({
+    authorPubky,
+    postId,
+    postDetails,
+  }: {
+    authorPubky: string;
+    postId: string;
+    postDetails?: EnrichedPostDetails | null;
+  }) => (
+    <div
+      data-testid="collection-hero"
+      data-author-pubky={authorPubky}
+      data-post-id={postId}
+      data-has-post-details={String(postDetails != null)}
+    />
+  ),
+}));
+
+vi.mock('@/organisms/AddContentDialog/AddContentDialog', () => ({
+  AddContentDialog: ({ dataCy, triggerVariant }: { dataCy?: string; triggerVariant?: string }) => (
+    <div data-testid="add-content-dialog" data-cy={dataCy} data-trigger-variant={triggerVariant ?? 'hero'} />
+  ),
 }));
 
 vi.mock('@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed', () => ({
@@ -34,17 +54,23 @@ vi.mock('@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed', () => ({
     children?: ReactNode;
     emptyState?: ReactNode;
     pullToRefreshContainerRef?: RefObject<HTMLElement | null>;
+    gridTrailingSlot?: ReactNode;
   }) => {
-    const { variant, children, emptyState, pullToRefreshContainerRef } = props;
-    mockTimelineFeedProps({ pullToRefreshContainerRef });
+    const { variant, children, emptyState, pullToRefreshContainerRef, gridTrailingSlot } = props;
+    mockTimelineFeedProps({ pullToRefreshContainerRef, gridTrailingSlot });
 
     return (
-      <div data-testid="timeline-feed" data-variant={variant} data-has-empty-state={String(Boolean(emptyState))}>
+      <div
+        data-testid="timeline-feed"
+        data-variant={variant}
+        data-has-empty-state={String(Boolean(emptyState))}
+        data-has-grid-trailing-slot={String(Boolean(gridTrailingSlot))}
+      >
         {children}
+        {gridTrailingSlot}
       </div>
     );
   },
-  useTimelineFeedContext: () => null,
 }));
 
 // ---------------------------------------------------------------------------
@@ -67,7 +93,18 @@ const COLLECTION_CONTENT_EMPTY = JSON.stringify({
   items: [],
 });
 
-const mockUsePostDetails = vi.mocked(usePostDetails);
+function buildPostDetails(content: string): EnrichedPostDetails {
+  return asOpaque<EnrichedPostDetails>({
+    id: COMPOSITE_ID,
+    content,
+    kind: 'collection',
+    indexed_at: 0,
+    uri: '',
+    attachments: null,
+    is_moderated: false,
+    is_blurred: false,
+  });
+}
 
 function setAuthStore(currentUserPubky: string | null) {
   mockUseAuthStore.mockImplementation((selector: (state: { currentUserPubky: string | null }) => unknown) =>
@@ -75,29 +112,27 @@ function setAuthStore(currentUserPubky: string | null) {
   );
 }
 
-function setPostDetails(content: string | null) {
-  mockUsePostDetails.mockReturnValue({
-    postDetails: content
-      ? asOpaque<EnrichedPostDetails>({
-          id: COMPOSITE_ID,
-          content,
-          kind: 'collection',
-          indexed_at: 0,
-          uri: '',
-          attachments: null,
-          is_moderated: false,
-          is_blurred: false,
-        })
-      : null,
-    isLoading: false,
-  });
+function renderCollectionItems({
+  postDetails = buildPostDetails(COLLECTION_CONTENT),
+  pullToRefreshContainerRef,
+}: {
+  postDetails?: EnrichedPostDetails | null;
+  pullToRefreshContainerRef?: RefObject<HTMLElement | null>;
+} = {}) {
+  return render(
+    <CollectionItems
+      authorPubky={AUTHOR_PUBKY}
+      postId={POST_ID}
+      postDetails={postDetails}
+      pullToRefreshContainerRef={pullToRefreshContainerRef}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockTimelineFeedProps.mockClear();
   setAuthStore(null);
-  setPostDetails(COLLECTION_CONTENT);
 });
 
 // ---------------------------------------------------------------------------
@@ -105,84 +140,85 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('CollectionItems', () => {
-  it('renders the COLLECTION TimelineFeed for a non-empty envelope with the collection empty state', () => {
-    setPostDetails(COLLECTION_CONTENT);
-
-    render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+  it('renders the COLLECTION TimelineFeed for a non-empty envelope with the hero inside the feed', () => {
+    renderCollectionItems();
 
     const feed = screen.getByTestId('timeline-feed');
     expect(feed).toHaveAttribute('data-variant', 'collection');
     expect(feed).toHaveAttribute('data-has-empty-state', 'true');
-    expect(screen.queryByLabelText('collections.single.addContent')).not.toBeInTheDocument();
+    expect(screen.getByTestId('collection-hero')).toBeInTheDocument();
     expect(screen.queryByTestId('collection-items-empty')).not.toBeInTheDocument();
   });
 
+  it('passes postDetails through to CollectionHero', () => {
+    renderCollectionItems();
+
+    expect(screen.getByTestId('collection-hero')).toHaveAttribute('data-has-post-details', 'true');
+  });
+
   it('passes the page-level pull-to-refresh ref to the timeline feed', () => {
-    setPostDetails(COLLECTION_CONTENT);
     const pullToRefreshContainerRef = createRef<HTMLElement>();
 
-    render(
-      <CollectionItems
-        authorPubky={AUTHOR_PUBKY}
-        postId={POST_ID}
-        pullToRefreshContainerRef={pullToRefreshContainerRef}
-      />,
-    );
+    renderCollectionItems({ pullToRefreshContainerRef });
 
     expect(mockTimelineFeedProps).toHaveBeenCalledWith({ pullToRefreshContainerRef });
   });
 
-  it('renders the owner Add Content CTA above the feed for a non-empty envelope', () => {
+  it('renders the feed for an owner non-empty envelope with the hero inside the feed', () => {
     setAuthStore(AUTHOR_PUBKY);
-    setPostDetails(COLLECTION_CONTENT);
 
-    render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderCollectionItems();
 
-    expect(screen.getByLabelText('collections.single.addContent')).toBeInTheDocument();
     expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-variant', 'collection');
-    expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-empty-state', 'true');
+    expect(screen.getByTestId('collection-hero')).toBeInTheDocument();
     expect(screen.queryByTestId('collection-items-empty')).not.toBeInTheDocument();
   });
 
   it('renders the feed (never the empty state) while the envelope is still loading', () => {
-    mockUsePostDetails.mockReturnValue({ postDetails: undefined, isLoading: true });
-
-    render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderCollectionItems({ postDetails: undefined });
 
     expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-variant', 'collection');
     expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-empty-state', 'true');
     expect(screen.queryByTestId('collection-items-empty')).not.toBeInTheDocument();
   });
 
-  it('renders the owner Add Content CTA and passes empty state for an empty envelope owned by the viewer', () => {
+  it('renders the feed and passes empty state for an empty envelope owned by the viewer', () => {
     setAuthStore(AUTHOR_PUBKY);
-    setPostDetails(COLLECTION_CONTENT_EMPTY);
 
-    render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderCollectionItems({ postDetails: buildPostDetails(COLLECTION_CONTENT_EMPTY) });
 
-    expect(screen.getByLabelText('collections.single.addContent')).toBeInTheDocument();
     expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-variant', 'collection');
     expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-empty-state', 'true');
+    expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-grid-trailing-slot', 'true');
+    expect(screen.getByTestId('add-content-dialog')).toHaveAttribute('data-cy', 'collection-add-content-grid');
+    expect(screen.getByTestId('add-content-dialog')).toHaveAttribute('data-trigger-variant', 'grid');
   });
 
-  it('renders plain empty text (and no Add Content CTA) for an empty envelope viewed by a non-owner', () => {
+  it('does not pass a grid trailing slot for non-owner collections', () => {
     setAuthStore('some-other-user');
-    setPostDetails(COLLECTION_CONTENT_EMPTY);
 
-    render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    renderCollectionItems();
 
+    expect(screen.getByTestId('timeline-feed')).toHaveAttribute('data-has-grid-trailing-slot', 'false');
+    expect(screen.queryByTestId('add-content-dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders plain empty text with the hero outside the feed for an empty envelope viewed by a non-owner', () => {
+    setAuthStore('some-other-user');
+
+    renderCollectionItems({ postDetails: buildPostDetails(COLLECTION_CONTENT_EMPTY) });
+
+    expect(screen.getByTestId('collection-hero')).toBeInTheDocument();
     expect(screen.getByText('collections.single.empty')).toBeInTheDocument();
-    expect(screen.queryByLabelText('collections.single.addContent')).not.toBeInTheDocument();
     expect(screen.queryByTestId('timeline-feed')).not.toBeInTheDocument();
   });
 });
 
 describe('CollectionItems - Snapshots', () => {
-  it('matches the owner non-empty snapshot with Add Content CTA above the feed', () => {
+  it('matches the owner non-empty snapshot', () => {
     setAuthStore(AUTHOR_PUBKY);
-    setPostDetails(COLLECTION_CONTENT);
 
-    const { container } = render(<CollectionItems authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = renderCollectionItems();
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/organisms/Collections/CollectionItems/CollectionItems.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionItems/CollectionItems.test.tsx.snap
@@ -1,61 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CollectionItems - Snapshots > matches the owner non-empty snapshot with Add Content CTA above the feed 1`] = `
+exports[`CollectionItems - Snapshots > matches the owner non-empty snapshot 1`] = `
 <div
-  class="flex w-full flex-col gap-6"
-  data-testid="container"
+  data-has-empty-state="true"
+  data-has-grid-trailing-slot="true"
+  data-testid="timeline-feed"
+  data-variant="collection"
 >
   <div
-    data-has-empty-state="true"
-    data-testid="timeline-feed"
-    data-variant="collection"
+    class="mb-6"
+    data-testid="container"
   >
     <div
-      class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 lg:gap-6"
-      data-cy="collection-add-content"
-      data-testid="container"
-    >
-      <button
-        aria-controls="radix-normalized"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        aria-label="collections.single.addContent"
-        class="flex h-39 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
-        data-as-child="true"
-        data-cy="add-content-cta"
-        data-slot="dialog-trigger"
-        data-state="closed"
-        data-testid="dialog-trigger"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-plus size-3 shrink-0"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5 12h14"
-          />
-          <path
-            d="M12 5v14"
-          />
-        </svg>
-        <span
-          class="text-sm font-bold"
-          data-testid="typography"
-        >
-          collections.single.addContent
-        </span>
-      </button>
-    </div>
+      data-author-pubky="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
+      data-has-post-details="true"
+      data-post-id="0034BBBDFK83G"
+      data-testid="collection-hero"
+    />
   </div>
+  <div
+    data-cy="collection-add-content-grid"
+    data-testid="add-content-dialog"
+    data-trigger-variant="grid"
+  />
 </div>
 `;

--- a/src/components/organisms/Collections/CollectionItems/CollectionItems.tsx
+++ b/src/components/organisms/Collections/CollectionItems/CollectionItems.tsx
@@ -1,39 +1,38 @@
 'use client';
 
 import { Container } from '@/atoms/Container/Container';
-import { GRID_FEED_COLUMNS_CLASS, GRID_FEED_GAP_CLASS, TIMELINE_FEED_VARIANT } from '@/config/feed';
-import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { parseCollectionContent } from '@/libs/post/collectionContent';
-import { cn } from '@/libs/utils/utils';
 import { buildCompositeId } from '@/models/models.utils';
 import { AddContentDialog } from '@/organisms/AddContentDialog/AddContentDialog';
+import { CollectionHero } from '@/organisms/Collections/CollectionHero/CollectionHero';
 import { CollectionItemsEmpty } from '@/organisms/Collections/CollectionItemsEmpty/CollectionItemsEmpty';
 import { TimelineFeed } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeed';
+import { TimelineFeedHeaderSlot } from '@/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import type { CollectionItemsProps } from './CollectionItems.types';
 
 /**
  * CollectionItems
  *
- * Middle region of the single-collection view: renders the collection item feed
- * and, for owners, the persistent Add Content CTA above it.
+ * Middle region of the single-collection view: renders the collection hero and
+ * item feed inside one `TimelineFeed` so hero actions (Add Content) can access
+ * `TimelineFeedContext` for optimistic inserts.
  *
  * The collection envelope is used only to confirm whether the collection is
- * empty. The grid itself is still driven by the `COLLECTION` stream, while
- * optimistic inserts bridge the gap until Nexus reflects local membership
- * changes. While the envelope is still resolving, we render the feed so the grid
- * can show its normal loading state instead of flashing the empty placeholder.
+ * empty. The grid itself is still driven by the `COLLECTION` stream. While the
+ * envelope is still resolving, we render the feed so the grid can show its
+ * normal loading state instead of flashing the empty placeholder.
  *
- * Empty non-owner collections can skip the feed entirely. Empty owner
- * collections keep the feed mounted so `AddContentDialog` can use the timeline
- * context for optimistic inserts.
+ * Empty non-owner collections skip the feed and render hero + empty copy only.
  */
-export function CollectionItems({ authorPubky, postId, pullToRefreshContainerRef }: CollectionItemsProps) {
-  const compositeId = buildCompositeId({ pubky: authorPubky, id: postId });
-  const { postDetails } = usePostDetails(compositeId);
-
+export function CollectionItems({ authorPubky, postId, postDetails, pullToRefreshContainerRef }: CollectionItemsProps) {
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const isOwn = currentUserPubky === authorPubky;
+
+  const compositeId = buildCompositeId({ pubky: authorPubky, id: postId });
+
+  const hero = <CollectionHero authorPubky={authorPubky} postId={postId} postDetails={postDetails} />;
 
   // Not-found / deleted collections are gated out upstream by the `Collection`
   // template (which renders `CollectionNotFound` instead), so by the time this
@@ -45,29 +44,29 @@ export function CollectionItems({ authorPubky, postId, pullToRefreshContainerRef
 
   if (!isOwn && isConfirmedEmpty) {
     return (
-      <Container overrideDefaults className="flex w-full flex-col gap-6">
+      <Container overrideDefaults className="flex w-full flex-col gap-12">
+        {hero}
         {emptyState}
       </Container>
     );
   }
 
   return (
-    <Container overrideDefaults className="flex w-full flex-col gap-6">
-      <TimelineFeed
-        variant={TIMELINE_FEED_VARIANT.COLLECTION}
-        emptyState={emptyState}
-        pullToRefreshContainerRef={pullToRefreshContainerRef}
-      >
-        {isOwn && (
-          <Container
-            overrideDefaults
-            data-cy="collection-add-content"
-            className={cn('grid', GRID_FEED_COLUMNS_CLASS, GRID_FEED_GAP_CLASS)}
-          >
-            <AddContentDialog target={{ type: 'collection', collectionId: compositeId }} />
-          </Container>
-        )}
-      </TimelineFeed>
-    </Container>
+    <TimelineFeed
+      variant={TIMELINE_FEED_VARIANT.COLLECTION}
+      emptyState={emptyState}
+      pullToRefreshContainerRef={pullToRefreshContainerRef}
+      gridTrailingSlot={
+        isOwn ? (
+          <AddContentDialog
+            triggerVariant="grid"
+            target={{ type: 'collection', collectionId: compositeId }}
+            dataCy="collection-add-content-grid"
+          />
+        ) : undefined
+      }
+    >
+      <TimelineFeedHeaderSlot>{hero}</TimelineFeedHeaderSlot>
+    </TimelineFeed>
   );
 }

--- a/src/components/organisms/Collections/CollectionItems/CollectionItems.types.ts
+++ b/src/components/organisms/Collections/CollectionItems/CollectionItems.types.ts
@@ -1,4 +1,5 @@
 import type { RefObject } from 'react';
+import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import type { Pubky } from '@/models/models.types';
 
 export interface CollectionItemsProps {
@@ -6,6 +7,8 @@ export interface CollectionItemsProps {
   authorPubky: Pubky;
   /** Collection post id (raw, not composite). */
   postId: string;
+  /** Loaded collection envelope from the page shell (shared with `CollectionHero`). */
+  postDetails: EnrichedPostDetails | null | undefined;
   /** Optional page-level container for collection pull-to-refresh gestures. */
   pullToRefreshContainerRef?: RefObject<HTMLElement | null>;
 }

--- a/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
@@ -42,6 +42,7 @@ vi.mock('dexie-react-hooks', () => ({
 vi.mock('@/controllers/post/post', () => ({
   PostController: {
     getDetailsByIds: vi.fn().mockResolvedValue([]),
+    commitCreateCollection: vi.fn(),
   },
 }));
 
@@ -100,6 +101,11 @@ vi.mock('@/organisms/Collections/CollectionCard/CollectionCard', () => ({
 
 vi.mock('@/organisms/Collections/CollectionCard/CollectionCard.skeleton', () => ({
   CollectionCardSkeleton: () => <div data-testid="collection-card-skeleton" />,
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string | null }) => unknown) =>
+    selector({ currentUserPubky: 'o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy' }),
 }));
 
 vi.mock('@/molecules/AvatarStack/AvatarStack.skeleton', () => ({
@@ -177,6 +183,7 @@ describe('MyCollections', () => {
     expect(skeleton).toHaveAttribute('data-count', '1');
     expect(screen.getByTestId('collection-bookmark-card')).toBeInTheDocument();
     expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'collections.new.cta' })).not.toBeInTheDocument();
     expect(mockUseStreamPagination).not.toHaveBeenCalled();
   });
 
@@ -193,6 +200,10 @@ describe('MyCollections', () => {
     const avatar = screen.getByTestId('avatar-with-fallback');
     expect(avatar).toHaveAttribute('data-name', 'Alice');
     expect(screen.getByTestId('collection-bookmark-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'collections.new.cta' })).toHaveAttribute(
+      'data-cy',
+      'new-collection-card-cta',
+    );
     expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
     expect(screen.queryByTestId('collection-card-skeleton')).not.toBeInTheDocument();
     expect(screen.queryByText('collections.showMore')).not.toBeInTheDocument();
@@ -221,6 +232,10 @@ describe('MyCollections', () => {
     expect(cards[1]).toHaveAttribute('data-author-pubky', AUTHOR_A);
     expect(cards[1]).toHaveAttribute('data-post-id', 'p2');
     expect(screen.getByTestId('collection-bookmark-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'collections.new.cta' })).toHaveAttribute(
+      'data-cy',
+      'new-collection-card-cta',
+    );
     expect(screen.queryByText('collections.showMore')).not.toBeInTheDocument();
   });
 
@@ -235,6 +250,10 @@ describe('MyCollections', () => {
 
     expect(screen.getByTestId('collection-bookmark-card')).toBeInTheDocument();
     expect(screen.getAllByTestId('collection-card-skeleton')).toHaveLength(COLLECTIONS_MY_SECTION_SKELETON_COUNT);
+    expect(screen.getByRole('button', { name: 'collections.new.cta' })).toHaveAttribute(
+      'data-cy',
+      'new-collection-card-cta',
+    );
   });
 
   it('does NOT render skeletons on warm-cache load (loading=true, postIds non-empty)', () => {

--- a/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx.snap
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx.snap
@@ -94,6 +94,51 @@ exports[`MyCollections > MyCollections - Snapshots > matches the snapshot for th
       data-post-id="p2"
       data-testid="collection-card"
     />
+    <div
+      class="block h-full w-full lg:max-w-187"
+      data-testid="container"
+    >
+      <button
+        aria-controls="radix-normalized"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-label="collections.new.cta"
+        class="flex h-full w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
+        data-as-child="true"
+        data-cy="new-collection-card-cta"
+        data-slot="dialog-trigger"
+        data-state="closed"
+        data-testid="dialog-trigger"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-plus size-3 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5 12h14"
+          />
+          <path
+            d="M12 5v14"
+          />
+        </svg>
+        <span
+          class="text-sm font-bold"
+          data-testid="typography"
+        >
+          collections.new.cta
+        </span>
+      </button>
+    </div>
   </div>
   <div
     class="flex w-full justify-center"

--- a/src/components/organisms/Collections/MyCollections/MyCollections.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.tsx
@@ -22,6 +22,7 @@ import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFal
 import { CollectionBookmarkCard } from '@/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard';
 import { CollectionCard } from '@/organisms/Collections/CollectionCard/CollectionCard';
 import { CollectionCardSkeleton } from '@/organisms/Collections/CollectionCard/CollectionCard.skeleton';
+import { NewCollectionCardCTA } from '@/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA';
 import { NewCollectionDialog } from '@/organisms/NewCollectionDialog/NewCollectionDialog';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 
@@ -178,6 +179,7 @@ function MyCollectionsStream({ currentUserPubky }: MyCollectionsStreamProps) {
               const { pubky, id } = parseCompositeId(compositeId);
               return <CollectionCard key={compositeId} authorPubky={pubky} postId={id} />;
             })}
+        <NewCollectionCardCTA />
       </Container>
 
       {showShowMore && (

--- a/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.test.tsx
+++ b/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NewCollectionCardCTA } from './NewCollectionCardCTA';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace?: string) => (key: string) => `${namespace ?? ''}.${key}`,
+}));
+
+vi.mock('@/controllers/post/post', () => ({
+  PostController: {
+    commitCreateCollection: vi.fn(),
+  },
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/stores/auth/auth.store', () => ({
+  useAuthStore: (selector: (state: { currentUserPubky: string }) => unknown) =>
+    selector({ currentUserPubky: 'current-user' }),
+}));
+
+describe('NewCollectionCardCTA', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the new collection trigger', () => {
+    render(<NewCollectionCardCTA />);
+
+    const trigger = screen.getByRole('button', { name: 'collections.new.cta' });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('data-cy', 'new-collection-card-cta');
+  });
+
+  it('opens the new collection dialog when the trigger is clicked', () => {
+    render(<NewCollectionCardCTA />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'collections.new.cta' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'collections.new.title' })).toBeInTheDocument();
+  });
+});
+
+describe('NewCollectionCardCTA - Snapshots', () => {
+  it('matches the closed trigger snapshot', () => {
+    const { container } = render(<NewCollectionCardCTA />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.test.tsx.snap
+++ b/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.test.tsx.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NewCollectionCardCTA - Snapshots > matches the closed trigger snapshot 1`] = `
+<div
+  class="block h-full w-full lg:max-w-187"
+  data-testid="container"
+>
+  <button
+    aria-controls="radix-normalized"
+    aria-expanded="false"
+    aria-haspopup="dialog"
+    aria-label="collections.new.cta"
+    class="flex h-full w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none"
+    data-as-child="true"
+    data-cy="new-collection-card-cta"
+    data-slot="dialog-trigger"
+    data-state="closed"
+    data-testid="dialog-trigger"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-plus size-3 shrink-0"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5 12h14"
+      />
+      <path
+        d="M12 5v14"
+      />
+    </svg>
+    <span
+      class="text-sm font-bold"
+      data-testid="typography"
+    >
+      collections.new.cta
+    </span>
+  </button>
+</div>
+`;

--- a/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.tsx
+++ b/src/components/organisms/Collections/NewCollectionCardCTA/NewCollectionCardCTA.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from 'react';
+import { Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/atoms/Button/Button';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { cn } from '@/libs/utils/utils';
+import {
+  GRID_DASHED_CTA_TRIGGER_CLASS,
+  GRID_DASHED_CTA_WRAPPER_CLASS,
+} from '@/organisms/Collections/gridDashedCta.const';
+import { NewCollectionDialog } from '@/organisms/NewCollectionDialog/NewCollectionDialog';
+
+const NewCollectionCardCTATrigger = forwardRef<ComponentRef<typeof Button>, ComponentPropsWithoutRef<typeof Button>>(
+  function NewCollectionCardCTATrigger({ className, ...props }, ref) {
+    const t = useTranslations('collections.new');
+
+    return (
+      <Button
+        ref={ref}
+        overrideDefaults
+        type="button"
+        aria-label={t('cta')}
+        data-cy="new-collection-card-cta"
+        className={cn(GRID_DASHED_CTA_TRIGGER_CLASS, className)}
+        {...props}
+      >
+        <Plus className="size-3 shrink-0" />
+        <Typography as="span" overrideDefaults className="text-sm font-bold">
+          {t('cta')}
+        </Typography>
+      </Button>
+    );
+  },
+);
+
+/**
+ * Large dashed-outline CTA for the Collections overview grid. Uses the same
+ * `h-full` grid stretch pattern as `CollectionCard` / `CollectionBookmarkCard`:
+ * grows to match a taller sibling in the same row, but never imposes a min-height
+ * that would force compact neighbours to expand.
+ */
+export function NewCollectionCardCTA() {
+  return (
+    <Container overrideDefaults className={cn(GRID_DASHED_CTA_WRAPPER_CLASS, 'lg:max-w-187')}>
+      <NewCollectionDialog>
+        <NewCollectionCardCTATrigger />
+      </NewCollectionDialog>
+    </Container>
+  );
+}

--- a/src/components/organisms/Collections/gridDashedCta.const.ts
+++ b/src/components/organisms/Collections/gridDashedCta.const.ts
@@ -1,0 +1,10 @@
+/**
+ * Dashed-outline grid CTA tile styling shared by collection grid CTAs (e.g.
+ * `NewCollectionCardCTA`, Add Content grid trigger). Uses `h-full` grid stretch:
+ * grows to match a taller sibling in the same row, never imposes a min-height on
+ * neighbours.
+ */
+export const GRID_DASHED_CTA_TRIGGER_CLASS =
+  'flex h-full w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-input p-6 text-foreground transition-colors outline-none hover:border-foreground focus:outline-none focus-visible:ring-0 focus-visible:outline-none';
+
+export const GRID_DASHED_CTA_WRAPPER_CLASS = 'block h-full w-full';

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -32,14 +32,20 @@ export { useTimelineFeedContext } from './TimelineFeedContext';
  * Organism that encapsulates stream calculation and pagination logic.
  * Routes to variant-specific wrappers so each only subscribes to its own data sources.
  */
-export function TimelineFeed({ variant, children, emptyState, pullToRefreshContainerRef }: TimelineFeedProps) {
+export function TimelineFeed(props: TimelineFeedProps) {
+  const { variant, children } = props;
+
   switch (variant) {
     case TIMELINE_FEED_VARIANT.HOME:
       return <HomeTimelineFeed>{children}</HomeTimelineFeed>;
     case TIMELINE_FEED_VARIANT.CUSTOM:
       return <CustomTimelineFeed>{children}</CustomTimelineFeed>;
     case TIMELINE_FEED_VARIANT.BOOKMARKS:
-      return <BookmarksTimelineFeed emptyState={emptyState}>{children}</BookmarksTimelineFeed>;
+      return (
+        <BookmarksTimelineFeed emptyState={props.emptyState} gridTrailingSlot={props.gridTrailingSlot}>
+          {children}
+        </BookmarksTimelineFeed>
+      );
     case TIMELINE_FEED_VARIANT.PROFILE:
       return <ProfileTimelineFeed>{children}</ProfileTimelineFeed>;
     case TIMELINE_FEED_VARIANT.PROFILE_COLLECTIONS:
@@ -50,7 +56,11 @@ export function TimelineFeed({ variant, children, emptyState, pullToRefreshConta
       return <SearchTimelineFeed>{children}</SearchTimelineFeed>;
     case TIMELINE_FEED_VARIANT.COLLECTION:
       return (
-        <CollectionTimelineFeed emptyState={emptyState} pullToRefreshContainerRef={pullToRefreshContainerRef}>
+        <CollectionTimelineFeed
+          emptyState={props.emptyState}
+          pullToRefreshContainerRef={props.pullToRefreshContainerRef}
+          gridTrailingSlot={props.gridTrailingSlot}
+        >
           {children}
         </CollectionTimelineFeed>
       );
@@ -103,9 +113,14 @@ function CustomTimelineFeed({ children }: { children?: TimelineFeedProps['childr
 function BookmarksTimelineFeed({
   children,
   emptyState,
+  gridTrailingSlot,
 }: {
   children?: TimelineFeedProps['children'];
-  emptyState?: TimelineFeedProps['emptyState'];
+  emptyState?: Extract<TimelineFeedProps, { variant: typeof TIMELINE_FEED_VARIANT.BOOKMARKS }>['emptyState'];
+  gridTrailingSlot?: Extract<
+    TimelineFeedProps,
+    { variant: typeof TIMELINE_FEED_VARIANT.BOOKMARKS }
+  >['gridTrailingSlot'];
 }) {
   const content = useHomeStore((state) => state.content);
   const layoutResolution = useFeedLayoutResolution(TIMELINE_FEED_VARIANT.BOOKMARKS);
@@ -125,6 +140,7 @@ function BookmarksTimelineFeed({
       tagsLayout={tagsLayout}
       layoutResolution={layoutResolution}
       emptyState={emptyState}
+      gridTrailingSlot={gridTrailingSlot}
     >
       {children}
     </TimelineFeedWithStream>
@@ -171,10 +187,18 @@ function CollectionTimelineFeed({
   children,
   emptyState,
   pullToRefreshContainerRef,
+  gridTrailingSlot,
 }: {
   children?: TimelineFeedProps['children'];
-  emptyState?: TimelineFeedProps['emptyState'];
-  pullToRefreshContainerRef?: TimelineFeedProps['pullToRefreshContainerRef'];
+  emptyState?: Extract<TimelineFeedProps, { variant: typeof TIMELINE_FEED_VARIANT.COLLECTION }>['emptyState'];
+  pullToRefreshContainerRef?: Extract<
+    TimelineFeedProps,
+    { variant: typeof TIMELINE_FEED_VARIANT.COLLECTION }
+  >['pullToRefreshContainerRef'];
+  gridTrailingSlot?: Extract<
+    TimelineFeedProps,
+    { variant: typeof TIMELINE_FEED_VARIANT.COLLECTION }
+  >['gridTrailingSlot'];
 }) {
   // The single-collection route owns these params (`/collections/[userId]/[postId]`).
   // Reading them here mirrors how `ProfileTimelineFeed` resolves its stream from context.
@@ -194,6 +218,7 @@ function CollectionTimelineFeed({
       emptyState={emptyState}
       collectionId={collectionId}
       pullToRefreshContainerRef={pullToRefreshContainerRef}
+      gridTrailingSlot={gridTrailingSlot}
     >
       {children}
     </TimelineFeedWithStream>

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.types.ts
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.types.ts
@@ -28,6 +28,10 @@ type BookmarksTimelineFeedProps = TimelineFeedPropsBase & {
    * Empty state for finite collection-like feeds.
    */
   emptyState?: ReactNode;
+  /**
+   * Last grid cell on the bookmarks feed (Add Content CTA for the signed-in user).
+   */
+  gridTrailingSlot?: ReactNode;
   pullToRefreshContainerRef?: never;
 };
 
@@ -37,6 +41,10 @@ type CollectionTimelineFeedProps = TimelineFeedPropsBase & {
    * Empty state for finite collection-like feeds.
    */
   emptyState?: ReactNode;
+  /**
+   * Last grid cell on the collection feed (owner-only Add Content CTA).
+   */
+  gridTrailingSlot?: ReactNode;
   /**
    * Optional element that should own pull-to-refresh touch events. Defaults to
    * the feed container.

--- a/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.test.tsx
@@ -110,14 +110,21 @@ vi.mock('@/organisms/Timeline/Posts/GridPosts/GridPosts', () => {
       postIds,
       showEndMessage,
       emptyState,
+      trailingSlot,
     }: {
       postIds: string[];
       showEndMessage?: boolean;
       emptyState?: ReactNode;
+      trailingSlot?: ReactNode;
     }) => (
-      <div data-testid="timeline-grid-posts" data-show-end-message={String(showEndMessage)}>
+      <div
+        data-testid="timeline-grid-posts"
+        data-show-end-message={String(showEndMessage)}
+        data-has-trailing-slot={String(Boolean(trailingSlot))}
+      >
         <span data-testid="grid-post-count">{postIds.length}</span>
         {postIds.length === 0 ? emptyState : null}
+        {trailingSlot}
       </div>
     ),
   };
@@ -581,6 +588,21 @@ describe('Grid layout variants (decisions D5/D7)', () => {
     );
 
     expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+  });
+
+  it('forwards gridTrailingSlot to the grid renderer', () => {
+    render(
+      <TimelineFeedWithStream
+        streamId={COLLECTION_STREAM_ID}
+        variant={TIMELINE_FEED_VARIANT.COLLECTION}
+        tagsLayout="inline"
+        layoutResolution={gridLayoutResolution}
+        gridTrailingSlot={<div data-testid="grid-trailing-slot">Add content</div>}
+      />,
+    );
+
+    expect(screen.getByTestId('timeline-grid-posts')).toHaveAttribute('data-has-trailing-slot', 'true');
+    expect(screen.getByTestId('grid-trailing-slot')).toBeInTheDocument();
   });
 
   it('renders the bookmarks variant in the grid and suppresses the end-of-feed message', () => {

--- a/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
@@ -20,6 +20,11 @@ import type { TimelineFeedContextValue, TimelineFeedProps } from '../TimelineFee
 import { TimelineFeedContext } from '../TimelineFeed/TimelineFeedContext';
 import { VisualTimelinePosts } from '../TimelineFeed/VisualTimelinePosts';
 
+type TimelineFeedGridTrailingSlot = Extract<
+  TimelineFeedProps,
+  { variant: typeof TIMELINE_FEED_VARIANT.BOOKMARKS | typeof TIMELINE_FEED_VARIANT.COLLECTION }
+>['gridTrailingSlot'];
+
 interface TimelineFeedContentProps {
   streamId: PostStreamId;
   variant: TimelineFeedProps['variant'];
@@ -29,6 +34,7 @@ interface TimelineFeedContentProps {
   emptyState?: TimelineFeedProps['emptyState'];
   collectionId?: TimelineFeedContextValue['collectionId'];
   pullToRefreshContainerRef?: TimelineFeedProps['pullToRefreshContainerRef'];
+  gridTrailingSlot?: TimelineFeedGridTrailingSlot;
 }
 
 interface TimelineFeedWithStreamProps {
@@ -40,6 +46,7 @@ interface TimelineFeedWithStreamProps {
   emptyState?: TimelineFeedProps['emptyState'];
   collectionId?: TimelineFeedContextValue['collectionId'];
   pullToRefreshContainerRef?: TimelineFeedProps['pullToRefreshContainerRef'];
+  gridTrailingSlot?: TimelineFeedGridTrailingSlot;
 }
 
 /**
@@ -57,6 +64,7 @@ export function TimelineFeedWithStream({
   emptyState,
   collectionId,
   pullToRefreshContainerRef,
+  gridTrailingSlot,
 }: TimelineFeedWithStreamProps) {
   if (!streamId) {
     return <TimelineLoading />;
@@ -71,6 +79,7 @@ export function TimelineFeedWithStream({
       emptyState={emptyState}
       collectionId={collectionId}
       pullToRefreshContainerRef={pullToRefreshContainerRef}
+      gridTrailingSlot={gridTrailingSlot}
     >
       {children}
     </TimelineFeedContent>
@@ -99,6 +108,7 @@ function TimelineFeedContent({
   emptyState,
   collectionId,
   pullToRefreshContainerRef,
+  gridTrailingSlot,
 }: TimelineFeedContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const refreshContainerRef = pullToRefreshContainerRef ?? containerRef;
@@ -204,6 +214,7 @@ function TimelineFeedContent({
               loadMore={loadMore}
               showEndMessage={showGridEndMessage}
               emptyState={emptyState}
+              trailingSlot={gridTrailingSlot}
             />
           ) : isVisualActive ? (
             <VisualTimelinePosts

--- a/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TimelineFeedHeaderSlot } from './TimelineFeedHeaderSlot';
+
+describe('TimelineFeedHeaderSlot', () => {
+  it('renders children inside a spaced container slot', () => {
+    render(
+      <TimelineFeedHeaderSlot>
+        <div data-testid="feed-header">Header</div>
+      </TimelineFeedHeaderSlot>,
+    );
+
+    const slot = screen.getByTestId('feed-header').closest('[data-testid="container"]');
+    expect(slot).toBeInTheDocument();
+    expect(slot).toHaveClass('mb-6');
+    expect(screen.getByTestId('feed-header')).toBeInTheDocument();
+  });
+});
+
+describe('TimelineFeedHeaderSlot - Snapshots', () => {
+  it('matches the snapshot with header children', () => {
+    const { container } = render(
+      <TimelineFeedHeaderSlot>
+        <div>Bookmarks hero</div>
+      </TimelineFeedHeaderSlot>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.test.tsx.snap
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.test.tsx.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TimelineFeedHeaderSlot - Snapshots > matches the snapshot with header children 1`] = `
+<div
+  class="mb-6"
+  data-testid="container"
+>
+  <div>
+    Bookmarks hero
+  </div>
+</div>
+`;

--- a/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedHeaderSlot/TimelineFeedHeaderSlot.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { Container } from '@/atoms/Container/Container';
+
+/**
+ * Spacing slot for hero/header content rendered as a direct child of `TimelineFeed`.
+ * Keeps a consistent gap between the header region and the feed grid below.
+ */
+export function TimelineFeedHeaderSlot({ children }: { children: ReactNode }) {
+  return (
+    <Container overrideDefaults className="mb-6">
+      {children}
+    </Container>
+  );
+}

--- a/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.test.tsx
+++ b/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.test.tsx
@@ -174,6 +174,46 @@ describe('TimelineGridPosts', () => {
       });
     });
 
+    it('should render the trailing slot when the feed is empty', async () => {
+      render(
+        <TimelineGridPosts
+          postIds={[]}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={false}
+          loadMore={vi.fn()}
+          trailingSlot={<div data-testid="grid-trailing-slot">Add content</div>}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('grid-trailing-slot')).toBeInTheDocument();
+        expect(screen.queryByTestId('timeline-empty')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should render the empty state above the trailing slot when there are no posts', async () => {
+      render(
+        <TimelineGridPosts
+          postIds={[]}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={false}
+          loadMore={vi.fn()}
+          emptyState={<div data-testid="custom-empty">Collection is empty</div>}
+          trailingSlot={<div data-testid="grid-trailing-slot">Add content</div>}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+        expect(screen.getByTestId('grid-trailing-slot')).toBeInTheDocument();
+        expect(screen.queryByTestId('timeline-empty')).not.toBeInTheDocument();
+      });
+    });
+
     it('should render end message when no more posts to load', async () => {
       render(
         <TimelineGridPosts
@@ -274,6 +314,27 @@ describe('TimelineGridPosts', () => {
         mockPostIds.forEach((postId) => {
           expect(screen.getByTestId(`post-${postId}`)).toBeInTheDocument();
         });
+      });
+
+      const postContainers = screen.getAllByTestId(/^post-/);
+      expect(postContainers).toHaveLength(mockPostIds.length);
+    });
+
+    it('should render the trailing slot as the last grid cell', async () => {
+      render(
+        <TimelineGridPosts
+          postIds={mockPostIds}
+          loading={false}
+          loadingMore={false}
+          error={null}
+          hasMore={true}
+          loadMore={vi.fn()}
+          trailingSlot={<div data-testid="grid-trailing-slot">Add content</div>}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('grid-trailing-slot')).toBeInTheDocument();
       });
 
       const postContainers = screen.getAllByTestId(/^post-/);

--- a/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.tsx
+++ b/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.tsx
@@ -29,6 +29,12 @@ interface TimelineGridPostsProps {
    */
   showEndMessage?: boolean;
   emptyState?: ReactNode;
+  /**
+   * Optional last grid cell (e.g. Add Content CTA on bookmarks/collection feeds).
+   * Rendered after post cards inside the same grid. The cell uses `h-full` so the
+   * tile stretches to a taller sibling in the row without imposing min-height.
+   */
+  trailingSlot?: ReactNode;
 }
 
 /**
@@ -47,7 +53,14 @@ interface TimelineGridPostsProps {
  * so the Phase C grid-scoped container-query overrides can adapt the card to the
  * narrow cell width. Because a container query with no ancestor container resolves
  * to `false`, those overrides are inert on every non-grid surface (decision D4).
+ *
+ * When `trailingSlot` is set, it becomes the last grid cell after all posts.
+ * When there are no posts but a trailing slot is present, `emptyState` is still
+ * rendered above the grid so the user sees both the empty copy and the CTA tile.
  */
+const GRID_TRAILING_CELL_CLASS =
+  '@container/grid block h-full w-full rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring [&>*:first-child]:flex-1';
+
 export function TimelineGridPosts({
   postIds,
   loading,
@@ -57,6 +70,7 @@ export function TimelineGridPosts({
   loadMore,
   showEndMessage = true,
   emptyState,
+  trailingSlot,
 }: TimelineGridPostsProps) {
   const { sentinelRef } = useInfiniteScroll({
     onLoadMore: loadMore,
@@ -68,16 +82,23 @@ export function TimelineGridPosts({
 
   const { handlePostKeyDown } = usePostNavigation();
   const { setCardRef, onListKeyDown } = usePostListKeyboard();
+  const hasGridContent = postIds.length > 0 || trailingSlot != null;
+  const showEmptyMessageWithTrailingSlot = postIds.length === 0 && trailingSlot != null && emptyState != null;
 
   return (
     <TimelineStateWrapper
       loading={loading}
       error={error}
-      hasItems={postIds.length > 0}
+      hasItems={hasGridContent}
       loadingComponent={<GridPostsSkeleton />}
       emptyComponent={emptyState}
     >
-      <Container data-cy="timeline-container">
+      <Container
+        data-cy="timeline-container"
+        overrideDefaults={showEmptyMessageWithTrailingSlot}
+        className={showEmptyMessageWithTrailingSlot ? 'flex w-full flex-col gap-6' : undefined}
+      >
+        {showEmptyMessageWithTrailingSlot ? emptyState : null}
         <Container
           data-cy="timeline-posts-grid"
           overrideDefaults
@@ -100,6 +121,11 @@ export function TimelineGridPosts({
               <PostMain postId={postId} isReply={false} />
             </Container>
           ))}
+          {trailingSlot != null ? (
+            <Container overrideDefaults className={GRID_TRAILING_CELL_CLASS}>
+              {trailingSlot}
+            </Container>
+          ) : null}
         </Container>
 
         {loadingMore && <TimelineLoadingMore />}

--- a/src/components/templates/BookmarksCollection/BookmarksCollection.test.tsx
+++ b/src/components/templates/BookmarksCollection/BookmarksCollection.test.tsx
@@ -34,7 +34,11 @@ vi.mock('@/organisms/Bookmarks/BookmarksHero/BookmarksHero', () => ({
 }));
 
 vi.mock('@/organisms/Bookmarks/BookmarksItems/BookmarksItems', () => ({
-  BookmarksItems: () => <div data-testid="bookmarks-items" />,
+  BookmarksItems: ({ header }: { header: ReactNode }) => (
+    <div data-testid="bookmarks-items">
+      <div data-testid="bookmarks-items-header">{header}</div>
+    </div>
+  ),
 }));
 
 vi.mock('@/organisms/Collections/CollectionsSections/CollectionsSections', () => ({
@@ -88,9 +92,27 @@ describe('BookmarksCollection', () => {
     expect(screen.getByTestId('content-layout')).toHaveAttribute('data-show-right-sidebar', 'false');
     expect(screen.getByTestId('content-layout')).toHaveAttribute('data-show-left-mobile-button', 'false');
     expect(screen.getByTestId('content-layout')).toHaveAttribute('data-show-right-mobile-button', 'false');
-    expect(screen.getByTestId('bookmarks-hero')).toHaveAttribute('data-bookmark-count', '4');
     expect(screen.getByTestId('bookmarks-items')).toBeInTheDocument();
     expect(screen.getByTestId('collections-sections')).toBeInTheDocument();
+  });
+
+  it('passes a BookmarksHero with summary props as the BookmarksItems header', () => {
+    mockUseBookmarksCollectionSummary.mockReturnValue({
+      avatarName: 'Alice',
+      avatarSeed: 'alice-pubky',
+      avatarUrl: 'https://example.com/avatar.png',
+      bookmarkCount: 4,
+      isProfileResolved: true,
+    });
+
+    render(<BookmarksCollection />);
+
+    const hero = screen.getByTestId('bookmarks-hero');
+    expect(hero).toHaveAttribute('data-avatar-name', 'Alice');
+    expect(hero).toHaveAttribute('data-avatar-seed', 'alice-pubky');
+    expect(hero).toHaveAttribute('data-avatar-url', 'https://example.com/avatar.png');
+    expect(hero).toHaveAttribute('data-bookmark-count', '4');
+    expect(hero).toHaveAttribute('data-is-profile-resolved', 'true');
   });
 });
 

--- a/src/components/templates/BookmarksCollection/BookmarksCollection.test.tsx.snap
+++ b/src/components/templates/BookmarksCollection/BookmarksCollection.test.tsx.snap
@@ -14,16 +14,21 @@ exports[`BookmarksCollection - Snapshots > matches the snapshot for the resolved
     data-testid="container"
   >
     <div
-      data-avatar-name="Alice"
-      data-avatar-seed="alice-pubky"
-      data-avatar-url="https://example.com/avatar.png"
-      data-bookmark-count="4"
-      data-is-profile-resolved="true"
-      data-testid="bookmarks-hero"
-    />
-    <div
       data-testid="bookmarks-items"
-    />
+    >
+      <div
+        data-testid="bookmarks-items-header"
+      >
+        <div
+          data-avatar-name="Alice"
+          data-avatar-seed="alice-pubky"
+          data-avatar-url="https://example.com/avatar.png"
+          data-bookmark-count="4"
+          data-is-profile-resolved="true"
+          data-testid="bookmarks-hero"
+        />
+      </div>
+    </div>
     <div
       data-testid="collections-sections"
     />

--- a/src/components/templates/BookmarksCollection/BookmarksCollection.tsx
+++ b/src/components/templates/BookmarksCollection/BookmarksCollection.tsx
@@ -19,14 +19,17 @@ export function BookmarksCollection() {
       className="pb-24 lg:pb-12 xl:px-0!"
     >
       <Container className="gap-12">
-        <BookmarksHero
-          avatarName={avatarName}
-          avatarSeed={avatarSeed}
-          avatarUrl={avatarUrl}
-          bookmarkCount={bookmarkCount}
-          isProfileResolved={isProfileResolved}
+        <BookmarksItems
+          header={
+            <BookmarksHero
+              avatarName={avatarName}
+              avatarSeed={avatarSeed}
+              avatarUrl={avatarUrl}
+              bookmarkCount={bookmarkCount}
+              isProfileResolved={isProfileResolved}
+            />
+          }
         />
-        <BookmarksItems />
         <CollectionsSections />
       </Container>
     </ContentLayout>

--- a/src/components/templates/Collection/Collection.test.tsx
+++ b/src/components/templates/Collection/Collection.test.tsx
@@ -14,22 +14,18 @@ vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
   usePostDetails: vi.fn(),
 }));
 
-vi.mock('@/organisms/Collections/CollectionHero/CollectionHero', () => ({
-  CollectionHero: (p: { authorPubky: string; postId: string }) => (
-    <div data-testid="collection-hero" data-author={p.authorPubky} data-post={p.postId} />
-  ),
-}));
-
 vi.mock('@/organisms/Collections/CollectionItems/CollectionItems', () => ({
   CollectionItems: (p: {
     authorPubky: string;
     postId: string;
+    postDetails?: unknown;
     pullToRefreshContainerRef?: RefObject<HTMLElement | null>;
   }) => (
     <div
       data-testid="collection-items"
       data-author={p.authorPubky}
       data-post={p.postId}
+      data-has-post-details={String(p.postDetails != null)}
       data-has-ptr-ref={String(Boolean(p.pullToRefreshContainerRef))}
     />
   ),
@@ -92,17 +88,15 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Collection (template)', () => {
-  it('renders the resolved hero + items + sections for a valid collection envelope', () => {
+  it('renders the resolved items region + sections for a valid collection envelope', () => {
     setPostDetails(COLLECTION_CONTENT, false);
 
     render(<Collection postId={COMPOSITE} />);
 
-    const hero = screen.getByTestId('collection-hero');
     const items = screen.getByTestId('collection-items');
-    expect(hero).toHaveAttribute('data-author', AUTHOR_PUBKY);
-    expect(hero).toHaveAttribute('data-post', POST_ID);
     expect(items).toHaveAttribute('data-author', AUTHOR_PUBKY);
     expect(items).toHaveAttribute('data-post', POST_ID);
+    expect(items).toHaveAttribute('data-has-post-details', 'true');
     expect(items).toHaveAttribute('data-has-ptr-ref', 'true');
     expect(screen.getByTestId('collections-sections')).toBeInTheDocument();
     expect(screen.queryByTestId('collection-not-found')).not.toBeInTheDocument();
@@ -113,12 +107,12 @@ describe('Collection (template)', () => {
 
     render(<Collection postId={COMPOSITE} />);
 
-    expect(screen.getByTestId('collection-hero')).toBeInTheDocument();
-    expect(screen.getByTestId('collection-items')).toBeInTheDocument();
+    const items = screen.getByTestId('collection-items');
+    expect(items).toHaveAttribute('data-has-post-details', 'false');
     expect(screen.queryByTestId('collection-not-found')).not.toBeInTheDocument();
   });
 
-  it('renders the not-found state (with sections, without hero) when the post is missing', () => {
+  it('renders the not-found state (with sections, without items) when the post is missing', () => {
     setPostDetails(null, false);
 
     render(<Collection postId={COMPOSITE} />);
@@ -126,7 +120,6 @@ describe('Collection (template)', () => {
     const notFound = screen.getByTestId('collection-not-found');
     expect(notFound).toHaveAttribute('data-post', COMPOSITE);
     expect(screen.getByTestId('collections-sections')).toBeInTheDocument();
-    expect(screen.queryByTestId('collection-hero')).not.toBeInTheDocument();
     expect(screen.queryByTestId('collection-items')).not.toBeInTheDocument();
   });
 
@@ -136,7 +129,7 @@ describe('Collection (template)', () => {
     render(<Collection postId={COMPOSITE} />);
 
     expect(screen.getByTestId('collection-not-found')).toBeInTheDocument();
-    expect(screen.queryByTestId('collection-hero')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('collection-items')).not.toBeInTheDocument();
   });
 
   it('treats an invalid composite as not found and disables the post details query', () => {
@@ -145,7 +138,7 @@ describe('Collection (template)', () => {
     render(<Collection postId="garbage" />);
 
     expect(screen.getByTestId('collection-not-found')).toBeInTheDocument();
-    expect(screen.queryByTestId('collection-hero')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('collection-items')).not.toBeInTheDocument();
     expect(mockUsePostDetails).toHaveBeenCalledWith('garbage', { enabled: false });
   });
 

--- a/src/components/templates/Collection/Collection.test.tsx.snap
+++ b/src/components/templates/Collection/Collection.test.tsx.snap
@@ -14,11 +14,7 @@ exports[`Collection (template) > matches the snapshot for the resolved collectio
     >
       <div
         data-author="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
-        data-post="0034BBBDFK83G"
-        data-testid="collection-hero"
-      />
-      <div
-        data-author="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
+        data-has-post-details="true"
         data-has-ptr-ref="true"
         data-post="0034BBBDFK83G"
         data-testid="collection-items"

--- a/src/components/templates/Collection/Collection.tsx
+++ b/src/components/templates/Collection/Collection.tsx
@@ -6,7 +6,6 @@ import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { isPostDeleted, isValidPostCompositeId } from '@/libs/utils/utils';
 import { parseCompositeId } from '@/models/models.utils';
-import { CollectionHero } from '@/organisms/Collections/CollectionHero/CollectionHero';
 import { CollectionItems } from '@/organisms/Collections/CollectionItems/CollectionItems';
 import { CollectionNotFound } from '@/organisms/Collections/CollectionNotFound/CollectionNotFound';
 import { CollectionsSections } from '@/organisms/Collections/CollectionsSections/CollectionsSections';
@@ -52,7 +51,11 @@ export function Collection({ postId }: CollectionProps) {
       className="pb-24 lg:pb-12 xl:px-0!"
     >
       <Container overrideDefaults className="flex w-full flex-col gap-12">
-        {collectionMissing ? <CollectionNotFound postId={postId} /> : <CollectionResolved postId={postId} />}
+        {collectionMissing ? (
+          <CollectionNotFound postId={postId} />
+        ) : (
+          <CollectionResolved postId={postId} postDetails={postDetails} />
+        )}
         <CollectionsSections />
       </Container>
     </ContentLayout>
@@ -64,16 +67,19 @@ export function Collection({ postId }: CollectionProps) {
  * composite id is valid, so `parseCompositeId` (which throws on malformed ids)
  * is safe here.
  */
-function CollectionResolved({ postId }: CollectionProps) {
+function CollectionResolved({
+  postId,
+  postDetails,
+}: CollectionProps & { postDetails: ReturnType<typeof usePostDetails>['postDetails'] }) {
   const pullToRefreshContainerRef = useRef<HTMLDivElement>(null);
   const { pubky: authorPubky, id: rawPostId } = parseCompositeId(postId);
 
   return (
     <Container ref={pullToRefreshContainerRef} overrideDefaults className="flex w-full flex-col gap-12">
-      <CollectionHero authorPubky={authorPubky} postId={rawPostId} />
       <CollectionItems
         authorPubky={authorPubky}
         postId={rawPostId}
+        postDetails={postDetails}
         pullToRefreshContainerRef={pullToRefreshContainerRef}
       />
     </Container>


### PR DESCRIPTION
## Summary

- Add a **Content** hero action on collection and bookmarks heroes (icon-only on mobile, labeled on desktop).
- Keep **Add Content** as a dashed trailing grid tile on bookmarks and owned collection feeds via new `gridTrailingSlot` → `trailingSlot` plumbing.
- Mount heroes inside `TimelineFeed` (`TimelineFeedHeaderSlot`) so `AddContentDialog` can call `prependOptimisticPosts` after paste/save.
- Add a dashed **New Collection** card CTA to the end of the My Collections overview grid.
- Refresh copy: hero label **Content**, grid label **Add Content**, dialog title **Content**.

## Why

Hero actions need feed context for optimistic inserts. Moving heroes into `TimelineFeed` preserves that while giving a primary CTA in the hero and a discoverable trailing tile in the grid (including empty collections).

## Test plan

- [ ] Owned collection: hero **Content** opens dialog; pasted URL prepends optimistically to grid.
- [ ] Owned collection: trailing grid **Add Content** tile works the same.
- [ ] Empty owned collection: empty copy + trailing grid CTA both visible.
- [ ] Bookmarks: hero + grid CTAs both work.
- [ ] My Collections: **New Collection** dashed card opens create dialog and matches row height.
- [ ] Collection delete in progress: hero Content disabled; verify grid CTA behavior (known gap if not fixed).
- [ ] Non-owner empty collection: hero + empty state only, no grid CTA.