### PR TITLE
fix: edge navigation clicks on collection card

### DIFF
--- a/src/components/molecules/EmojiPickerDialog/EmojiPickerDialog.test.tsx
+++ b/src/components/molecules/EmojiPickerDialog/EmojiPickerDialog.test.tsx
@@ -16,8 +16,16 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
         {open && children}
       </div>
     ),
-    DialogContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-      <div data-testid="dialog-content" className={className}>
+    DialogContent: ({
+      children,
+      className,
+      onClick,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      onClick?: (e: React.MouseEvent) => void;
+    }) => (
+      <div data-testid="dialog-content" className={className} onClick={onClick}>
         {children}
       </div>
     ),
@@ -126,6 +134,23 @@ describe('EmojiPickerDialog', () => {
       expect(mockOnEmojiSelect).toHaveBeenCalledWith({ native: '😊' });
       expect(mockOnOpenChange).toHaveBeenCalledWith(false);
     });
+  });
+
+  it('contains clicks within the dialog so they do not reach a clickable ancestor', () => {
+    // Regression: the dialog is portaled, but React events bubble up the React
+    // tree — without stopPropagation an emoji click reaches an ancestor (e.g. a
+    // collection card's Link) and triggers navigation.
+    const ancestorClick = vi.fn();
+    render(
+      <div onClick={ancestorClick}>
+        <EmojiPickerDialog open={true} onOpenChange={mockOnOpenChange} onEmojiSelect={mockOnEmojiSelect} />
+      </div>,
+    );
+
+    screen.getByTestId('test-emoji-select').click();
+
+    expect(mockOnEmojiSelect).toHaveBeenCalledWith({ native: '😊' });
+    expect(ancestorClick).not.toHaveBeenCalled();
   });
 
   it('renders with correct dialog classes', () => {

--- a/src/components/molecules/EmojiPickerDialog/EmojiPickerDialog.tsx
+++ b/src/components/molecules/EmojiPickerDialog/EmojiPickerDialog.tsx
@@ -30,6 +30,11 @@ export function EmojiPickerDialog({
         className="max-w-sm overflow-hidden p-0 outline-none sm:p-0"
         showCloseButton={false}
         hiddenTitle="Emoji Picker"
+        // The dialog is portaled to <body>, but React synthetic events still
+        // bubble up the React tree — so an emoji click would otherwise reach a
+        // clickable/linked ancestor (e.g. a collection card's `Link`) and
+        // trigger navigation. Stop clicks at the dialog content boundary.
+        onClick={(e) => e.stopPropagation()}
       >
         <DialogDescription className="sr-only">Select an emoji</DialogDescription>
         <Container overrideDefaults={true} className="flex justify-center overflow-hidden">

--- a/src/components/molecules/PostTag/PostTag.test.tsx
+++ b/src/components/molecules/PostTag/PostTag.test.tsx
@@ -23,6 +23,34 @@ describe('PostTag', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
+  it('suppresses navigation (preventDefault + stopPropagation) on click, while still calling onClick', () => {
+    const mockOnClick = vi.fn();
+    render(<PostTag label="bitcoin" onClick={mockOnClick} />);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(clickEvent, 'preventDefault');
+    const stopPropagation = vi.spyOn(clickEvent, 'stopPropagation');
+    screen.getByRole('button').dispatchEvent(clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses navigation on close, while still calling onClose', () => {
+    const mockOnClose = vi.fn();
+    render(<PostTag label="bitcoin" showClose onClose={mockOnClose} />);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(clickEvent, 'preventDefault');
+    const stopPropagation = vi.spyOn(clickEvent, 'stopPropagation');
+    screen.getByLabelText(/remove bitcoin tag/i).dispatchEvent(clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
   it('does not call onClick when close button is clicked', () => {
     const mockOnClick = vi.fn();
     const mockOnClose = vi.fn();

--- a/src/components/molecules/PostTag/PostTag.tsx
+++ b/src/components/molecules/PostTag/PostTag.tsx
@@ -18,7 +18,12 @@ export function PostTag({
 }: PostTagProps) {
   const tagColor = color || generateRandomColor(label);
   const backgroundGradient = `linear-gradient(90deg, ${hexToRgba(COLORS.background, 0.7)} 0%, ${hexToRgba(COLORS.background, 0.7)} 100%), linear-gradient(90deg, ${tagColor} 0%, ${tagColor} 100%)`;
+  // A tag chip's only jobs are toggle / close — never navigation. Suppressing
+  // both the native default and propagation lets it sit inside a clickable or
+  // linked surface (e.g. a collection card wrapped in a `Link`) without the
+  // click bubbling into navigation; harmless everywhere else.
   const handleClose = (e: React.MouseEvent) => {
+    e.preventDefault();
     e.stopPropagation();
     onClose?.(e);
   };
@@ -27,6 +32,7 @@ export function PostTag({
       {...rest}
       pressed={selected}
       onClick={(e) => {
+        e.preventDefault();
         e.stopPropagation();
         onClick?.(e);
       }}

--- a/src/components/molecules/PostTagAddButton/PostTagAddButton.test.tsx
+++ b/src/components/molecules/PostTagAddButton/PostTagAddButton.test.tsx
@@ -19,6 +19,20 @@ describe('PostTagAddButton', () => {
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
+  it('suppresses navigation (preventDefault + stopPropagation) on click, while still calling onClick', () => {
+    const mockOnClick = vi.fn();
+    render(<PostTagAddButton onClick={mockOnClick} />);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(clickEvent, 'preventDefault');
+    const stopPropagation = vi.spyOn(clickEvent, 'stopPropagation');
+    screen.getByRole('button').dispatchEvent(clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
   it('has correct aria-label', () => {
     render(<PostTagAddButton />);
 

--- a/src/components/molecules/PostTagAddButton/PostTagAddButton.tsx
+++ b/src/components/molecules/PostTagAddButton/PostTagAddButton.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Plus } from 'lucide-react';
 import { Button } from '@/atoms/Button/Button';
 import { cn } from '@/libs/utils/utils';
@@ -8,7 +7,14 @@ export function PostTagAddButton({ onClick, className, disabled, variant = 'dash
   return (
     <Button
       data-cy="post-tag-add-button"
-      onClick={onClick}
+      // Opening the tag input is the only intent — never navigation. Suppress
+      // the native default + propagation so the button works inside a clickable
+      // / linked surface (e.g. a collection card) without triggering it.
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick?.();
+      }}
       variant="outline"
       size="sm"
       disabled={disabled}

--- a/src/components/molecules/TagInput/TagInput.test.tsx
+++ b/src/components/molecules/TagInput/TagInput.test.tsx
@@ -57,6 +57,21 @@ describe('TagInput', () => {
     expect(screen.getByLabelText('Open emoji picker')).not.toHaveClass('shadow-xs-dark');
   });
 
+  it('suppresses navigation (preventDefault + stopPropagation) on container click, while still calling onClick', () => {
+    const mockOnClick = vi.fn();
+    const { container } = render(<TagInput onTagAdd={mockOnTagAdd} onClick={mockOnClick} />);
+    const tagInputContainer = container.querySelector('div.relative')!;
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(clickEvent, 'preventDefault');
+    const stopPropagation = vi.spyOn(clickEvent, 'stopPropagation');
+    tagInputContainer.dispatchEvent(clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
   it('calls onTagAdd when Enter is pressed with valid tag', async () => {
     render(<TagInput onTagAdd={mockOnTagAdd} />);
     const input = screen.getByPlaceholderText('add tag') as HTMLInputElement;

--- a/src/components/molecules/TagInput/TagInput.tsx
+++ b/src/components/molecules/TagInput/TagInput.tsx
@@ -164,7 +164,16 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
               isAtLimit && 'w-40',
             )}
             style={style}
-            onClick={onClick}
+            // Adding / typing a tag is the only intent here — never navigation.
+            // Suppress the native default + propagation (focus still happens on
+            // mousedown, so this is safe) so the input works inside a clickable /
+            // linked surface without bubbling into navigation. `cursor-pointer`
+            // stays keyed on the caller `onClick` so standalone styling is intact.
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onClick?.(e);
+            }}
           >
             <Input
               data-cy="add-tag-input"
@@ -247,6 +256,11 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
             onCloseAutoFocus={(e) => e.preventDefault()}
             onFocusOutside={(e) => e.preventDefault()}
             onInteractOutside={(e) => e.preventDefault()}
+            // Portaled to <body>, but React events bubble up the React tree, so
+            // a suggestion click would otherwise reach a clickable/linked
+            // ancestor (e.g. a collection card's `Link`) and navigate. Keep
+            // clicks contained to the dropdown.
+            onClick={(e) => e.stopPropagation()}
           >
             <TagSuggestionsDropdown
               suggestions={displaySuggestions}

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -296,10 +296,13 @@ function CollectionCardContent({
             {!isPreview && (
               <Container
                 overrideDefaults
-                onClick={suppressCardNavigation}
-                onAuxClick={suppressCardNavigation}
                 className="flex w-full flex-wrap items-center justify-between gap-3 sm:flex-nowrap"
               >
+                {/* No suppression on this row (or the tag column): the tag chips,
+                  add button and input each suppress navigation themselves, so
+                  clicks in the gaps between chips — which wrap to several rows on
+                  narrow cards — fall through to the wrapping `Link` and navigate.
+                  That keeps the dead zone at zero. */}
                 <Container overrideDefaults className="min-w-0 flex-1">
                   <ClickableTagsList
                     taggedId={compositeId}
@@ -311,7 +314,16 @@ function CollectionCardContent({
                   />
                 </Container>
 
-                <Container overrideDefaults className="flex shrink-0 items-center gap-2">
+                {/* The action button suppresses navigation in its own `onClick`
+                  (see `handleFollowToggle` / `handleDelete`); this wrapper hugs
+                  the button (`shrink-0`) and adds `onAuxClick` so middle-clicks
+                  are caught too without widening the suppression surface. */}
+                <Container
+                  overrideDefaults
+                  onClick={suppressCardNavigation}
+                  onAuxClick={suppressCardNavigation}
+                  className="flex shrink-0 items-center gap-2"
+                >
                   {isOwn ? (
                     <Button
                       variant="secondary"


### PR DESCRIPTION
  # Fix collection card tag interactions: dead zone & accidental navigation 🎯

  ## Summary

  The collection card is wrapped in a `Link`, with the tags row and action button suppressing navigation via handlers on
  the **parent containers**. This caused two QA issues:

  1. **Dead zone** — clicks in the spacing *around* the tags/button (not directly on them) neither navigated nor triggered
  an action. On narrow/mobile cards where tags wrap to multiple rows, this dead area was large.
  2. **Accidental navigation** — opening the emoji picker from the tag input and selecting an emoji (or clicking the
  dialog overlay) navigated away from the card unexpectedly.

  This PR moves navigation suppression onto the interactive elements themselves and fixes the portal-related navigation
  leak.

  ## Changes

  ### 🧩 Dead zone — suppress at the leaf, not the wrapper

  Moved `preventDefault` + `stopPropagation` directly onto the interactive controls so clicks in the gaps between them
  fall through to the wrapping `Link` and navigate as expected:

  - `PostTag` — added `preventDefault` alongside the existing `stopPropagation` on both the chip click and the close
  button.
  - `PostTagAddButton` — its click now suppresses navigation before invoking the callback.
  - `TagInput` — same on the container click (focus still happens on `mousedown`, so typing/focus behaviour is unaffected;
  `cursor-pointer` styling stays keyed on the caller's `onClick`).
  - `CollectionCard` — removed the wide `onClick`/`onAuxClick` handlers from the full-width bottom row; the action button
  keeps its own suppression plus `onAuxClick` on its hugging wrapper.

  The result is **zero dead zone**: only the chips/button/input themselves swallow the click; everything between them
  navigates.

  ### 🪟 Accidental navigation from portaled overlays

  React synthetic events bubble through the **React tree**, not the DOM tree — so even though the emoji picker and
  tag-suggestions dropdown are portaled to `<body>`, a click inside them still bubbled up to the card's `Link` and
  triggered navigation.

  - `EmojiPickerDialog` — `stopPropagation` on `DialogContent` so emoji clicks stay contained (this also covers the
  overlay, which dismisses via the in-content close button).
  - `TagInput` — `stopPropagation` on the suggestions `PopoverContent`, which had the identical latent bug (clicking a
  suggestion would have navigated too).

  `preventDefault` is intentionally **not** added on these overlays: because they're portaled outside the anchor's DOM
  subtree, there is no native `<a>` navigation to prevent — the only path is the `Link`'s React `onClick`, which
  `stopPropagation` fully blocks.

  ## Why keep the `Link` (vs `router.push`)?

  Switching the card to an `onClick` + `router.push` would **not** remove the portal bubbling issue (a `router.push`
  handler is still a React ancestor that portaled content bubbles to), and it would sacrifice real anchor semantics —
  open-in-new-tab via cmd/middle-click, right-click "copy link", `role=link`, and keyboard activation. The `Link` is
  retained and suppression is handled at the interactive elements instead.

  ## Safety / audit 🔍

  Audited every usage of `PostTag`, `PostTagAddButton`, and `TagInput` across the app (search, notifications, article
  detail, composer, feed dialog, etc.). No usage relies on a tag chip / add button / input navigating via a native anchor
  — all navigation is done through `router.push` in handlers or callbacks, neither of which `preventDefault` affects. The
  change is therefore a defensive improvement, not a regression, and is safe to apply universally.

  ## Tests ✅

  - Added `preventDefault`/`stopPropagation` regression tests for `PostTag`, `PostTagAddButton`, and `TagInput`.
  - Added a regression test for `EmojiPickerDialog` verifying a click inside the dialog does **not** reach a clickable
  ancestor (while emoji selection still fires).
  - All affected suites pass; lint and typecheck clean.

  _This pull request summary was generated, for full implementation details please reference the file changes._