### PR TITLE
refactor: show deleted posts in collections and bookmarks

### DIFF
--- a/src/components/molecules/PostDeleted/PostDeleted.test.tsx.snap
+++ b/src/components/molecules/PostDeleted/PostDeleted.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostDeleted - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="py-2"
+  class="flex flex-1 items-center justify-center py-2"
   data-testid="card-content"
 >
   <p

--- a/src/components/molecules/PostDeleted/PostDeleted.tsx
+++ b/src/components/molecules/PostDeleted/PostDeleted.tsx
@@ -8,7 +8,7 @@ export const PostDeleted = () => {
   const t = useTranslations('post');
 
   return (
-    <CardContent className="py-2">
+    <CardContent className="flex flex-1 items-center justify-center py-2">
       <Typography size="sm" className="text-center font-normal text-muted-foreground">
         {t('deleted')}
       </Typography>

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -293,6 +293,74 @@ describe('PostStreamApplication', () => {
 
       expect(result).toEqual([missingPostId]);
     });
+
+    const createDeletedPostDetail = async (postId: string) => {
+      await PostDetailsModel.create({
+        id: postId,
+        content: DELETED,
+        kind: 'short',
+        indexed_at: BASE_TIMESTAMP,
+        uri: `https://pubky.app/${DEFAULT_AUTHOR}/pub/pubky.app/posts/${postId}`,
+        attachments: null,
+      });
+    };
+
+    it('removes deleted posts from timeline streams', async () => {
+      const livePostId = `${DEFAULT_AUTHOR}:live-post`;
+      const deletedPostId = `${DEFAULT_AUTHOR}:deleted-post`;
+      await createPostDetailWithKind(livePostId, 'short');
+      await createDeletedPostDetail(deletedPostId);
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: PostStreamTypes.TIMELINE_ALL_ALL,
+        postIds: [livePostId, deletedPostId],
+      });
+
+      expect(result).toEqual([livePostId]);
+    });
+
+    it('keeps deleted posts in bookmark streams so they render their deleted state', async () => {
+      const livePostId = `${DEFAULT_AUTHOR}:live-post`;
+      const deletedPostId = `${DEFAULT_AUTHOR}:deleted-post`;
+      await createPostDetailWithKind(livePostId, 'short');
+      await createDeletedPostDetail(deletedPostId);
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: PostStreamTypes.TIMELINE_BOOKMARKS_ALL,
+        postIds: [livePostId, deletedPostId],
+      });
+
+      expect(result).toEqual([livePostId, deletedPostId]);
+    });
+
+    it('removes deleted posts from the collection-kind bookmark stream (FollowedCollections seed)', async () => {
+      const livePostId = `${DEFAULT_AUTHOR}:live-post`;
+      const deletedPostId = `${DEFAULT_AUTHOR}:deleted-post`;
+      await createPostDetailWithKind(livePostId, 'collection');
+      await createDeletedPostDetail(deletedPostId);
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: PostStreamTypes.TIMELINE_BOOKMARKS_COLLECTION,
+        postIds: [livePostId, deletedPostId],
+      });
+
+      expect(result).toEqual([livePostId]);
+    });
+
+    it('keeps deleted posts in single-collection item streams', async () => {
+      const collectionItemsStreamId = `collection:${DEFAULT_AUTHOR}:my-collection` as PostStreamId;
+      const livePostId = `${DEFAULT_AUTHOR}:live-post`;
+      const deletedPostId = `${DEFAULT_AUTHOR}:deleted-post`;
+      await createPostDetailWithKind(livePostId, 'short');
+      await createDeletedPostDetail(deletedPostId);
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: collectionItemsStreamId,
+        postIds: [livePostId, deletedPostId],
+      });
+
+      expect(result).toEqual([livePostId, deletedPostId]);
+    });
   });
 
   describe('getOrFetchStreamSlice', () => {

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -22,6 +22,7 @@ import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import {
   isAuthorStreamSkippingMuteFilter,
+  isDeletedRetainingStream,
   isSkipPaginatedStream,
   type PostStreamId,
 } from '@/models/stream/post/postStream.types';
@@ -125,8 +126,12 @@ export class PostStreamApplication {
     streamId: PostStreamId;
     postIds: string[];
   }): Promise<string[]> {
-    const notDeletedPostIds = await LocalPostService.filterDeletedPosts(postIds);
-    return await this.filterCollectionsFromStream({ streamId, postIds: notDeletedPostIds });
+    // Bookmark and single-collection item feeds keep deleted posts so the post
+    // component can render its deleted-state placeholder; all other streams drop them.
+    const visiblePostIds = isDeletedRetainingStream(streamId)
+      ? postIds
+      : await LocalPostService.filterDeletedPosts(postIds);
+    return await this.filterCollectionsFromStream({ streamId, postIds: visiblePostIds });
   }
 
   /**

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -173,6 +173,24 @@ export function isCollectionItemsStream(streamId: string): streamId is Collectio
   return streamId.startsWith(`${StreamSource.COLLECTION}:`);
 }
 
+/**
+ * Single-collection item feeds (`collection:<author>:<postId>`) and the
+ * bookmarks post feeds (`<sorting>:bookmarks:<kind>`) intentionally keep deleted
+ * posts in the stream so the feed still renders the saved/collected slot with the
+ * post component's deleted-state placeholder, rather than silently dropping it.
+ * Every other stream filters deleted posts out entirely.
+ *
+ * The collection-kind bookmark stream (`<sorting>:bookmarks:collection`) is
+ * excluded: it is not a bookmarks post feed but the seed for the
+ * `FollowedCollections` section, which deliberately hides deleted collections
+ * (its live query filters them out). Keeping stream-level filtering here stays
+ * consistent with that, rather than surfacing deleted collections in that section.
+ */
+export function isDeletedRetainingStream(streamId: string): boolean {
+  if (isCollectionItemsStream(streamId)) return true;
+  return streamId.includes(`:${StreamSource.BOOKMARKS}:`) && !streamId.endsWith(`:${StreamKind.COLLECTION}`);
+}
+
 export type PostStreamId =
   | PostStreamTypes
   | ReplyStreamCompositeId


### PR DESCRIPTION
  # Show deleted posts in bookmark and collection feeds 🗑️

  ## Overview

  The **bookmarks feed** (`/collections/bookmarks`) and the **single-collection items feed**
  (`/collections/[userId]/[postId]`) were filtering deleted posts out on the client, but the bookmark and collection item
  **counts include deleted posts**. That left a mismatch between the count shown and what actually rendered in the feed
  (e.g. a count of 60 against 5 visible cards). The count cannot currently be made accurate on the backend, so rather than
  fight it, this PR aligns the feeds to the count: deleted items are kept in these two feeds and rendered with the
  existing deleted-post placeholder, so the number and the feed line up. It also tidies up how that placeholder sits
  inside a stretched grid cell.

  ## What changed

  ### 🔹 Retain deleted posts in bookmark & collection-item streams

  All post streams previously ran every page through a single deletion filter in
  `PostStreamApplication.filterStreamPosts`, which dropped any post whose content is `[DELETED]`. We now skip that filter
  for the two target stream shapes while every other feed (home, hot, search, profile, replies, discover, etc.) continues
  to filter deleted posts out as before.

  A new `isDeletedRetainingStream(streamId)` predicate centralizes this decision:

  - ✅ Single-collection item feeds — `collection:<author>:<postId>`
  - ✅ Bookmark post feeds — `<sorting>:bookmarks:<kind>` (all / short / long / image / video / link / file)
  - ❌ The collection-kind bookmark stream — `<sorting>:bookmarks:collection` — is **excluded**

  The `:bookmarks:collection` exclusion is important: that stream is not a bookmarks post feed, it is the seed for the
  **Followed Collections** section, which deliberately hides deleted collections via its own Dexie live query. Excluding
  it keeps stream-level behavior consistent with that section rather than surfacing deleted collections there.

  ### 🔹 Scope & safety notes

  - The visual (image/video) tile layout still filters deleted posts — a deleted post has no attachments, so it can't form
  a media tile; the deleted-state card only makes sense in the standard list/grid layout.
  - `FollowedCollections`, `MyCollections`, and `DiscoverCollections` are unaffected — they use different stream shapes
  and/or re-filter deleted items in their own live queries.
  - Write-side bookmark cache updates don't flow through the changed filter, so they're untouched.

  ### 🔹 Center the "deleted" placeholder vertically in grid cells

  In the collection/bookmark **grid**, each card stretches to the tallest card in its row, which left the short "This post
  has been deleted by its author." message pinned to the top with empty space below. `PostDeleted` now fills its parent
  card and centers the message vertically.

  Because the placeholder is a shared component, this was verified to be a no-op everywhere else it's used (single-post
  page, timeline list, nested post previews) — in those contexts the card is content-sized, so the fill-and-center has no
  extra space to act on and nothing visibly changes. The effect is naturally scoped to the stretched grid case, so no new
  prop or component was needed.

  ## Testing ✅

  - Added unit tests covering `filterStreamPosts`: deleted posts are **removed** from timeline streams and the
  collection-kind bookmark stream, and **retained** in bookmark post feeds and single-collection item streams.
  - Updated the `PostDeleted` snapshot for the new centering classes.
  - Full suite, typecheck, and lint all pass.

  _This pull request summary was generated, for full implementation details please reference the file changes._