### PR TITLE
Spike/2058 lock content zip bundle

### DIFF
--- a/src/hooks/usePostInput/usePostInput.ts
+++ b/src/hooks/usePostInput/usePostInput.ts
@@ -23,6 +23,7 @@ import { useMentionAutocomplete } from '@/hooks/useMentionAutocomplete/useMentio
 import { getContentWithMention } from '@/hooks/useMentionAutocomplete/useMentionAutocomplete.utils';
 import { usePost } from '@/hooks/usePost/usePost';
 import { useUserDetails } from '@/hooks/useUserDetails/useUserDetails';
+import { LOCK_BUNDLE_SPIKE_DEMO_ENABLED, runLockBundleSpikeDemo } from '@/libs/lockBundle/lockBundle.demo';
 import { useToast } from '@/molecules/Toaster/use-toast';
 import { POST_INPUT_VARIANT } from '@/organisms/PostInput/PostInput.constants';
 import { useTimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext';
@@ -228,6 +229,29 @@ export function usePostInput({
         break;
       case POST_INPUT_VARIANT.POST:
       default:
+        // TODO:[Locks] #2058 — spike demo intercepts POST: no network write. Runs the
+        // zip → decode round-trip in the console, then renders the decoded bundle as a
+        // real local post in the feed. Remove together with the spike.
+        if (LOCK_BUNDLE_SPIKE_DEMO_ENABLED) {
+          const draftContent = content;
+          const draftFiles = attachments;
+          const draftIsArticle = isArticle;
+          // Clear the composer immediately, like a normal submit.
+          setContent('');
+          setTags([]);
+          setAttachments([]);
+          setIsArticle(false);
+          setArticleTitle('');
+          setIsExpanded(false);
+          await runLockBundleSpikeDemo({
+            content: draftContent,
+            files: draftFiles,
+            isArticle: draftIsArticle,
+            authorId: currentUserPubky,
+            prependPost: (createdPostId) => timelineFeed?.prependPosts(createdPostId),
+          });
+          break;
+        }
         await post({ onSuccess: handleSuccess });
         break;
     }
@@ -249,6 +273,12 @@ export function usePostInput({
     onSuccess,
     timelineFeed,
     deletePost,
+    currentUserPubky,
+    setContent,
+    setTags,
+    setAttachments,
+    setIsArticle,
+    setArticleTitle,
   ]);
 
   // Handle textarea change with validation

--- a/src/libs/lockBundle/lockBundle.constants.ts
+++ b/src/libs/lockBundle/lockBundle.constants.ts
@@ -1,0 +1,33 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway prototype, NOT production code.
+import validationLimits from 'pubky-app-specs/validationLimits.json';
+
+/** Manifest entry name inside the ZIP. */
+export const LOCK_BUNDLE_MANIFEST_PATH = 'post.json';
+
+/** Directory prefix for raw media entries inside the ZIP. */
+export const LOCK_BUNDLE_MEDIA_DIR = 'media';
+
+/**
+ * Transport label for the bundle bytes. `application/octet-stream` (paired with
+ * `X-Content-Type-Options: nosniff` on the wire) so browsers never auto-interpret
+ * the untrusted archive as html/js. The client confirms the ZIP magic itself.
+ */
+export const LOCK_BUNDLE_CONTENT_TYPE = 'application/octet-stream';
+
+/** ZIP local-file-header magic: `PK\x03\x04`. */
+export const ZIP_LOCAL_HEADER_MAGIC = Uint8Array.from([0x50, 0x4b, 0x03, 0x04]);
+
+/** Total bundle byte ceiling — the homeserver blob cap (100 MB). */
+export const LOCK_BUNDLE_MAX_BYTES = validationLimits.maxBlobSizeBytes;
+
+/** Hard cap on the (decompressed) manifest, to bound a manifest-side zip bomb. */
+export const LOCK_BUNDLE_MANIFEST_MAX_BYTES = 512 * 1024;
+
+/** Max number of media entries in one bundle. Matches the post composer cap. */
+export const LOCK_BUNDLE_MAX_ATTACHMENTS = validationLimits.postAttachmentsMaxCount;
+
+/**
+ * Allowed media entry path: `media/<safe-name>`. Anchored, no slashes beyond the
+ * one prefix and no `..`, so it cannot express path traversal.
+ */
+export const LOCK_BUNDLE_MEDIA_PATH_RE = /^media\/[A-Za-z0-9._-]+$/;

--- a/src/libs/lockBundle/lockBundle.demo.ts
+++ b/src/libs/lockBundle/lockBundle.demo.ts
@@ -1,0 +1,102 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway browser demo, NOT production code.
+//
+// Intercepts the composer's Post button: instead of a network write it builds
+// the ZIP bundle, holds it in memory for 5s, then decodes it back — narrating
+// every step to the console so the round-trip is visible without a backend.
+import { buildLockBundleParts, deserializeLockBundle, serializeLockBundle } from './lockBundle';
+import { LOCK_BUNDLE_CONTENT_TYPE } from './lockBundle.constants';
+import { createLocalPostFromBundle } from './lockBundle.localPost';
+import { toLocalAttachments } from './lockBundle.render';
+import type { LockPostKind } from './lockBundle.types';
+
+/** Master switch for the spike demo. Flip to `false` to restore real posting. */
+export const LOCK_BUNDLE_SPIKE_DEMO_ENABLED = true;
+
+/** Console prefix so this demo's output can be filtered in the browser console. */
+const TAG = '[#2058: blob structure]';
+
+const URL_RE = /https?:\/\/[^\s]+/g;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Mirror of `inferPostKindForCreate` ordering, kept self-contained for the spike. */
+function inferKind(files: File[], isArticle: boolean, hasLinks: boolean): LockPostKind {
+  if (isArticle) return 'long';
+  if (hasLinks) return 'link';
+  if (files.some((f) => f.type.startsWith('video/'))) return 'video';
+  if (files.some((f) => f.type.startsWith('image/'))) return 'image';
+  if (files.length > 0) return 'file';
+  return 'short';
+}
+
+export async function runLockBundleSpikeDemo(input: {
+  content: string;
+  files: File[];
+  isArticle: boolean;
+  authorId: string | null;
+  prependPost: (postId: string) => void;
+}): Promise<void> {
+  const { content, files, isArticle, authorId, prependPost } = input;
+  const links = content.match(URL_RE) ?? undefined;
+  const kind = inferKind(files, isArticle, links != null);
+
+  console.group(`%c${TAG} compose → zip → decode`, 'color:#7c3aed;font-weight:bold;');
+  try {
+    // ① pre-zip manifest (the structure we are about to pack)
+    const { manifest } = await buildLockBundleParts({ content, kind, files });
+    console.log(`%c${TAG} ① manifest (pre-zip):`, 'color:#2563eb;font-weight:bold;');
+    console.log(TAG, JSON.stringify(manifest, null, 2));
+
+    // ② build the ZIP — kept in memory, no network call
+    const bytes = await serializeLockBundle({ content, kind, files });
+    console.log(
+      `%c${TAG} ② zip built — ${bytes.byteLength} bytes, content-type "${LOCK_BUNDLE_CONTENT_TYPE}" (no network call)`,
+      'color:#16a34a;font-weight:bold;',
+    );
+
+    // ③ hold the in-memory bytes, count down
+    console.log(`%c${TAG} ③ holding zip in memory, decoding in 5s…`, 'color:#ca8a04;font-weight:bold;');
+    for (let n = 5; n >= 1; n--) {
+      console.log(`${TAG}    ⏳ ${n}…`);
+      await sleep(1000);
+    }
+
+    // ④ decode the same in-memory bytes and show the unpacked structure
+    const decoded = await deserializeLockBundle(bytes);
+    console.log(`%c${TAG} ④ decoded structure:`, 'color:#dc2626;font-weight:bold;');
+    console.log(TAG, {
+      // post.json — parsed: the post body + the attachment index it declares
+      'post.json': decoded.manifest,
+      // media/ — the actual extracted files
+      'media/': decoded.attachments.map((a) => ({
+        name: a.name,
+        content_type: a.content_type,
+        size: a.bytes.byteLength,
+      })),
+    });
+
+    const matches = JSON.stringify(decoded.manifest) === JSON.stringify(manifest);
+    console.log(
+      `%c${TAG} ✔ decoded manifest matches pre-zip manifest: ${matches}`,
+      `color:${matches ? '#16a34a' : '#dc2626'};font-weight:bold;`,
+    );
+
+    // ⑤ render the decoded bundle as a REAL post at the top of the feed (no network):
+    // a normal local post card with header, footer actions and attachments.
+    if (authorId) {
+      const localAttachments = toLocalAttachments(decoded);
+      const postId = await createLocalPostFromBundle({ bundle: decoded, files, isArticle, authorId, localAttachments });
+      prependPost(postId);
+      console.log(
+        `%c${TAG} ⑤ decoded bundle rendered as a real post in the feed (id ${postId})`,
+        'color:#7c3aed;font-weight:bold;',
+      );
+    } else {
+      console.warn(`${TAG} ⑤ skipped feed render — no authenticated user`);
+    }
+  } catch (error) {
+    console.error(`${TAG} failed:`, error);
+  } finally {
+    console.groupEnd();
+  }
+}

--- a/src/libs/lockBundle/lockBundle.localPost.ts
+++ b/src/libs/lockBundle/lockBundle.localPost.ts
@@ -1,0 +1,39 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway, NOT production code.
+//
+// Writes the decoded bundle as a LOCAL-ONLY post (Dexie, no homeserver sync) and
+// registers its attachments as object URLs, so the standard feed Post card —
+// header, footer actions, card chrome — renders it through the normal timeline
+// path. Mirrors the local half of PostController.commitCreate, minus the network.
+import { buildCompositeId } from '@/models/models.utils';
+import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
+import { inferPostKindForCreate } from '@/pipes/post/post.kind';
+import { PostNormalizer } from '@/pipes/post/post.normalizer';
+import { LocalPostService } from '@/services/local/post/post';
+import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
+import type { DeserializedLockBundle } from './lockBundle.types';
+
+export async function createLocalPostFromBundle(params: {
+  bundle: DeserializedLockBundle;
+  files: File[];
+  isArticle: boolean;
+  authorId: string;
+  localAttachments: AttachmentConstructed[];
+}): Promise<string> {
+  const { bundle, files, isArticle, authorId, localAttachments } = params;
+  const { content } = bundle.manifest.post;
+
+  const kind = inferPostKindForCreate({ content, attachments: files, isArticle });
+
+  // Build a real PubkyAppPost (no file URIs — the bytes are rendered locally via
+  // object URLs registered below, the same mechanism optimistic posts use).
+  const { post, meta } = await PostNormalizer.to(
+    { content, kind, attachments: undefined, embed: undefined, parentUri: undefined },
+    authorId,
+  );
+
+  const compositePostId = buildCompositeId({ pubky: authorId, id: meta.id });
+  await LocalPostService.create({ compositePostId, post });
+  useLocalFilesStore.getState().setPostAttachments(compositePostId, localAttachments);
+
+  return compositePostId;
+}

--- a/src/libs/lockBundle/lockBundle.render.ts
+++ b/src/libs/lockBundle/lockBundle.render.ts
@@ -1,0 +1,26 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway adapter, NOT production code.
+//
+// Maps decoded bundle attachments → the object-URL props the existing
+// PostAttachments component consumes (`AttachmentConstructed`). The raw bytes
+// are wrapped in a Blob and an object URL; the owning store revokes those URLs
+// when they are replaced, so no revoke bookkeeping is needed here.
+import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
+import type { DeserializedLockBundle } from './lockBundle.types';
+
+/** Copy into a fresh ArrayBuffer so the bytes are a valid `BlobPart` (not a generic ArrayBufferLike). */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+export function toLocalAttachments(bundle: DeserializedLockBundle): AttachmentConstructed[] {
+  return bundle.attachments.map((attachment) => {
+    // The MIME was already checked against the spec allowlist during deserialize,
+    // so labelling the Blob with it here is safe.
+    const url = URL.createObjectURL(new Blob([toArrayBuffer(attachment.bytes)], { type: attachment.content_type }));
+    // `feed` mirrors `main`: the image grid renders the `feed` variant for
+    // non-gif images, while video/gif use `main`. One object URL serves both.
+    return { type: attachment.content_type, name: attachment.name, urls: { main: url, feed: url } };
+  });
+}

--- a/src/libs/lockBundle/lockBundle.schema.ts
+++ b/src/libs/lockBundle/lockBundle.schema.ts
@@ -1,0 +1,35 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway prototype, NOT production code.
+import { getValidMimeTypes, PubkyAppPostKind } from 'pubky-app-specs';
+import validationLimits from 'pubky-app-specs/validationLimits.json';
+import { z } from 'zod';
+import { LOCK_BUNDLE_MAX_ATTACHMENTS, LOCK_BUNDLE_MEDIA_PATH_RE } from './lockBundle.constants';
+import type { LockPostKind } from './lockBundle.types';
+
+const VALID_MIME_TYPES = new Set(getValidMimeTypes() as string[]);
+
+// Derive the kind values from the spec enum (drops the numeric reverse-map keys)
+// so the schema stays in lockstep with pubky-app-specs.
+const POST_KIND_VALUES = Object.keys(PubkyAppPostKind)
+  .filter((key) => Number.isNaN(Number(key)))
+  .map((key) => key.toLowerCase()) as [LockPostKind, ...LockPostKind[]];
+
+const kindSchema = z.enum(POST_KIND_VALUES);
+
+const attachmentSchema = z.strictObject({
+  path: z.string().regex(LOCK_BUNDLE_MEDIA_PATH_RE, 'invalid media path'),
+  name: z.string().min(validationLimits.fileNameMinLength).max(validationLimits.fileNameMaxLength),
+  content_type: z.string().refine((t) => VALID_MIME_TYPES.has(t), 'unsupported MIME type'),
+  size: z.number().int().positive(),
+});
+
+/**
+ * Strict manifest schema. Unknown keys are rejected (`strictObject`) so a
+ * tampered bundle from the content-agnostic server cannot smuggle extra fields.
+ */
+export const lockBundleManifestSchema = z.strictObject({
+  post: z.strictObject({
+    content: z.string().max(validationLimits.postLongContentMaxLength),
+    kind: kindSchema,
+  }),
+  attachments: z.array(attachmentSchema).max(LOCK_BUNDLE_MAX_ATTACHMENTS),
+});

--- a/src/libs/lockBundle/lockBundle.test.ts
+++ b/src/libs/lockBundle/lockBundle.test.ts
@@ -1,0 +1,143 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway prototype, NOT production code.
+import JSZip from 'jszip';
+import { describe, expect, it } from 'vitest';
+import { deserializeLockBundle, serializeLockBundle } from './lockBundle';
+import { LOCK_BUNDLE_MANIFEST_PATH, LOCK_BUNDLE_MAX_BYTES } from './lockBundle.constants';
+import { toLocalAttachments } from './lockBundle.render';
+import type { LockBundleInput } from './lockBundle.types';
+
+const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74]);
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function makeFile(name: string, type: string, bytes: Uint8Array): File {
+  return new File([toArrayBuffer(bytes)], name, { type });
+}
+
+const baseInput: LockBundleInput = {
+  content: 'A locked post with **markdown** and media. https://pubky.org',
+  kind: 'image',
+  files: [makeFile('photo.jpg', 'image/jpeg', jpeg), makeFile('clip.mp4', 'video/mp4', mp4)],
+};
+
+/** Craft an arbitrary (possibly hostile) bundle for the negative-path tests. */
+async function craftZip(
+  manifest: unknown,
+  media: Array<{ path: string; bytes: Uint8Array }> = [],
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const m of media) zip.file(m.path, m.bytes, { compression: 'STORE' });
+  if (manifest !== undefined) {
+    zip.file(LOCK_BUNDLE_MANIFEST_PATH, typeof manifest === 'string' ? manifest : JSON.stringify(manifest));
+  }
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('lockBundle round-trip', () => {
+  it('serializes then deserializes back to the same content + attachments', async () => {
+    const bytes = await serializeLockBundle(baseInput);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+
+    const { manifest, attachments } = await deserializeLockBundle(bytes);
+
+    expect(manifest.post.content).toBe(baseInput.content);
+    expect(manifest.post.kind).toBe('image');
+
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0]).toMatchObject({ name: 'photo.jpg', content_type: 'image/jpeg' });
+    expect(Array.from(attachments[0].bytes)).toEqual(Array.from(jpeg));
+    expect(attachments[1]).toMatchObject({ name: 'clip.mp4', content_type: 'video/mp4' });
+    expect(Array.from(attachments[1].bytes)).toEqual(Array.from(mp4));
+  });
+
+  it('handles a text-only bundle (no attachments)', async () => {
+    const bytes = await serializeLockBundle({ content: 'hello', kind: 'short', files: [] });
+    const { manifest, attachments } = await deserializeLockBundle(bytes);
+    expect(manifest.post.content).toBe('hello');
+    expect(attachments).toHaveLength(0);
+  });
+});
+
+describe('toLocalAttachments', () => {
+  it('produces PostAttachments props with object URLs', async () => {
+    const deserialized = await deserializeLockBundle(await serializeLockBundle(baseInput));
+    const localAttachments = toLocalAttachments(deserialized);
+
+    expect(localAttachments).toHaveLength(2);
+    expect(localAttachments[0]).toMatchObject({ type: 'image/jpeg', name: 'photo.jpg' });
+    expect(localAttachments[0].urls.main).toMatch(/^blob:/);
+    expect(localAttachments[0].urls.feed).toMatch(/^blob:/);
+  });
+});
+
+describe('lockBundle security guards', () => {
+  it('rejects bytes that are not a ZIP', async () => {
+    await expect(deserializeLockBundle(new Uint8Array([1, 2, 3]))).rejects.toMatchObject({ code: 'NOT_ZIP' });
+  });
+
+  it('rejects an over-size bundle before parsing', async () => {
+    const tooBig = new Uint8Array(LOCK_BUNDLE_MAX_BYTES + 1);
+    await expect(deserializeLockBundle(tooBig)).rejects.toMatchObject({ code: 'TOO_LARGE' });
+  });
+
+  it('rejects a missing manifest', async () => {
+    const bytes = await craftZip(undefined, [{ path: 'media/0-a.jpg', bytes: jpeg }]);
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'MISSING_MANIFEST' });
+  });
+
+  it('rejects a non-JSON manifest', async () => {
+    const bytes = await craftZip('not json{');
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'INVALID_MANIFEST_JSON' });
+  });
+
+  it('rejects unknown manifest fields (strict schema)', async () => {
+    const bytes = await craftZip({
+      post: { content: 'x', kind: 'short' },
+      attachments: [],
+      evil: 'smuggled',
+    });
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'SCHEMA_INVALID' });
+  });
+
+  it('rejects a path-traversal attachment path', async () => {
+    const bytes = await craftZip({
+      post: { content: 'x', kind: 'image' },
+      attachments: [{ path: '../evil', name: 'evil', content_type: 'image/jpeg', size: 4 }],
+    });
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'SCHEMA_INVALID' });
+  });
+
+  it('rejects an unsupported MIME type', async () => {
+    const bytes = await craftZip({
+      post: { content: 'x', kind: 'image' },
+      attachments: [{ path: 'media/0-a.bin', name: 'a.bin', content_type: 'application/x-evil', size: 4 }],
+    });
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'SCHEMA_INVALID' });
+  });
+
+  it('rejects an undeclared extra entry', async () => {
+    const manifest = {
+      post: { content: 'x', kind: 'image' },
+      attachments: [{ path: 'media/0-a.jpg', name: 'a.jpg', content_type: 'image/jpeg', size: jpeg.byteLength }],
+    };
+    const bytes = await craftZip(manifest, [
+      { path: 'media/0-a.jpg', bytes: jpeg },
+      { path: 'extra.txt', bytes: new Uint8Array([9, 9, 9]) },
+    ]);
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'UNEXPECTED_ENTRY' });
+  });
+
+  it('rejects a declared/actual size mismatch', async () => {
+    const manifest = {
+      post: { content: 'x', kind: 'image' },
+      attachments: [{ path: 'media/0-a.jpg', name: 'a.jpg', content_type: 'image/jpeg', size: 999 }],
+    };
+    const bytes = await craftZip(manifest, [{ path: 'media/0-a.jpg', bytes: jpeg }]);
+    await expect(deserializeLockBundle(bytes)).rejects.toMatchObject({ code: 'SIZE_MISMATCH' });
+  });
+});

--- a/src/libs/lockBundle/lockBundle.ts
+++ b/src/libs/lockBundle/lockBundle.ts
@@ -59,12 +59,6 @@ function hasZipMagic(bytes: Uint8Array): boolean {
 }
 
 /**
- * Package a locked post + attachments into a single ZIP blob.
- *
- * Per-entry compression: the manifest is DEFLATE-d (text compresses well);
- * already-compressed media is STORE-d (re-deflating wastes CPU for ~no gain).
- */
-/**
  * Build the manifest + raw media entries for a bundle, without zipping. Exposed
  * so a caller can inspect the exact manifest that will be serialized before the
  * ZIP is produced (used by the spike demo to log the pre-zip structure).
@@ -90,6 +84,12 @@ export async function buildLockBundleParts(
   return { manifest, media };
 }
 
+/**
+ * Package a locked post + attachments into a single ZIP blob.
+ *
+ * Per-entry compression: the manifest is DEFLATE-d (text compresses well);
+ * already-compressed media is STORE-d (re-deflating wastes CPU for ~no gain).
+ */
 export async function serializeLockBundle(input: LockBundleInput): Promise<Uint8Array> {
   const { manifest, media } = await buildLockBundleParts(input);
 

--- a/src/libs/lockBundle/lockBundle.ts
+++ b/src/libs/lockBundle/lockBundle.ts
@@ -1,0 +1,196 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway prototype, NOT production code.
+//
+// Pure (environment-agnostic) serialize/deserialize for a locked-content bundle.
+// A locked post is packaged into ONE ZIP: `post.json` (manifest) + raw media
+// bytes. The Lock Server returns these bytes verbatim, so EVERYTHING here is
+// validated client-side on the way back in — there is no backend enforcing the
+// shape. Treat every byte from {@link deserializeLockBundle} as hostile until it
+// has passed these guards.
+import JSZip from 'jszip';
+import {
+  LOCK_BUNDLE_MANIFEST_MAX_BYTES,
+  LOCK_BUNDLE_MANIFEST_PATH,
+  LOCK_BUNDLE_MAX_BYTES,
+  LOCK_BUNDLE_MEDIA_DIR,
+  LOCK_BUNDLE_MEDIA_PATH_RE,
+  ZIP_LOCAL_HEADER_MAGIC,
+} from './lockBundle.constants';
+import { lockBundleManifestSchema } from './lockBundle.schema';
+import type {
+  DeserializedLockBundle,
+  LockBundleAttachment,
+  LockBundleInput,
+  LockBundleManifest,
+} from './lockBundle.types';
+
+type LockBundleErrorCode =
+  | 'TOO_LARGE'
+  | 'NOT_ZIP'
+  | 'CORRUPT_ZIP'
+  | 'MISSING_MANIFEST'
+  | 'MANIFEST_TOO_LARGE'
+  | 'INVALID_MANIFEST_JSON'
+  | 'SCHEMA_INVALID'
+  | 'UNEXPECTED_ENTRY'
+  | 'MISSING_ENTRY'
+  | 'SIZE_MISMATCH';
+
+export class LockBundleError extends Error {
+  readonly code: LockBundleErrorCode;
+  override readonly cause?: unknown;
+
+  constructor(code: LockBundleErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'LockBundleError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+/** Reduce an arbitrary filename to the `media/` path charset, keeping it unique by index. */
+function toMediaPath(index: number, name: string): string {
+  const safe = name.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '') || 'file';
+  return `${LOCK_BUNDLE_MEDIA_DIR}/${index}-${safe}`;
+}
+
+function hasZipMagic(bytes: Uint8Array): boolean {
+  if (bytes.length < ZIP_LOCAL_HEADER_MAGIC.length) return false;
+  return ZIP_LOCAL_HEADER_MAGIC.every((b, i) => bytes[i] === b);
+}
+
+/**
+ * Package a locked post + attachments into a single ZIP blob.
+ *
+ * Per-entry compression: the manifest is DEFLATE-d (text compresses well);
+ * already-compressed media is STORE-d (re-deflating wastes CPU for ~no gain).
+ */
+/**
+ * Build the manifest + raw media entries for a bundle, without zipping. Exposed
+ * so a caller can inspect the exact manifest that will be serialized before the
+ * ZIP is produced (used by the spike demo to log the pre-zip structure).
+ */
+export async function buildLockBundleParts(
+  input: LockBundleInput,
+): Promise<{ manifest: LockBundleManifest; media: Array<{ path: string; bytes: Uint8Array }> }> {
+  const media: Array<{ path: string; bytes: Uint8Array }> = [];
+  const attachments: LockBundleAttachment[] = [];
+
+  for (let i = 0; i < input.files.length; i++) {
+    const file = input.files[i];
+    const path = toMediaPath(i, file.name);
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    media.push({ path, bytes });
+    attachments.push({ path, name: file.name, content_type: file.type, size: bytes.byteLength });
+  }
+
+  const manifest: LockBundleManifest = {
+    post: { content: input.content, kind: input.kind },
+    attachments,
+  };
+  return { manifest, media };
+}
+
+export async function serializeLockBundle(input: LockBundleInput): Promise<Uint8Array> {
+  const { manifest, media } = await buildLockBundleParts(input);
+
+  // Validate our own manifest before emitting so authoring bugs fail loudly here
+  // rather than on a viewer's machine.
+  lockBundleManifestSchema.parse(manifest);
+
+  const zip = new JSZip();
+  for (const { path, bytes } of media) {
+    zip.file(path, bytes, { compression: 'STORE' });
+  }
+  zip.file(LOCK_BUNDLE_MANIFEST_PATH, JSON.stringify(manifest), { compression: 'DEFLATE' });
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+/**
+ * Validate + unpack a bundle produced by {@link serializeLockBundle}.
+ *
+ * Security gauntlet (all client-side — the server validates nothing):
+ *  1. total byte ceiling (homeserver blob cap)
+ *  2. ZIP magic-byte check before handing bytes to the parser
+ *  3. manifest present, size-bounded, valid JSON, strict-schema valid
+ *  4. entry allowlist — only the manifest + declared media paths may exist
+ *  5. path-traversal guard on every declared path
+ *  6. declared size === actual size, and cumulative uncompressed ≤ cap (zip-bomb bound)
+ */
+export async function deserializeLockBundle(bytes: Uint8Array): Promise<DeserializedLockBundle> {
+  if (bytes.byteLength > LOCK_BUNDLE_MAX_BYTES) {
+    throw new LockBundleError('TOO_LARGE', 'bundle exceeds the maximum allowed size');
+  }
+  if (!hasZipMagic(bytes)) {
+    throw new LockBundleError('NOT_ZIP', 'bytes are not a ZIP archive');
+  }
+
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(bytes);
+  } catch (error) {
+    throw new LockBundleError('CORRUPT_ZIP', 'failed to read ZIP archive', error);
+  }
+
+  const manifestEntry = zip.file(LOCK_BUNDLE_MANIFEST_PATH);
+  if (!manifestEntry) {
+    throw new LockBundleError('MISSING_MANIFEST', `missing ${LOCK_BUNDLE_MANIFEST_PATH}`);
+  }
+
+  // Read raw bytes first so an oversized (bomb) manifest is caught before decode.
+  const manifestBytes = await manifestEntry.async('uint8array');
+  if (manifestBytes.byteLength > LOCK_BUNDLE_MANIFEST_MAX_BYTES) {
+    throw new LockBundleError('MANIFEST_TOO_LARGE', 'manifest exceeds the maximum allowed size');
+  }
+
+  let rawManifest: unknown;
+  try {
+    rawManifest = JSON.parse(new TextDecoder().decode(manifestBytes));
+  } catch (error) {
+    throw new LockBundleError('INVALID_MANIFEST_JSON', 'manifest is not valid JSON', error);
+  }
+
+  const parsed = lockBundleManifestSchema.safeParse(rawManifest);
+  if (!parsed.success) {
+    throw new LockBundleError('SCHEMA_INVALID', 'manifest failed schema validation', parsed.error);
+  }
+  const manifest = parsed.data as LockBundleManifest;
+
+  // Entry allowlist: reject anything the manifest did not declare (extra payloads,
+  // traversal entries, hidden files).
+  const declaredPaths = new Set<string>([LOCK_BUNDLE_MANIFEST_PATH, ...manifest.attachments.map((a) => a.path)]);
+  for (const [name, entry] of Object.entries(zip.files)) {
+    if (entry.dir) continue;
+    if (!declaredPaths.has(name)) {
+      throw new LockBundleError('UNEXPECTED_ENTRY', `undeclared entry: ${name}`);
+    }
+  }
+
+  let cumulativeBytes = manifestBytes.byteLength;
+  const attachments: DeserializedLockBundle['attachments'] = [];
+
+  for (const declared of manifest.attachments) {
+    // Schema already enforces the path shape; re-assert traversal safety defensively.
+    if (!LOCK_BUNDLE_MEDIA_PATH_RE.test(declared.path) || declared.path.includes('..')) {
+      throw new LockBundleError('UNEXPECTED_ENTRY', `unsafe path: ${declared.path}`);
+    }
+
+    const entry = zip.file(declared.path);
+    if (!entry) {
+      throw new LockBundleError('MISSING_ENTRY', `declared entry not found: ${declared.path}`);
+    }
+
+    const data = await entry.async('uint8array');
+    if (data.byteLength !== declared.size) {
+      throw new LockBundleError('SIZE_MISMATCH', `size mismatch for ${declared.path}`);
+    }
+
+    cumulativeBytes += data.byteLength;
+    if (cumulativeBytes > LOCK_BUNDLE_MAX_BYTES) {
+      throw new LockBundleError('TOO_LARGE', 'uncompressed payload exceeds the maximum allowed size');
+    }
+
+    attachments.push({ name: declared.name, content_type: declared.content_type, bytes: data });
+  }
+
+  return { manifest, attachments };
+}

--- a/src/libs/lockBundle/lockBundle.types.ts
+++ b/src/libs/lockBundle/lockBundle.types.ts
@@ -1,0 +1,50 @@
+// TODO:[Locks] #1998 / Spike #2058 — throwaway prototype, NOT production code.
+// Proves the round-trip: lock-post compose -> FE builds ZIP -> unzip -> render
+// from the unzipped data. The Lock Server / homeserver / Nexus stay
+// content-agnostic; only the unlocking client interprets these bytes.
+
+import { PubkyAppPostKind } from 'pubky-app-specs';
+
+/**
+ * Post kind in its JSON (lowercase) form. Derived from the spec enum, which
+ * serializes via serde `rename_all = "lowercase"` — single source of truth, so
+ * a new kind in the spec widens this automatically.
+ */
+export type LockPostKind = Lowercase<keyof typeof PubkyAppPostKind>;
+
+/** One media entry inside the bundle, indexed by its zip-relative path. */
+export interface LockBundleAttachment {
+  /** zip-relative entry path, e.g. "media/0-photo.jpg". */
+  path: string;
+  /** Original filename, for display / download. */
+  name: string;
+  /** MIME type; must be in the pubky-app-spec valid set. */
+  content_type: string;
+  /** Exact byte length of the stored entry. */
+  size: number;
+}
+
+/**
+ * `post.json` — the manifest. A normal PubkyAppPost-shaped body plus an
+ * attachment index whose paths point at the raw media entries in the same ZIP.
+ */
+export interface LockBundleManifest {
+  post: {
+    content: string;
+    kind: LockPostKind;
+  };
+  attachments: LockBundleAttachment[];
+}
+
+/** Author-side input handed to {@link serializeLockBundle}. */
+export interface LockBundleInput {
+  content: string;
+  kind: LockPostKind;
+  files: File[];
+}
+
+/** Raw, validated output of {@link deserializeLockBundle} (pre-render). */
+export interface DeserializedLockBundle {
+  manifest: LockBundleManifest;
+  attachments: Array<{ name: string; content_type: string; bytes: Uint8Array }>;
+}


### PR DESCRIPTION
## Spike: lock-content ZIP bundle (#2058)

**Throwaway spike — not production.** Resolves
[#2058](https://github.com/pubky/pubky-app/issues/2058): defines the locked-content bundle format and
proves the round-trip on the client.

compose lock post → FE builds ONE ZIP → (Lock Server returns bytes verbatim) → unzip → render

Lock Server / homeserver / Nexus stay **content-agnostic** (opaque bytes); the whole format +
validation lives client-side.

### Bundle format

Transport content-type: `application/octet-stream`.

content.zip
├── post.json          # DEFLATE
├── media/0-photo.jpg  # STORE
└── media/1-clip.mp4   # STORE

- `post` = PubkyAppPost core (`content`, `kind`) → spec-validatable later.
- `attachments` index carries per-file `content_type`/`size` (PubkyAppPost's URI-only attachments
can't); each `path` → a raw ZIP entry.
- Per-entry compression: DEFLATE manifest, STORE already-compressed media.

### Security (all client-side — server validates nothing)

- `attachments` index carries per-file `content_type`/`size` (PubkyAppPost's URI-only attachments
can't); each `path` → a raw ZIP entry.
- Per-entry compression: DEFLATE manifest, STORE already-compressed media.

`deserializeLockBundle` treats every byte as hostile: 100 MB cap, ZIP magic-byte check, strict-schema
manifest, entry allowlist, path-traversal guard, declared-size === actual-size + cumulative zip-bomb
bound. Each failure → typed `LockBundleError`.

### Demo

Behind `LOCK_BUNDLE_SPIKE_DEMO_ENABLED` (default on). `npm run dev` → home composer → add text + link
+ image → **Post**. Intercepts the button (no network) and narrates the round-trip to the console
(filter `#2058: blob structure`):

1. `①` pre-zip manifest
2. `②` zip built (bytes + `application/octet-stream`)
3. `③` 5s countdown, zip held in memory
4. `④` decoded structure (`post.json` + `media/`)
5. `⑤` decoded bundle rendered as a **real post** at the top of the feed


https://github.com/user-attachments/assets/1e8a334f-2f2a-4b75-90f6-46a9fe2c6e2b



### Scope

- **Out:** real auth / encryption / payment, production publish + private-HS wiring,
multi-content-per-lock, schema promotion into `pubky-app-specs`.
- Viewer-side persistence (IDB vs private table, `bundle_id` storage, re-fetch) → design note on
[#2003](https://github.com/pubky/pubky-app/issues/2003).
- ⚠️ Demo writes the decoded body into the public `post_details` table to reuse the feed card —
**spike shortcut**; production needs a separate private store (#2003).

### Testing

```sh
npx vitest run src/libs/lockBundle   # 12 passing — round-trip + every security guard lint + typecheck clean.
```
Manual demo round-trip (Post → console ①–⑤ → image/text/link render) verified on:

- [x] Chrome (desktop)
- [x] Firefox (desktop)
- [x] Safari (desktop)
- [ ] Mobile Safari (iOS)
- [x] Mobile Chrome (Android)

Refs #2058, #2003, #2029, epic #1998