### PR TITLE
fix(ui): Use border token for inactive feed navigation tabs

### DIFF
--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
@@ -229,7 +229,7 @@ describe('FeedNavigation', () => {
 
     const links = screen.getAllByTestId('link');
     const homeLink = links.find((link) => link.getAttribute('href') === '/home');
-    expect(homeLink).toHaveClass('border-muted-foreground');
+    expect(homeLink).toHaveClass('border-border');
     expect(homeLink).toHaveClass('text-muted-foreground');
   });
 
@@ -296,7 +296,7 @@ describe('FeedNavigation', () => {
 
     const links = screen.getAllByTestId('link');
     const inactiveLink = links.find((link) => link.getAttribute('href') === '/feed/feed-inactive');
-    expect(inactiveLink).toHaveClass('border-muted-foreground');
+    expect(inactiveLink).toHaveClass('border-border');
     expect(inactiveLink).toHaveClass('text-muted-foreground');
   });
 

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
     Feed
   </div>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/home"
@@ -95,7 +95,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
     data-testid="custom-feed-dialog-create"
   >
     <button
-      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
       data-override-defaults="true"
       data-testid="button"
     >
@@ -184,7 +184,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
     </span>
   </a>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/feed/feed-1"
@@ -218,7 +218,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
     </span>
   </a>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/feed/feed-2"
@@ -255,7 +255,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
     data-testid="custom-feed-dialog-create"
   >
     <button
-      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
       data-override-defaults="true"
       data-testid="button"
     >
@@ -310,7 +310,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
     Feed
   </div>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/home"
@@ -344,7 +344,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
     </span>
   </a>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/feed/feed-1"
@@ -422,7 +422,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
     </span>
   </a>
   <a
-    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-muted-foreground text-muted-foreground"
+    class="flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center border-border text-muted-foreground"
     data-override-defaults="true"
     data-testid="link"
     href="/feed/feed-3"
@@ -459,7 +459,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
     data-testid="custom-feed-dialog-create"
   >
     <button
-      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
       data-override-defaults="true"
       data-testid="button"
     >
@@ -551,7 +551,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
     data-testid="custom-feed-dialog-create"
   >
     <button
-      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+      class="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
       data-override-defaults="true"
       data-testid="button"
     >

--- a/src/components/organisms/FeedNavigation/FeedNavigation.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.tsx
@@ -81,7 +81,7 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
           }
           className={cn(
             'flex min-h-12 w-full min-w-40 items-center gap-x-2 border-b transition-colors hover:text-white lg:justify-center',
-            pathname === f.href ? 'border-white text-white' : 'border-muted-foreground text-muted-foreground',
+            pathname === f.href ? 'border-white text-white' : 'border-border text-muted-foreground',
           )}
         >
           {f.href !== APP_ROUTES.HOME && f.href === pathname ? (
@@ -104,7 +104,7 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
         <CustomFeedDialog mode="create">
           <Button
             overrideDefaults
-            className="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+            className="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
           >
             <PlusCircle className="size-5 shrink-0" />
 
@@ -116,7 +116,7 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
       ) : (
         <Button
           overrideDefaults
-          className="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-muted-foreground text-muted-foreground transition-colors hover:text-white lg:justify-center"
+          className="flex min-h-12 w-full min-w-40 cursor-pointer items-center gap-x-2 border-b border-border text-muted-foreground transition-colors hover:text-white lg:justify-center"
           onClick={() => requireAuth(() => undefined)}
         >
           <PlusCircle className="size-5 shrink-0" />


### PR DESCRIPTION
## Summary

- Updates inactive FeedNavigation tab bottom borders from `border-muted-foreground` (incorrect) to `border-border` (correct) to match Figma designs.
- Keeps inactive tab text using `text-muted-foreground`.
- Applies the same border token to the create-feed button states.
- Updates FeedNavigation test expectations and snapshots.

## Validation

- `npx vitest run src/components/organisms/FeedNavigation/FeedNavigation.test.tsx -u`

Before:
<img width="822" height="71" alt="image" src="https://github.com/user-attachments/assets/ed83b20d-9c10-4d9c-8a71-f8057a7c000c" />
After:
<img width="822" height="75" alt="image" src="https://github.com/user-attachments/assets/f15370bf-e3fd-4593-b55d-e0274689282c" />