### PR TITLE
refactor: fix and update toasts after changes from dev

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1368,9 +1368,9 @@
       "unfollow": "إلغاء المتابعة",
       "delete": "حذف",
       "toast": {
-        "followed": "لقد تابعت مجموعة {name}",
-        "unfollowed": "لقد ألغيت متابعة مجموعة {name}",
-        "shared": "لقد شاركت مجموعة {name}"
+        "followed": "لقد تابعت هذه المجموعة",
+        "unfollowed": "لقد ألغيت متابعة هذه المجموعة",
+        "shared": "لقد شاركت هذه المجموعة"
       }
     },
     "single": {
@@ -1420,8 +1420,8 @@
     "collectionNamePlaceholder": "اسم المجموعة",
     "createCollection": "إنشاء مجموعة",
     "loadingCollections": "جارٍ تحميل المجموعات...",
-    "addedToCollection": "تمت إضافة المنشور إلى {name}.",
-    "removedFromCollection": "تمت إزالة المنشور من {name}.",
+    "addedToCollection": "تمت إضافة المنشور إلى المجموعة.",
+    "removedFromCollection": "تمت إزالة المنشور من المجموعة.",
     "updateCollectionFailed": "فشل تحديث المجموعة.",
     "collectionCreated": "تم إنشاء المجموعة وحفظ المنشور.",
     "createCollectionFailed": "فشل إنشاء المجموعة."

--- a/messages/de.json
+++ b/messages/de.json
@@ -1374,9 +1374,9 @@
       "unfollow": "Entfolgen",
       "delete": "Löschen",
       "toast": {
-        "followed": "Du folgst jetzt der Sammlung {name}",
-        "unfollowed": "Du folgst der Sammlung {name} nicht mehr",
-        "shared": "Du hast die Sammlung {name} geteilt"
+        "followed": "Du folgst jetzt dieser Sammlung",
+        "unfollowed": "Du folgst dieser Sammlung nicht mehr",
+        "shared": "Du hast diese Sammlung geteilt"
       }
     },
     "single": {
@@ -1426,8 +1426,8 @@
     "collectionNamePlaceholder": "Name der Sammlung",
     "createCollection": "Sammlung erstellen",
     "loadingCollections": "Sammlungen werden geladen...",
-    "addedToCollection": "Beitrag zu {name} hinzugefügt.",
-    "removedFromCollection": "Beitrag aus {name} entfernt.",
+    "addedToCollection": "Beitrag zur Sammlung hinzugefügt.",
+    "removedFromCollection": "Beitrag aus der Sammlung entfernt.",
     "updateCollectionFailed": "Sammlung konnte nicht aktualisiert werden.",
     "collectionCreated": "Sammlung erstellt und Beitrag gespeichert.",
     "createCollectionFailed": "Sammlung konnte nicht erstellt werden."

--- a/messages/en.json
+++ b/messages/en.json
@@ -1372,9 +1372,9 @@
       "unfollow": "Unfollow",
       "delete": "Delete",
       "toast": {
-        "followed": "You've followed the {name} collection",
-        "unfollowed": "You've unfollowed the {name} collection",
-        "shared": "You've shared the {name} collection"
+        "followed": "You've followed this collection",
+        "unfollowed": "You've unfollowed this collection",
+        "shared": "You've shared this collection"
       }
     },
     "single": {
@@ -1424,8 +1424,8 @@
     "collectionNamePlaceholder": "Collection name",
     "createCollection": "Create collection",
     "loadingCollections": "Loading collections...",
-    "addedToCollection": "Post added to {name}.",
-    "removedFromCollection": "Post removed from {name}.",
+    "addedToCollection": "Post added to collection.",
+    "removedFromCollection": "Post removed from collection.",
     "updateCollectionFailed": "Failed to update collection.",
     "collectionCreated": "Collection created and post saved.",
     "createCollectionFailed": "Failed to create collection."

--- a/messages/es.json
+++ b/messages/es.json
@@ -1376,9 +1376,9 @@
       "unfollow": "Dejar de seguir",
       "delete": "Eliminar",
       "toast": {
-        "followed": "Ahora sigues la colección {name}",
-        "unfollowed": "Has dejado de seguir la colección {name}",
-        "shared": "Has compartido la colección {name}"
+        "followed": "Ahora sigues esta colección",
+        "unfollowed": "Has dejado de seguir esta colección",
+        "shared": "Has compartido esta colección"
       }
     },
     "single": {
@@ -1428,8 +1428,8 @@
     "collectionNamePlaceholder": "Nombre de la colección",
     "createCollection": "Crear colección",
     "loadingCollections": "Cargando colecciones...",
-    "addedToCollection": "Publicación añadida a {name}.",
-    "removedFromCollection": "Publicación eliminada de {name}.",
+    "addedToCollection": "Publicación añadida a la colección.",
+    "removedFromCollection": "Publicación eliminada de la colección.",
     "updateCollectionFailed": "No se pudo actualizar la colección.",
     "collectionCreated": "Colección creada y publicación guardada.",
     "createCollectionFailed": "No se pudo crear la colección."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1372,9 +1372,9 @@
       "unfollow": "Ne plus suivre",
       "delete": "Supprimer",
       "toast": {
-        "followed": "Vous suivez désormais la collection {name}",
-        "unfollowed": "Vous ne suivez plus la collection {name}",
-        "shared": "Vous avez partagé la collection {name}"
+        "followed": "Vous suivez désormais cette collection",
+        "unfollowed": "Vous ne suivez plus cette collection",
+        "shared": "Vous avez partagé cette collection"
       }
     },
     "single": {
@@ -1424,8 +1424,8 @@
     "collectionNamePlaceholder": "Nom de la collection",
     "createCollection": "Créer une collection",
     "loadingCollections": "Chargement des collections...",
-    "addedToCollection": "Publication ajoutée à {name}.",
-    "removedFromCollection": "Publication retirée de {name}.",
+    "addedToCollection": "Publication ajoutée à la collection.",
+    "removedFromCollection": "Publication retirée de la collection.",
     "updateCollectionFailed": "Échec de la mise à jour de la collection.",
     "collectionCreated": "Collection créée et publication enregistrée.",
     "createCollectionFailed": "Échec de la création de la collection."

--- a/messages/it.json
+++ b/messages/it.json
@@ -1372,9 +1372,9 @@
       "unfollow": "Non seguire più",
       "delete": "Elimina",
       "toast": {
-        "followed": "Ora segui la raccolta {name}",
-        "unfollowed": "Hai smesso di seguire la raccolta {name}",
-        "shared": "Hai condiviso la raccolta {name}"
+        "followed": "Ora segui questa raccolta",
+        "unfollowed": "Hai smesso di seguire questa raccolta",
+        "shared": "Hai condiviso questa raccolta"
       }
     },
     "single": {
@@ -1424,8 +1424,8 @@
     "collectionNamePlaceholder": "Nome della collezione",
     "createCollection": "Crea collezione",
     "loadingCollections": "Caricamento collezioni...",
-    "addedToCollection": "Post aggiunto a {name}.",
-    "removedFromCollection": "Post rimosso da {name}.",
+    "addedToCollection": "Post aggiunto alla raccolta.",
+    "removedFromCollection": "Post rimosso dalla raccolta.",
     "updateCollectionFailed": "Impossibile aggiornare la collezione.",
     "collectionCreated": "Collezione creata e post salvato.",
     "createCollectionFailed": "Impossibile creare la collezione."

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1372,9 +1372,9 @@
       "unfollow": "フォロー解除",
       "delete": "削除",
       "toast": {
-        "followed": "「{name}」コレクションをフォローしました",
-        "unfollowed": "「{name}」コレクションのフォローを解除しました",
-        "shared": "「{name}」コレクションを共有しました"
+        "followed": "このコレクションをフォローしました",
+        "unfollowed": "このコレクションのフォローを解除しました",
+        "shared": "このコレクションを共有しました"
       }
     },
     "single": {
@@ -1424,8 +1424,8 @@
     "collectionNamePlaceholder": "コレクション名",
     "createCollection": "コレクションを作成",
     "loadingCollections": "コレクションを読み込み中...",
-    "addedToCollection": "投稿を「{name}」に追加しました。",
-    "removedFromCollection": "投稿を「{name}」から削除しました。",
+    "addedToCollection": "投稿をコレクションに追加しました。",
+    "removedFromCollection": "投稿をコレクションから削除しました。",
     "updateCollectionFailed": "コレクションの更新に失敗しました。",
     "collectionCreated": "コレクションを作成し、投稿を保存しました。",
     "createCollectionFailed": "コレクションの作成に失敗しました。"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1372,9 +1372,9 @@
       "unfollow": "Deixar de seguir",
       "delete": "Excluir",
       "toast": {
-        "followed": "Você agora segue a coleção {name}",
-        "unfollowed": "Você deixou de seguir a coleção {name}",
-        "shared": "Você compartilhou a coleção {name}"
+        "followed": "Você agora segue esta coleção",
+        "unfollowed": "Você deixou de seguir esta coleção",
+        "shared": "Você compartilhou esta coleção"
       }
     },
     "single": {
@@ -1424,8 +1424,8 @@
     "collectionNamePlaceholder": "Nome da coleção",
     "createCollection": "Criar coleção",
     "loadingCollections": "Carregando coleções...",
-    "addedToCollection": "Publicação adicionada a {name}.",
-    "removedFromCollection": "Publicação removida de {name}.",
+    "addedToCollection": "Publicação adicionada à coleção.",
+    "removedFromCollection": "Publicação removida da coleção.",
     "updateCollectionFailed": "Falha ao atualizar a coleção.",
     "collectionCreated": "Coleção criada e publicação salva.",
     "createCollectionFailed": "Falha ao criar a coleção."

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1366,9 +1366,9 @@
       "unfollow": "取消关注",
       "delete": "删除",
       "toast": {
-        "followed": "你已关注 {name} 收藏",
-        "unfollowed": "你已取消关注 {name} 收藏",
-        "shared": "你已分享 {name} 收藏"
+        "followed": "你已关注此收藏",
+        "unfollowed": "你已取消关注此收藏",
+        "shared": "你已分享此收藏"
       }
     },
     "single": {
@@ -1418,8 +1418,8 @@
     "collectionNamePlaceholder": "收藏集名称",
     "createCollection": "创建收藏集",
     "loadingCollections": "正在加载收藏集...",
-    "addedToCollection": "帖子已添加到 {name}。",
-    "removedFromCollection": "帖子已从 {name} 移除。",
+    "addedToCollection": "帖子已添加到收藏。",
+    "removedFromCollection": "帖子已从收藏移除。",
     "updateCollectionFailed": "更新收藏集失败。",
     "collectionCreated": "收藏集已创建并保存帖子。",
     "createCollectionFailed": "创建收藏集失败。"

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -154,14 +154,11 @@ function CollectionCardContent({
   const title = collection?.name ?? '';
 
   // Override the generic "Bookmark added / removed" toast copy so collection
-  // Follow / Unfollow reads as a collection action, with the collection name
-  // interpolated. Falls back to the author pubky if the envelope failed to
-  // parse a name — the button is disabled while toggling, so this is rare.
-  const toastName = title || authorPubky;
+  // Follow / Unfollow reads as a collection action.
   const { isBookmarked, isToggling, toggle } = useBookmark(compositeId, {
     toastMessages: {
-      added: tCardToast('followed', { name: toastName }),
-      removed: tCardToast('unfollowed', { name: toastName }),
+      added: tCardToast('followed'),
+      removed: tCardToast('unfollowed'),
     },
     initialIsBookmarked,
   });

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
@@ -97,12 +97,11 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
   const ownerAvatarUrl = ownerProfile?.avatarUrl;
 
   // Override the generic bookmark toast copy so Follow / Unfollow reads as a
-  // collection action, with the name interpolated (matches `CollectionCard`).
-  const toastName = title || authorPubky;
+  // collection action (matches `CollectionCard`).
   const { isBookmarked, isToggling, toggle } = useBookmark(compositeId, {
     toastMessages: {
-      added: tCardToast('followed', { name: toastName }),
-      removed: tCardToast('unfollowed', { name: toastName }),
+      added: tCardToast('followed'),
+      removed: tCardToast('unfollowed'),
     },
   });
 
@@ -118,7 +117,7 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
     title: t('shareTitle'),
     submitLabel: t('share'),
     submitIcon: StickyNote,
-    successToastTitle: tCardToast('shared', { name: toastName }),
+    successToastTitle: tCardToast('shared'),
   });
   const handleShare = openRepostDialog;
 

--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
@@ -418,7 +418,7 @@ describe('DiscoverCollections', () => {
     // Mirror of the `MyCollections` onError toast — keeps failure UX
     // consistent across the three Collections sections.
     expect(mockToast).toHaveBeenCalledWith({
-      title: 'toast.error',
+      variant: 'error',
       description: 'collections.loadFailed',
     });
     // No spinner, no Show More, no cards.

--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
@@ -86,7 +86,6 @@ const EMPTY_CURSOR: DiscoverCursor = { lastPostId: undefined, streamTail: 0 };
  */
 export function DiscoverCollections() {
   const t = useTranslations('collections');
-  const tToast = useTranslations('toast');
   const { toast } = useToast();
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   // Gate the initial fetch on auth hydration so we never fire a fetch under a
@@ -256,7 +255,7 @@ export function DiscoverCollections() {
       // Mirror `MyCollections`' `useStreamPagination({ onError })` toast so the
       // three Collections sections fail consistently from the user's POV.
       toast({
-        title: tToast('error'),
+        variant: 'error',
         description: t('loadFailed'),
       });
       // Give up on this action so the spinner clears.

--- a/src/components/organisms/Collections/FollowedCollections/FollowedCollections.test.tsx
+++ b/src/components/organisms/Collections/FollowedCollections/FollowedCollections.test.tsx
@@ -330,7 +330,7 @@ describe('FollowedCollections', () => {
     // Mirror of the `MyCollections` onError toast — keeps failure UX
     // consistent across the three Collections sections.
     expect(mockToast).toHaveBeenCalledWith({
-      title: 'toast.error',
+      variant: 'error',
       description: 'collections.loadFailed',
     });
     expect(screen.queryByText('collections.showMore')).not.toBeInTheDocument();

--- a/src/components/organisms/Collections/FollowedCollections/FollowedCollections.tsx
+++ b/src/components/organisms/Collections/FollowedCollections/FollowedCollections.tsx
@@ -55,7 +55,6 @@ const EMPTY_IDS: string[] = [];
  */
 export function FollowedCollections() {
   const t = useTranslations('collections');
-  const tToast = useTranslations('toast');
   const { toast } = useToast();
   // Gate the seed fetch on auth hydration. `StreamPostsController.getOrFetchStreamSlice`
   // reads `viewerId` from the auth store synchronously, and the bookmarks-collection
@@ -99,7 +98,7 @@ export function FollowedCollections() {
       // Mirror `MyCollections`' `useStreamPagination({ onError })` toast so the
       // three Collections sections fail consistently from the user's POV.
       toast({
-        title: tToast('error'),
+        variant: 'error',
         description: t('loadFailed'),
       });
       setReachedEnd(true);

--- a/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
@@ -363,7 +363,7 @@ describe('MyCollections', () => {
 
     expect(mockToast).toHaveBeenCalledTimes(1);
     expect(mockToast).toHaveBeenCalledWith({
-      title: 'toast.error',
+      variant: 'error',
       description: 'collections.loadFailed',
     });
   });

--- a/src/components/organisms/Collections/MyCollections/MyCollections.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.tsx
@@ -123,7 +123,6 @@ interface MyCollectionsStreamProps {
  */
 function MyCollectionsStream({ currentUserPubky }: MyCollectionsStreamProps) {
   const t = useTranslations('collections');
-  const tToast = useTranslations('toast');
   const { toast } = useToast();
   const streamId = buildAuthorCollectionsStreamId(currentUserPubky);
 
@@ -136,7 +135,7 @@ function MyCollectionsStream({ currentUserPubky }: MyCollectionsStreamProps) {
     // across all three sections of the Collections landing.
     onError: () => {
       toast({
-        title: tToast('error'),
+        variant: 'error',
         description: t('loadFailed'),
       });
     },

--- a/src/components/organisms/EditCollectionDialog/EditCollectionDialog.test.tsx
+++ b/src/components/organisms/EditCollectionDialog/EditCollectionDialog.test.tsx
@@ -131,8 +131,7 @@ describe('EditCollectionDialog', () => {
     });
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Collection updated',
+      title: 'Collection updated',
     });
   });
 
@@ -147,7 +146,7 @@ describe('EditCollectionDialog', () => {
 
     await waitFor(() => {
       expect(mocks.toast).toHaveBeenCalledWith({
-        title: 'Error',
+        variant: 'error',
         description: 'Failed to update collection.',
       });
     });

--- a/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx
+++ b/src/components/organisms/NewCollectionDialog/NewCollectionDialog.test.tsx
@@ -190,8 +190,7 @@ describe('NewCollectionDialog', () => {
       });
     });
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Collection created',
+      title: 'Collection created',
     });
     await waitFor(() => {
       expect(mocks.push).toHaveBeenCalledWith('/collections/current-user/collection1');

--- a/src/hooks/useCreateCollection/useCreateCollection.test.ts
+++ b/src/hooks/useCreateCollection/useCreateCollection.test.ts
@@ -127,8 +127,7 @@ describe('useCreateCollection', () => {
       coverImage: file,
     });
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Collection created',
+      title: 'Collection created',
     });
   });
 
@@ -179,7 +178,7 @@ describe('useCreateCollection', () => {
 
     expect(saved).toBeNull();
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Error',
+      variant: 'error',
       description: 'Failed to create collection.',
     });
   });

--- a/src/hooks/useCreateCollection/useCreateCollection.ts
+++ b/src/hooks/useCreateCollection/useCreateCollection.ts
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { PostController } from '@/controllers/post/post';
 import { useCoverImagePicker, type UseCoverImagePickerResult } from '@/hooks/useCoverImagePicker/useCoverImagePicker';
+import { isAppError } from '@/libs/error/error.utils';
 import { Logger } from '@/libs/logger/logger';
 import { useToast } from '@/molecules/Toaster/use-toast';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -48,7 +49,6 @@ type UseCreateCollectionResult = {
  */
 export function useCreateCollection(): UseCreateCollectionResult {
   const t = useTranslations('collections.new');
-  const tToast = useTranslations('toast');
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const { toast } = useToast();
   const cover = useCoverImagePicker();
@@ -85,15 +85,14 @@ export function useCreateCollection(): UseCreateCollectionResult {
           useLocalFilesStore.getState().setCollectionCover(compositeId, blobUrl);
         }
         toast({
-          title: tToast('success'),
-          description: t('created'),
+          title: t('created'),
         });
         createdCollectionId = compositeId;
       } catch (error) {
         Logger.error('[useCreateCollection] Failed to create collection', { error });
         toast({
-          title: tToast('error'),
-          description: t('createFailed'),
+          variant: 'error',
+          description: isAppError(error) ? error.message : t('createFailed'),
         });
       }
     })();

--- a/src/hooks/useEditCollection/useEditCollection.test.ts
+++ b/src/hooks/useEditCollection/useEditCollection.test.ts
@@ -130,8 +130,7 @@ describe('useEditCollection', () => {
     // No new file picked → store should NOT be touched (CDN already has it).
     expect(mocks.setCollectionCover).not.toHaveBeenCalled();
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Collection updated',
+      title: 'Collection updated',
     });
   });
 
@@ -186,7 +185,7 @@ describe('useEditCollection', () => {
 
     expect(ok).toBe(false);
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Error',
+      variant: 'error',
       description: 'Failed to update collection.',
     });
   });

--- a/src/hooks/useEditCollection/useEditCollection.ts
+++ b/src/hooks/useEditCollection/useEditCollection.ts
@@ -13,6 +13,7 @@ import {
   createCollectionFormSchema,
 } from '@/hooks/useCreateCollection/useCreateCollection.types';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { isAppError } from '@/libs/error/error.utils';
 import { Logger } from '@/libs/logger/logger';
 import { parseCollectionContent, resolveCollectionCoverImage } from '@/libs/post/collectionContent';
 import { useToast } from '@/molecules/Toaster/use-toast';
@@ -48,7 +49,6 @@ type UseEditCollectionResult = {
 export function useEditCollection({ compositeCollectionId }: UseEditCollectionParams): UseEditCollectionResult {
   const tEdit = useTranslations('collections.edit');
   const tForm = useTranslations('collections.new');
-  const tToast = useTranslations('toast');
   const { toast } = useToast();
 
   const { postDetails } = usePostDetails(compositeCollectionId);
@@ -133,15 +133,14 @@ export function useEditCollection({ compositeCollectionId }: UseEditCollectionPa
         }
 
         toast({
-          title: tToast('success'),
-          description: tEdit('updated'),
+          title: tEdit('updated'),
         });
         ok = true;
       } catch (error) {
         Logger.error('[useEditCollection] Failed to edit collection', { error });
         toast({
-          title: tToast('error'),
-          description: tEdit('updateFailed'),
+          variant: 'error',
+          description: isAppError(error) ? error.message : tEdit('updateFailed'),
         });
       }
     })();

--- a/src/hooks/usePostSaveTargets/usePostSaveTargets.test.ts
+++ b/src/hooks/usePostSaveTargets/usePostSaveTargets.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '@/libs/error/error';
+import { ValidationErrorCode } from '@/libs/error/error.codes';
+import { ErrorCategory, ErrorService } from '@/libs/error/error.types';
 import { usePostSaveTargets } from './usePostSaveTargets';
 
 const mocks = vi.hoisted(() => ({
@@ -11,8 +14,8 @@ const mocks = vi.hoisted(() => ({
 
 const translations: Record<string, string> = {
   success: 'Success',
-  addedToCollection: 'Post added to {name}.',
-  removedFromCollection: 'Post removed from {name}.',
+  addedToCollection: 'Post added to collection.',
+  removedFromCollection: 'Post removed from collection.',
 };
 
 vi.mock('@/controllers/post/post', () => ({
@@ -101,12 +104,11 @@ describe('usePostSaveTargets', () => {
     });
     expect(mocks.toggleBookmark).not.toHaveBeenCalled();
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Post removed from Proof of Work.',
+      title: 'Post removed from collection.',
     });
   });
 
-  it('shows the target collection name when adding a post to a collection', async () => {
+  it('shows a generic toast when adding a post to a collection', async () => {
     const { result } = renderHook(() => usePostSaveTargets('author:post1'));
 
     await act(async () => {
@@ -119,8 +121,29 @@ describe('usePostSaveTargets', () => {
       shouldAdd: true,
     });
     expect(mocks.toast).toHaveBeenCalledWith({
-      title: 'Success',
-      description: 'Post added to AI Papers.',
+      title: 'Post added to collection.',
+    });
+  });
+
+  it('forwards the backend error message when updating a collection fails', async () => {
+    mocks.commitUpdateCollectionItem.mockRejectedValue(
+      new AppError({
+        category: ErrorCategory.Validation,
+        code: ValidationErrorCode.INVALID_INPUT,
+        message: 'Collection has too many items',
+        service: ErrorService.Local,
+        operation: 'validateCollectionContent',
+      }),
+    );
+    const { result } = renderHook(() => usePostSaveTargets('author:post1'));
+
+    await act(async () => {
+      await result.current.toggleCollection('author:collection2');
+    });
+
+    expect(mocks.toast).toHaveBeenCalledWith({
+      variant: 'error',
+      description: 'Collection has too many items',
     });
   });
 

--- a/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
+++ b/src/hooks/usePostSaveTargets/usePostSaveTargets.ts
@@ -6,6 +6,7 @@ import { postUriBuilder } from 'pubky-app-specs';
 import { PostController } from '@/controllers/post/post';
 import { useAuthoredCollections } from '@/hooks/useAuthoredCollections/useAuthoredCollections';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
+import { isAppError } from '@/libs/error/error.utils';
 import { Logger } from '@/libs/logger/logger';
 import { parseCompositeId } from '@/models/models.utils';
 import { useToast } from '@/molecules/Toaster/use-toast';
@@ -36,7 +37,6 @@ export function usePostSaveTargets(postId: string): UsePostSaveTargetsResult {
   const bookmark = useBookmark(postId);
   const { collections, isLoading: isCollectionsLoading } = useAuthoredCollections(Boolean(currentUserPubky));
   const { toast } = useToast();
-  const tToast = useTranslations('toast');
   const tSave = useTranslations('postSave');
   const [updatingCollectionIds, setUpdatingCollectionIds] = useState<Set<string>>(new Set());
   const [isCreatingCollection, setIsCreatingCollection] = useState(false);
@@ -77,16 +77,13 @@ export function usePostSaveTargets(postId: string): UsePostSaveTargetsResult {
         shouldAdd: !target.isSaved,
       });
       toast({
-        title: tToast('success'),
-        description: target.isSaved
-          ? tSave('removedFromCollection', { name: target.name })
-          : tSave('addedToCollection', { name: target.name }),
+        title: target.isSaved ? tSave('removedFromCollection') : tSave('addedToCollection'),
       });
     } catch (error) {
       Logger.error('[usePostSaveTargets] Failed to update collection membership', { error, collectionId, postId });
       toast({
-        title: tToast('error'),
-        description: tSave('updateCollectionFailed'),
+        variant: 'error',
+        description: isAppError(error) ? error.message : tSave('updateCollectionFailed'),
       });
     } finally {
       setCollectionUpdating(collectionId, false);
@@ -105,14 +102,13 @@ export function usePostSaveTargets(postId: string): UsePostSaveTargetsResult {
         items: [postUri],
       });
       toast({
-        title: tToast('success'),
-        description: tSave('collectionCreated'),
+        title: tSave('collectionCreated'),
       });
     } catch (error) {
       Logger.error('[usePostSaveTargets] Failed to create collection', { error, postId });
       toast({
-        title: tToast('error'),
-        description: tSave('createCollectionFailed'),
+        variant: 'error',
+        description: isAppError(error) ? error.message : tSave('createCollectionFailed'),
       });
     } finally {
       setIsCreatingCollection(false);


### PR DESCRIPTION
  ## 🧹 Collections Toast Review & Cleanup

  Audits and standardizes every toast notification in the Collections feature. The toasts had grown inconsistent: some
  error toasts rendered with success styling, several piped dynamic collection names into the copy, and failure messages
  hid the actual reason from the user.

  ### 🎯 What & Why

  **1. Removed dynamic values from toast copy**
  Collection toasts that interpolated the collection `{name}` (follow / unfollow / share, add / remove post) are now
  generic. This avoids having to truncate long names and keeps the messaging consistent.

  - `"You've followed the {name} collection"` → `"You've followed this collection"`
  - `"Post added to {name}."` → `"Post added to collection."`

  **2. Explicit `variant` on error toasts**
  There is no `success` variant — `variant` defaults to `'default'`, which *is* the success/checkmark styling. As a
  result, error toasts that omitted `variant` were rendering as success. Every collection error toast now explicitly sets
  `variant: 'error'`. Success toasts intentionally stay on the default variant (the established app-wide convention).

  **3. Collapsed redundant title + description**
  Aligned with the app convention of a single field per toast:

  - ✅ Success toasts → `title` only (dropped the generic `"Success"` title in favor of the descriptive message)
  - ❌ Error toasts → `variant: 'error'` + `description` only (the Toaster auto-fills the `"Error"` title for the error
  variant)

  **4. Forward backend error messages on write failures** 🔎
  Collection write failures (create, edit, add/remove item) previously showed generic copy even when the backend threw a
  readable reason. They now forward the backend message, falling back to generic copy when the error isn't an `AppError`:

  ```ts
  description: isAppError(error) ? error.message : t('updateFailed')
  ```

  This means a user who hits the 100-item cap now sees **"Collection has too many items"** instead of a generic failure —
  and the toast is correctly styled as an error rather than success.

  ### 🌍 Localization

  Removing the `{name}` placeholder from the call sites means the value is no longer passed to `next-intl`. The `{name}`
  placeholder was therefore removed from the 5 affected collection-toast keys across **all 9 locale files** (`en`, `ar`,
  `de`, `es`, `fr`, `it`, `ja`, `pt-BR`, `zh`) — otherwise non-English languages would have rendered a literal `{name}`.
  Each translation was reworded to a grammatically-correct generic equivalent, for example:

  - 🇫🇷 `"Vous suivez désormais la collection {name}"` → `"Vous suivez désormais cette collection"`
  - 🇩🇪 `"Beitrag zu {name} hinzugefügt."` → `"Beitrag zur Sammlung hinzugefügt."`
  - 🇯🇵 `"投稿を「{name}」に追加しました。"` → `"投稿をコレクションに追加しました。"`
  - 🇨🇳 `"你已分享 {name} 收藏"` → `"你已分享此收藏"`

  All 9 locale files remain valid JSON with a consistent placeholder count.

  ### 📦 Changes

  - `messages/*.json` (all 9 locales) — removed `{name}` from 5 collection toast keys
  (`card.toast.followed/unfollowed/shared`, `postSave.addedToCollection/removedFromCollection`)
  - `useCreateCollection`, `useEditCollection`, `usePostSaveTargets` — added `variant: 'error'`, collapsed to single-field
  toasts, and forward `AppError.message` on failures
  - `FollowedCollections`, `MyCollections`, `DiscoverCollections` — load-failure toasts switched to `variant: 'error'` +
  single field; removed now-unused `tToast` declarations
  - `CollectionHero`, `CollectionCard` — dropped the `{ name: toastName }` args and removed the unused `toastName` locals
  - Updated affected test suites (hooks, list sections, and the `NewCollectionDialog` / `EditCollectionDialog` integration
  tests) and added a new test asserting the backend max-items error message is forwarded

  ### 🚫 Out of scope

  - Shared hooks (`useBookmark`, `useDeletePost`, `usePostReplyRepostDialogs`) were left untouched. Their success toasts
  already use the correct default variant and the delete-failure toast already sets `variant: 'error'` — only the
  collection-specific override strings/args at the call sites were adjusted.
  - The delete-collection **dialog** body still uses `{name}` — it's a dialog (not a toast) and its call site still passes
  the value, so it's outside this toast review.

  ### ✅ Verification

  - `tsc --noEmit` clean
  - `eslint` clean
  - Full test suite green: **660 test files, 10,640 tests passing** (4 skipped, 0 failures) — including the new
  backend-error-forwarding test
  - All 9 locale files validated as parseable JSON with consistent `{name}` counts

  ### 📝 Note

  Forwarded `AppError.message` strings (e.g. `"Collection has too many items"`) are English literals, not localized —
  consistent with the app's existing copy/feedback error toasts.

  _This pull request summary was generated, for full implementation details please reference the file changes._