### PR TITLE
fix: post save picker

### DIFF
--- a/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
@@ -83,150 +83,155 @@ exports[`PostSavePicker > matches desktop picker snapshot when open 1`] = `
         data-testid="container"
       >
         <div
-          class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
-          data-cy="post-save-bookmarks-option"
-          data-orientation="vertical"
-          data-radix-collection-item=""
-          role="menuitem"
-          tabindex="-1"
+          class="flex max-h-[50dvh] flex-col overflow-y-auto gap-3"
+          data-testid="container"
         >
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-bookmark size-4"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <div
+            class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
+            data-cy="post-save-bookmarks-option"
+            data-orientation="vertical"
+            data-radix-collection-item=""
+            role="menuitem"
+            tabindex="-1"
           >
-            <path
-              d="M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z"
-            />
-          </svg>
-          <span
-            class="min-w-0 flex-1 truncate"
-            data-testid="typography"
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-bookmark size-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z"
+              />
+            </svg>
+            <span
+              class="min-w-0 flex-1 truncate"
+              data-testid="typography"
+            >
+              Bookmarks
+            </span>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-check size-4 text-brand"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 6 9 17l-5-5"
+              />
+            </svg>
+          </div>
+          <div
+            class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
+            data-orientation="vertical"
+            data-radix-collection-item=""
+            role="menuitem"
+            tabindex="-1"
           >
-            Bookmarks
-          </span>
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-check size-4 text-brand"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-library size-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16 6 4 14"
+              />
+              <path
+                d="M12 6v14"
+              />
+              <path
+                d="M8 8v12"
+              />
+              <path
+                d="M4 4v16"
+              />
+            </svg>
+            <span
+              class="min-w-0 flex-1 truncate"
+              data-testid="typography"
+            >
+              Proof of Work
+            </span>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-check size-4 text-brand"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 6 9 17l-5-5"
+              />
+            </svg>
+          </div>
+          <div
+            class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
+            data-orientation="vertical"
+            data-radix-collection-item=""
+            role="menuitem"
+            tabindex="-1"
           >
-            <path
-              d="M20 6 9 17l-5-5"
-            />
-          </svg>
-        </div>
-        <div
-          class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
-          data-orientation="vertical"
-          data-radix-collection-item=""
-          role="menuitem"
-          tabindex="-1"
-        >
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-library size-4"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m16 6 4 14"
-            />
-            <path
-              d="M12 6v14"
-            />
-            <path
-              d="M8 8v12"
-            />
-            <path
-              d="M4 4v16"
-            />
-          </svg>
-          <span
-            class="min-w-0 flex-1 truncate"
-            data-testid="typography"
-          >
-            Proof of Work
-          </span>
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-check size-4 text-brand"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M20 6 9 17l-5-5"
-            />
-          </svg>
-        </div>
-        <div
-          class="relative flex cursor-pointer items-center rounded-sm transition-colors outline-none select-none hover:text-foreground focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 w-full gap-2 p-0 text-base font-medium text-muted-foreground"
-          data-orientation="vertical"
-          data-radix-collection-item=""
-          role="menuitem"
-          tabindex="-1"
-        >
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-library size-4"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m16 6 4 14"
-            />
-            <path
-              d="M12 6v14"
-            />
-            <path
-              d="M8 8v12"
-            />
-            <path
-              d="M4 4v16"
-            />
-          </svg>
-          <span
-            class="min-w-0 flex-1 truncate"
-            data-testid="typography"
-          >
-            AI Papers
-          </span>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-library size-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16 6 4 14"
+              />
+              <path
+                d="M12 6v14"
+              />
+              <path
+                d="M8 8v12"
+              />
+              <path
+                d="M4 4v16"
+              />
+            </svg>
+            <span
+              class="min-w-0 flex-1 truncate"
+              data-testid="typography"
+            >
+              AI Papers
+            </span>
+          </div>
         </div>
         <div
           aria-orientation="horizontal"

--- a/src/components/organisms/PostSavePicker/PostSavePicker.tsx
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.tsx
@@ -168,40 +168,49 @@ function SavePickerContent({
 
   return (
     <Container overrideDefaults className={cn('flex w-full flex-col', layout === 'sheet' ? 'gap-4' : 'gap-3')}>
-      <SavePickerRow
-        layout={layout}
-        disabled={isBookmarkBusy}
-        dataCy="post-save-bookmarks-option"
-        onActivate={() => void toggleBookmark()}
+      {/* Bookmark + collections scroll as one region so a long collection list
+          can't push the "New collection" creator off-screen and out of reach.
+          `max-h-[50dvh]` keeps the picker within the viewport on both the
+          desktop dropdown and the mobile sheet. */}
+      <Container
+        overrideDefaults
+        className={cn('flex max-h-[50dvh] flex-col overflow-y-auto', layout === 'sheet' ? 'gap-4' : 'gap-3')}
       >
-        <Bookmark className="size-4" />
-        <Typography
-          as="span"
-          overrideDefaults
-          className={cn('min-w-0 flex-1 truncate', layout === 'sheet' && 'text-left')}
+        <SavePickerRow
+          layout={layout}
+          disabled={isBookmarkBusy}
+          dataCy="post-save-bookmarks-option"
+          onActivate={() => void toggleBookmark()}
         >
-          {t('bookmarks')}
-        </Typography>
-        <SaveTargetIcon isSaved={isBookmarked} isBusy={isBookmarkBusy} />
-      </SavePickerRow>
-
-      {isCollectionsLoading ? (
-        <Container overrideDefaults className="flex items-center gap-2 text-muted-foreground">
-          <Loader2 className="size-4 animate-spin" />
-          <Typography overrideDefaults className="text-base font-medium">
-            {t('loadingCollections')}
+          <Bookmark className="size-4" />
+          <Typography
+            as="span"
+            overrideDefaults
+            className={cn('min-w-0 flex-1 truncate', layout === 'sheet' && 'text-left')}
+          >
+            {t('bookmarks')}
           </Typography>
-        </Container>
-      ) : (
-        collections.map((collection) => (
-          <CollectionRow
-            key={collection.id}
-            layout={layout}
-            collection={collection}
-            onToggleCollection={toggleCollection}
-          />
-        ))
-      )}
+          <SaveTargetIcon isSaved={isBookmarked} isBusy={isBookmarkBusy} />
+        </SavePickerRow>
+
+        {isCollectionsLoading ? (
+          <Container overrideDefaults className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            <Typography overrideDefaults className="text-base font-medium">
+              {t('loadingCollections')}
+            </Typography>
+          </Container>
+        ) : (
+          collections.map((collection) => (
+            <CollectionRow
+              key={collection.id}
+              layout={layout}
+              collection={collection}
+              onToggleCollection={toggleCollection}
+            />
+          ))
+        )}
+      </Container>
 
       {layout === 'dropdown' ? <DropdownMenuSeparator /> : <Container overrideDefaults className="h-px bg-muted" />}
 

--- a/src/config/nexus.ts
+++ b/src/config/nexus.ts
@@ -4,5 +4,6 @@ export const NEXUS_URL = Env.NEXT_PUBLIC_NEXUS_URL;
 export const CDN_URL = Env.NEXT_PUBLIC_CDN_URL;
 export const NEXUS_NOTIFICATIONS_LIMIT = 30;
 export const NEXUS_POSTS_PER_PAGE = 10; // Number of posts to fetch per page in streams
+export const NEXUS_STREAM_MAX_LIMIT = 50; // Hard cap Nexus enforces on a single stream `limit`; requests above this are rejected
 export const NEXUS_USERS_PER_PAGE = 10; // Number of users to fetch per page in streams
 export const STREAM_CACHE_MAX_AGE_MS = Env.NEXT_PUBLIC_STREAM_CACHE_MAX_AGE_MS; // Maximum age for stream cache before considered stale

--- a/src/core/application/post/post.test.ts
+++ b/src/core/application/post/post.test.ts
@@ -6,6 +6,7 @@ import type { TCreatePostInput, TEditPostInput } from '@/application/post/post.t
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { TagApplication } from '@/application/tag/tag';
 import { TagKind, type TCreateTagInput } from '@/application/tag/tag.types';
+import { NEXUS_STREAM_MAX_LIMIT } from '@/config/nexus';
 import type { TFetchPostTaggersParams } from '@/controllers/post/post.types';
 import { DatabaseErrorCode } from '@/libs/error/error.codes';
 import { Err } from '@/libs/error/error.factories';
@@ -1021,6 +1022,28 @@ describe('Post Application', () => {
 
       expect(result).toHaveLength(1);
       expect(result?.[0].details.id).toBe(liveId);
+    });
+  });
+
+  describe('fetchAuthoredCollections', () => {
+    // Regression: Nexus rejects any stream `limit` above 50 with
+    // "limit exceeds maximum of 50". A previous hardcoded `limit: 100` made
+    // every collections fetch fail, so the post-save picker rendered no
+    // collections. Pin the request to the Nexus cap so it can't regress.
+    it('requests the collections stream slice within the Nexus limit cap', async () => {
+      const authorId = asOpaque<Pubky>('author-1');
+      const viewerId = asOpaque<Pubky>('viewer-1');
+      const fetchSliceSpy = vi
+        .spyOn(PostStreamApplication, 'fetchStreamSlice')
+        .mockResolvedValue({ cacheMissPostIds: [] } as never);
+      vi.spyOn(PostApplication, 'getAuthoredCollections').mockResolvedValue([]);
+
+      await PostApplication.fetchAuthoredCollections({ authorId, viewerId });
+
+      expect(fetchSliceSpy).toHaveBeenCalledTimes(1);
+      const sliceArgs = fetchSliceSpy.mock.calls[0][0];
+      expect(sliceArgs.limit).toBe(NEXUS_STREAM_MAX_LIMIT);
+      expect(sliceArgs.limit).toBeLessThanOrEqual(50);
     });
   });
 

--- a/src/core/application/post/post.ts
+++ b/src/core/application/post/post.ts
@@ -9,6 +9,7 @@ import type {
 } from '@/application/post/post.types';
 import { PostStreamApplication } from '@/application/stream/posts/post';
 import { TagApplication } from '@/application/tag/tag';
+import { NEXUS_STREAM_MAX_LIMIT } from '@/config/nexus';
 import { ModerationController } from '@/controllers/moderation/moderation';
 import type {
   TDeletePostParams,
@@ -200,7 +201,7 @@ export class PostApplication {
       streamId,
       streamHead: SKIP_FETCH_NEW_POSTS,
       streamTail: NOT_FOUND_CACHED_STREAM,
-      limit: 100,
+      limit: NEXUS_STREAM_MAX_LIMIT,
       viewerId: viewerId ?? null,
     });
 


### PR DESCRIPTION
## 🐛 Fix PostSavePicker: Nexus limit error + unreachable collections on overflow

  This PR fixes two issues affecting the save-to-collection picker (`PostSavePicker`).

  ---

  ### 1️⃣  Nexus `limit exceeds maximum of 50` error

  #### Problem

  The picker was failing to load a user's collections. Requests to the Nexus stream endpoint returned:

  ```json
  {
    "error": "Invalid input: Failed to deserialize query string: Invalid input: limit exceeds maximum of 50"
  }
```

  The root cause was a hardcoded limit: 100 in fetchAuthoredCollections (src/core/application/post/post.ts). Nexus rejects
  any stream limit above 50, so the request errored out entirely and the picker rendered zero collections.

  Call chain

  PostSavePicker
    → usePostSaveTargets
      → useAuthoredCollections
        → PostController.fetchAuthoredCollections
          → PostStreamApplication.fetchStreamSlice({ limit: 100 })  ❌

  Changes

  - ➕ Added NEXUS_STREAM_MAX_LIMIT = 50 to src/config/nexus.ts, documented as the hard cap Nexus enforces on a single
  stream limit.
  - 🔧 Updated fetchAuthoredCollections to use the new constant instead of the magic 100, so the constraint is
  self-documenting and reusable.
  - ✅ Added a regression test for fetchAuthoredCollections asserting the stream slice is requested at or below the Nexus
  cap — closing the coverage gap that let this bug ship (the Nexus-fetch path was previously untested).

  Scope & Impact

  - ✅ Single consumer. fetchAuthoredCollections / getAuthoredCollections is used only by useAuthoredCollections →
  usePostSaveTargets → PostSavePicker. The fix is isolated to the save-to-collection picker.
  - ✅ No other over-limit queries. A repo-wide search confirmed this was the only stream call exceeding 50. All other
  streams use safe per-page constants (NEXUS_POSTS_PER_PAGE = 10, NEXUS_USERS_PER_PAGE = 10, COLLECTIONS_SECTION_PAGE_SIZE
  = 20).
  - ✅ Net improvement. The picker previously fetched nothing due to the error; it now loads collections correctly.

  Consequences / Notes

  - ⚠️  This fetches a single slice, so a user with more than 50 collections would only see the first 50 in the picker.
  Since 50 is the maximum Nexus returns per request, this is the practical ceiling without adding pagination. Supporting >50 collections (looping slices until the stream is exhausted) would be a separate follow-up.

  ---
  2️⃣  Long collection lists grew off-screen and couldn't be selected

  Problem

  In SavePickerContent, the bookmark row, the full collections list, the separator, and the "New collection" creator were
  all direct children of one unbounded flex column. With many collections (up to the 50 we now fetch), the list grew past
  the viewport — rows at the bottom, including the create-collection input, became unreachable in both the desktop
  dropdown and the mobile sheet.

  Changes

  - 📜 Wrapped only the bookmark row + collections list in a scroll region (max-h-[50dvh] overflow-y-auto), matching the
  existing codebase pattern (MentionPopover, UserInfoPopover).
  - 📌 Kept the separator and "New collection" creator pinned below the scroll region, so the create field is always
  reachable no matter how many collections exist.
  - 🎚️  50dvh keeps the picker within the viewport on both layouts; preserved the existing gap-4 / gap-3 row spacing inside
  the scroll container.

  Note

  The scroll was scoped to the bookmark + collections region rather than the whole panel, specifically so the
  create-collection input never scrolls out of view.

  ---
  ✅ Verification

  - ✅ tsc --noEmit passes
  - ✅ eslint passes on all changed files
  - ✅ post.test.ts passes (49/49), including the new fetchAuthoredCollections regression test
  - ✅ PostSavePicker.test.tsx passes (14/14); desktop picker snapshot updated to reflect the new scroll container

  This pull request summary was generated, for full implementation details please reference the file changes.