### PR TITLE
fix(ui): wire Friends empty state buttons to Who to Follow and Hot

### DIFF
--- a/src/components/molecules/FollowersEmpty/FollowersEmpty.test.tsx
+++ b/src/components/molecules/FollowersEmpty/FollowersEmpty.test.tsx
@@ -1,12 +1,51 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FollowersEmpty } from './FollowersEmpty';
+
+const mocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(<T,>(action: () => T) => action()),
+}));
+
+vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
+  useRequireAuth: () => ({
+    isAuthenticated: true,
+    requireAuth: mocks.requireAuth,
+  }),
+}));
+
+vi.mock('@/organisms/DialogNewPost/DialogNewPost', () => ({
+  DialogNewPost: ({ open, onOpenChangeAction }: { open: boolean; onOpenChangeAction: (open: boolean) => void }) => (
+    <div data-testid="dialog-new-post" data-open={open}>
+      <button type="button" data-testid="mock-close-btn" onClick={() => onOpenChangeAction(false)}>
+        Close
+      </button>
+    </div>
+  ),
+}));
 
 // Mock atoms
 vi.mock('@/atoms/Button/Button', () => {
   return {
-    Button: ({ children, className, variant }: { children: React.ReactNode; className?: string; variant?: string }) => (
-      <button data-testid="button" className={className} data-variant={variant}>
+    Button: ({
+      children,
+      className,
+      variant,
+      onClick,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      variant?: string;
+      onClick?: () => void;
+    }) => (
+      <button
+        type="button"
+        data-testid="button"
+        className={className}
+        data-variant={variant}
+        onClick={onClick}
+        {...props}
+      >
         {children}
       </button>
     ),
@@ -51,9 +90,25 @@ vi.mock('@/atoms/Typography/Typography', () => {
 });
 
 describe('FollowersEmpty', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockImplementation(<T,>(action: () => T) => action());
+  });
+
   it('renders title', () => {
     render(<FollowersEmpty />);
     expect(screen.getByText(/Looking for followers?/i)).toBeInTheDocument();
+  });
+
+  it('opens the new post dialog when Create a Post is clicked', () => {
+    render(<FollowersEmpty />);
+
+    expect(screen.getByTestId('dialog-new-post')).toHaveAttribute('data-open', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: /Create a Post/i }));
+
+    expect(mocks.requireAuth).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('dialog-new-post')).toHaveAttribute('data-open', 'true');
   });
 });
 

--- a/src/components/molecules/FollowersEmpty/FollowersEmpty.test.tsx.snap
+++ b/src/components/molecules/FollowersEmpty/FollowersEmpty.test.tsx.snap
@@ -71,8 +71,10 @@ exports[`FollowersEmpty - Snapshots > matches snapshot with default props 1`] = 
   </div>
   <button
     class="gap-2"
+    data-cy="profile-followers-empty-create-post"
     data-testid="button"
     data-variant="default"
+    type="button"
   >
     <svg
       aria-hidden="true"

--- a/src/components/molecules/FollowersEmpty/FollowersEmpty.tsx
+++ b/src/components/molecules/FollowersEmpty/FollowersEmpty.tsx
@@ -1,56 +1,75 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import { Plus, UsersRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
+import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
+import { DialogNewPost } from '@/organisms/DialogNewPost/DialogNewPost';
 
 export function FollowersEmpty() {
   const t = useTranslations('profile.empty.followers');
+  const [newPostOpen, setNewPostOpen] = useState(false);
+  const { requireAuth } = useRequireAuth();
+
+  const handleCreatePostClick = () => {
+    requireAuth(() => setNewPostOpen(true));
+  };
 
   return (
-    <Container data-cy="profile-followers-empty" className="relative items-center gap-6 px-0 py-6">
-      {/* Background image */}
-      <Image
-        src="/images/connections-empty-state.webp"
-        alt={t('alt')}
-        fill
-        className="pointer-events-none object-contain object-center"
-        aria-hidden="true"
-      />
+    <>
+      <Container data-cy="profile-followers-empty" className="relative items-center gap-6 px-0 py-6">
+        {/* Background image */}
+        <Image
+          src="/images/connections-empty-state.webp"
+          alt={t('alt')}
+          fill
+          className="pointer-events-none object-contain object-center"
+          aria-hidden="true"
+        />
 
-      {/* Icon */}
-      <Container overrideDefaults={true} className="flex items-center rounded-full bg-brand/16 p-6">
-        <UsersRound className="size-12 text-brand" strokeWidth={1.5} />
+        {/* Icon */}
+        <Container overrideDefaults={true} className="flex items-center rounded-full bg-brand/16 p-6">
+          <UsersRound className="size-12 text-brand" strokeWidth={1.5} />
+        </Container>
+
+        {/* Title and subtitle */}
+        <Container className="items-center gap-6">
+          <Typography as="h3" size="lg">
+            {t('title')}
+          </Typography>
+
+          <Typography className="text-center text-base leading-6 font-medium text-secondary-foreground">
+            {t('subtitle')
+              .split('\n')
+              .map((line, i) => (
+                <span key={i}>
+                  {line}
+                  {i === 0 && <br />}
+                </span>
+              ))}
+          </Typography>
+        </Container>
+
+        {/* CTA */}
+        <Button
+          type="button"
+          variant="default"
+          size="default"
+          className="gap-2"
+          data-cy="profile-followers-empty-create-post"
+          onClick={handleCreatePostClick}
+        >
+          <Plus className="size-4" />
+          <Typography as="span" overrideDefaults={true}>
+            {t('createPost')}
+          </Typography>
+        </Button>
       </Container>
-
-      {/* Title and subtitle */}
-      <Container className="items-center gap-6">
-        <Typography as="h3" size="lg">
-          {t('title')}
-        </Typography>
-
-        <Typography className="text-center text-base leading-6 font-medium text-secondary-foreground">
-          {t('subtitle')
-            .split('\n')
-            .map((line, i) => (
-              <span key={i}>
-                {line}
-                {i === 0 && <br />}
-              </span>
-            ))}
-        </Typography>
-      </Container>
-
-      {/* CTA */}
-      <Button variant="default" size="default" className="gap-2">
-        <Plus className="size-4" />
-        <Typography as="span" overrideDefaults={true}>
-          {t('createPost')}
-        </Typography>
-      </Button>
-    </Container>
+      <DialogNewPost open={newPostOpen} onOpenChangeAction={setNewPostOpen} />
+    </>
   );
 }

--- a/src/components/molecules/FollowingEmpty/FollowingEmpty.test.tsx
+++ b/src/components/molecules/FollowingEmpty/FollowingEmpty.test.tsx
@@ -1,12 +1,49 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/app/routes';
 import { FollowingEmpty } from './FollowingEmpty';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  requireAuth: vi.fn(<T,>(action: () => T) => action()),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
+  useRequireAuth: () => ({
+    isAuthenticated: true,
+    requireAuth: mocks.requireAuth,
+  }),
+}));
 
 // Mock atoms
 vi.mock('@/atoms/Button/Button', () => {
   return {
-    Button: ({ children, className, variant }: { children: React.ReactNode; className?: string; variant?: string }) => (
-      <button data-testid="button" className={className} data-variant={variant}>
+    Button: ({
+      children,
+      className,
+      variant,
+      onClick,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      variant?: string;
+      onClick?: () => void;
+    }) => (
+      <button
+        type="button"
+        data-testid="button"
+        className={className}
+        data-variant={variant}
+        onClick={onClick}
+        {...props}
+      >
         {children}
       </button>
     ),
@@ -51,9 +88,31 @@ vi.mock('@/atoms/Typography/Typography', () => {
 });
 
 describe('FollowingEmpty', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockImplementation(<T,>(action: () => T) => action());
+  });
+
   it('renders title', () => {
     render(<FollowingEmpty />);
     expect(screen.getByText(/You are the algorithm/i)).toBeInTheDocument();
+  });
+
+  it('navigates to Who to Follow when the first button is clicked', () => {
+    render(<FollowingEmpty />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Who to Follow/i }));
+
+    expect(mocks.requireAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.push).toHaveBeenCalledWith(APP_ROUTES.WHO_TO_FOLLOW);
+  });
+
+  it('navigates to Hot when Popular Users is clicked', () => {
+    render(<FollowingEmpty />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Popular Users/i }));
+
+    expect(mocks.push).toHaveBeenCalledWith(APP_ROUTES.HOT);
   });
 });
 

--- a/src/components/molecules/FollowingEmpty/FollowingEmpty.test.tsx.snap
+++ b/src/components/molecules/FollowingEmpty/FollowingEmpty.test.tsx.snap
@@ -78,8 +78,10 @@ exports[`FollowingEmpty - Snapshots > matches snapshot with default props 1`] = 
   >
     <button
       class="gap-2"
+      data-cy="profile-following-empty-who-to-follow"
       data-testid="button"
       data-variant="secondary"
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -117,8 +119,10 @@ exports[`FollowingEmpty - Snapshots > matches snapshot with default props 1`] = 
     </button>
     <button
       class="gap-2"
+      data-cy="profile-following-empty-popular-users"
       data-testid="button"
       data-variant="secondary"
+      type="button"
     >
       <svg
         aria-hidden="true"

--- a/src/components/molecules/FollowingEmpty/FollowingEmpty.tsx
+++ b/src/components/molecules/FollowingEmpty/FollowingEmpty.tsx
@@ -1,15 +1,28 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { UserRoundPlus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { APP_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
+import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 
 export function FollowingEmpty() {
   const t = useTranslations('profile.empty.following');
   const tNav = useTranslations('profile.navigation');
+  const router = useRouter();
+  const { requireAuth } = useRequireAuth();
+
+  const handleWhoToFollowClick = () => {
+    requireAuth(() => router.push(APP_ROUTES.WHO_TO_FOLLOW));
+  };
+
+  const handlePopularUsersClick = () => {
+    router.push(APP_ROUTES.HOT);
+  };
 
   return (
     <Container data-cy="profile-following-empty" className="relative items-center gap-6 px-0 py-6">
@@ -47,13 +60,27 @@ export function FollowingEmpty() {
 
       {/* Action Buttons */}
       <Container className="items-center justify-center gap-3 lg:flex-row">
-        <Button variant="secondary" size="default" className="gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="default"
+          className="gap-2"
+          data-cy="profile-following-empty-who-to-follow"
+          onClick={handleWhoToFollowClick}
+        >
           <UserRoundPlus className="size-4" />
           <Typography as="span" overrideDefaults={true}>
             {tNav('whoToFollow')}
           </Typography>
         </Button>
-        <Button variant="secondary" size="default" className="gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="default"
+          className="gap-2"
+          data-cy="profile-following-empty-popular-users"
+          onClick={handlePopularUsersClick}
+        >
           <UserRoundPlus className="size-4" />
           <Typography as="span" overrideDefaults={true}>
             {tNav('popularUsers')}

--- a/src/components/molecules/FriendsEmpty/FriendsEmpty.test.tsx
+++ b/src/components/molecules/FriendsEmpty/FriendsEmpty.test.tsx
@@ -1,12 +1,49 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/app/routes';
 import { FriendsEmpty } from './FriendsEmpty';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  requireAuth: vi.fn(<T,>(action: () => T) => action()),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
+  useRequireAuth: () => ({
+    isAuthenticated: true,
+    requireAuth: mocks.requireAuth,
+  }),
+}));
 
 // Mock atoms
 vi.mock('@/atoms/Button/Button', () => {
   return {
-    Button: ({ children, className, variant }: { children: React.ReactNode; className?: string; variant?: string }) => (
-      <button data-testid="button" className={className} data-variant={variant}>
+    Button: ({
+      children,
+      className,
+      variant,
+      onClick,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      variant?: string;
+      onClick?: () => void;
+    }) => (
+      <button
+        type="button"
+        data-testid="button"
+        className={className}
+        data-variant={variant}
+        onClick={onClick}
+        {...props}
+      >
         {children}
       </button>
     ),
@@ -51,9 +88,31 @@ vi.mock('@/atoms/Typography/Typography', () => {
 });
 
 describe('FriendsEmpty', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuth.mockImplementation(<T,>(action: () => T) => action());
+  });
+
   it('renders title', () => {
     render(<FriendsEmpty />);
     expect(screen.getByText(/No friends yet/i)).toBeInTheDocument();
+  });
+
+  it('navigates to Who to Follow when the first button is clicked', () => {
+    render(<FriendsEmpty />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Who to Follow/i }));
+
+    expect(mocks.requireAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.push).toHaveBeenCalledWith(APP_ROUTES.WHO_TO_FOLLOW);
+  });
+
+  it('navigates to Hot when Popular Users is clicked', () => {
+    render(<FriendsEmpty />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Popular Users/i }));
+
+    expect(mocks.push).toHaveBeenCalledWith(APP_ROUTES.HOT);
   });
 });
 

--- a/src/components/molecules/FriendsEmpty/FriendsEmpty.test.tsx.snap
+++ b/src/components/molecules/FriendsEmpty/FriendsEmpty.test.tsx.snap
@@ -78,8 +78,10 @@ exports[`FriendsEmpty - Snapshots > matches snapshot with default props 1`] = `
   >
     <button
       class="gap-2"
+      data-cy="profile-friends-empty-who-to-follow"
       data-testid="button"
       data-variant="secondary"
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -117,8 +119,10 @@ exports[`FriendsEmpty - Snapshots > matches snapshot with default props 1`] = `
     </button>
     <button
       class="gap-2"
+      data-cy="profile-friends-empty-popular-users"
       data-testid="button"
       data-variant="secondary"
+      type="button"
     >
       <svg
         aria-hidden="true"

--- a/src/components/molecules/FriendsEmpty/FriendsEmpty.tsx
+++ b/src/components/molecules/FriendsEmpty/FriendsEmpty.tsx
@@ -1,15 +1,28 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { UserRoundPlus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { APP_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
+import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 
 export function FriendsEmpty() {
   const t = useTranslations('profile.empty.friends');
   const tNav = useTranslations('profile.navigation');
+  const router = useRouter();
+  const { requireAuth } = useRequireAuth();
+
+  const handleWhoToFollowClick = () => {
+    requireAuth(() => router.push(APP_ROUTES.WHO_TO_FOLLOW));
+  };
+
+  const handlePopularUsersClick = () => {
+    router.push(APP_ROUTES.HOT);
+  };
 
   return (
     <Container data-cy="profile-friends-empty" className="relative items-center gap-6 px-0 py-6">
@@ -47,13 +60,27 @@ export function FriendsEmpty() {
 
       {/* Action Buttons */}
       <Container className="items-center justify-center gap-3 lg:flex-row">
-        <Button variant="secondary" size="default" className="gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="default"
+          className="gap-2"
+          data-cy="profile-friends-empty-who-to-follow"
+          onClick={handleWhoToFollowClick}
+        >
           <UserRoundPlus className="size-4" />
           <Typography as="span" overrideDefaults={true}>
             {tNav('whoToFollow')}
           </Typography>
         </Button>
-        <Button variant="secondary" size="default" className="gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="default"
+          className="gap-2"
+          data-cy="profile-friends-empty-popular-users"
+          onClick={handlePopularUsersClick}
+        >
           <UserRoundPlus className="size-4" />
           <Typography as="span" overrideDefaults={true}>
             {tNav('popularUsers')}


### PR DESCRIPTION
## Summary
- fix #2092
- Profile connection empty states rendered CTA buttons without handlers, so clicks did nothing
- Wire all three empty states to the correct destinations, matching existing app patterns (Who to Follow sidebar, FAB create-post flow)

## Changes
- **FriendsEmpty** — Who to Follow → `/who-to-follow` (auth-gated via `requireAuth`); Popular Users → `/hot`
- **FollowingEmpty** — same navigation handlers as Friends (identical inert-button bug)
- **FollowersEmpty** — Create a Post opens `DialogNewPost` after `requireAuth`, matching the FAB create-post flow
- Add `data-cy` attributes on all empty-state CTAs for E2E targeting
- Extend unit tests and update snapshots for `FriendsEmpty`, `FollowingEmpty`, and `FollowersEmpty`


https://github.com/user-attachments/assets/ea2c886b-6be5-43c0-92d0-d3c307ff504b


## Test plan
- [x] `/profile/{pubky}/friends` (empty) — **Who to Follow** → `/who-to-follow`; **Popular Users** → `/hot`
- [x] `/profile/{pubky}/following` (empty) — same button behavior as Friends
- [x] `/profile/{pubky}/followers` (empty) — **Create a Post** opens new-post dialog when signed in
- [x] Signed-out on a public profile: **Popular Users** and **Create a Post** (after sign-in prompt) behave correctly; **Who to Follow** opens sign-in dialog
- [x] `npm run test -- src/components/molecules/FriendsEmpty/FriendsEmpty.test.tsx`
- [x] `npm run test -- src/components/molecules/FollowingEmpty/FollowingEmpty.test.tsx`
- [x] `npm run test -- src/components/molecules/FollowersEmpty/FollowersEmpty.test.tsx`

## Notes
- On mobile Hot, the Users tab is not pre-selected when navigating via Popular Users (Hot has no URL section param today)
- No other empty-state components in the profile/connections area had inert navigation CTAs