### PR TITLE
Improve landing page design on mobile

### DIFF
--- a/src/components/molecules/ActionButtons/ActionButtons.test.tsx.snap
+++ b/src/components/molecules/ActionButtons/ActionButtons.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`ActionButtons - Snapshots > matches snapshot with all callbacks 1`] = `
 <div
-  class="mx-auto w-full flex-col flex gap-3 sm:flex-row sm:items-center"
+  class="mx-auto w-full flex-col grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center"
   data-testid="container"
 >
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal w-full sm:w-auto"
     data-cy="learn-btn"
     data-size="lg"
     data-slot="button"
@@ -36,7 +36,7 @@ exports[`ActionButtons - Snapshots > matches snapshot with all callbacks 1`] = `
     Learn
   </button>
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal w-full sm:w-auto"
     data-cy="explore-btn"
     data-size="lg"
     data-slot="button"
@@ -68,7 +68,7 @@ exports[`ActionButtons - Snapshots > matches snapshot with all callbacks 1`] = `
     Explore
   </button>
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal px-10 sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
     data-size="lg"
     data-slot="button"
     data-variant="brand"
@@ -109,11 +109,11 @@ exports[`ActionButtons - Snapshots > matches snapshot with all callbacks 1`] = `
 
 exports[`ActionButtons - Snapshots > matches snapshot with create account and explore callbacks 1`] = `
 <div
-  class="mx-auto w-full flex-col flex gap-3 sm:flex-row sm:items-center"
+  class="mx-auto w-full flex-col grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center"
   data-testid="container"
 >
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-auto gap-2 px-8 py-5 text-sm font-bold leading-normal w-full sm:w-auto col-span-2 sm:col-span-1"
     data-cy="explore-btn"
     data-size="lg"
     data-slot="button"
@@ -145,7 +145,7 @@ exports[`ActionButtons - Snapshots > matches snapshot with create account and ex
     Explore
   </button>
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal px-10 sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
     data-size="lg"
     data-slot="button"
     data-variant="brand"
@@ -186,11 +186,11 @@ exports[`ActionButtons - Snapshots > matches snapshot with create account and ex
 
 exports[`ActionButtons - Snapshots > matches snapshot with create account callback only 1`] = `
 <div
-  class="mx-auto w-full flex-col flex gap-3 sm:flex-row sm:items-center"
+  class="mx-auto w-full flex-col grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center"
   data-testid="container"
 >
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal px-10 sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
     data-size="lg"
     data-slot="button"
     data-variant="brand"
@@ -231,11 +231,11 @@ exports[`ActionButtons - Snapshots > matches snapshot with create account callba
 
 exports[`ActionButtons - Snapshots > matches snapshot with custom className 1`] = `
 <div
-  class="mx-auto w-full flex-col flex gap-3 sm:flex-row sm:items-center custom-action-buttons"
+  class="mx-auto w-full flex-col grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center custom-action-buttons"
   data-testid="container"
 >
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal px-10 sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
     data-size="lg"
     data-slot="button"
     data-variant="brand"
@@ -276,11 +276,11 @@ exports[`ActionButtons - Snapshots > matches snapshot with custom className 1`] 
 
 exports[`ActionButtons - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="mx-auto w-full flex-col flex gap-3 sm:flex-row sm:items-center"
+  class="mx-auto w-full flex-col grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center"
   data-testid="container"
 >
   <button
-    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal px-10 sm:w-auto"
+    class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer rounded-full border shadow-xs bg-brand text-background border-brand hover:bg-brand/90 h-auto gap-2 py-5 text-sm font-bold leading-normal order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
     data-size="lg"
     data-slot="button"
     data-variant="brand"

--- a/src/components/molecules/ActionButtons/ActionButtons.tsx
+++ b/src/components/molecules/ActionButtons/ActionButtons.tsx
@@ -15,15 +15,21 @@ interface ActionButtonsProps {
 
 export function ActionButtons({ className, onLearn, onCreateAccount, onExplore, ...props }: ActionButtonsProps) {
   const t = useTranslations('landing');
+  const hasBothSecondaryActions = Boolean(onLearn && onExplore);
+  const secondaryActionClassName = cn('w-full sm:w-auto', !hasBothSecondaryActions && 'col-span-2 sm:col-span-1');
 
   return (
-    <Container className={cn('gap-3 sm:flex-row sm:items-center', className)} {...props}>
+    <Container
+      display="grid"
+      className={cn('grid-cols-2 gap-3 sm:flex sm:flex-row sm:items-center', className)}
+      {...props}
+    >
       {onLearn && (
         <Button
           id="learn-btn"
           data-cy="learn-btn"
           variant="secondary"
-          className="sm:w-auto"
+          className={secondaryActionClassName}
           size="lg"
           onClick={onLearn}
         >
@@ -36,7 +42,7 @@ export function ActionButtons({ className, onLearn, onCreateAccount, onExplore, 
           id="explore-btn"
           data-cy="explore-btn"
           variant="secondary"
-          className="sm:w-auto"
+          className={secondaryActionClassName}
           size="lg"
           onClick={onExplore}
         >
@@ -44,7 +50,13 @@ export function ActionButtons({ className, onLearn, onCreateAccount, onExplore, 
           {t('explore')}
         </Button>
       )}
-      <Button id="create-account-btn" variant="brand" className="px-10 sm:w-auto" size="lg" onClick={onCreateAccount}>
+      <Button
+        id="create-account-btn"
+        variant="brand"
+        className="order-first col-span-2 w-full px-10 sm:order-none sm:col-span-1 sm:w-auto"
+        size="lg"
+        onClick={onCreateAccount}
+      >
         <UserRoundPlus className="h-4 w-4" />
         {t('join')}
       </Button>

--- a/src/components/molecules/Home/Home.test.tsx.snap
+++ b/src/components/molecules/Home/Home.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`Home - Snapshots > matches snapshot for HomeSectionTitle with default p
   data-testid="container"
 >
   <h2
-    class="self-center font-light text-muted-foreground sm:text-3xl"
+    class="self-center text-xl font-light text-muted-foreground sm:text-3xl"
     data-size="md"
     data-testid="typography"
   >

--- a/src/components/molecules/Home/Home.test.tsx.snap
+++ b/src/components/molecules/Home/Home.test.tsx.snap
@@ -159,7 +159,6 @@ exports[`Home - Snapshots > matches snapshot for HomeSectionTitle with default p
 >
   <h2
     class="self-center text-xl font-light text-muted-foreground sm:text-3xl"
-    data-size="md"
     data-testid="typography"
   >
     Your keys, your content, your rules.

--- a/src/components/molecules/Home/Home.tsx
+++ b/src/components/molecules/Home/Home.tsx
@@ -94,7 +94,7 @@ export const HomeSectionTitle = () => {
   const t = useTranslations('landing');
   return (
     <Container className="flex-row items-start gap-2">
-      <Typography as="h2" size="md" className="self-center text-xl font-light text-muted-foreground sm:text-3xl">
+      <Typography as="h2" overrideDefaults className="self-center text-xl font-light text-muted-foreground sm:text-3xl">
         {t('subtitle')}
       </Typography>
     </Container>

--- a/src/components/molecules/Home/Home.tsx
+++ b/src/components/molecules/Home/Home.tsx
@@ -94,7 +94,7 @@ export const HomeSectionTitle = () => {
   const t = useTranslations('landing');
   return (
     <Container className="flex-row items-start gap-2">
-      <Typography as="h2" size="md" className="self-center font-light text-muted-foreground sm:text-3xl">
+      <Typography as="h2" size="md" className="self-center text-xl font-light text-muted-foreground sm:text-3xl">
         {t('subtitle')}
       </Typography>
     </Container>

--- a/src/components/templates/Public/Landing/LandingBrokenSection.tsx
+++ b/src/components/templates/Public/Landing/LandingBrokenSection.tsx
@@ -79,7 +79,7 @@ export function LandingBrokenSection() {
                 <span className={`absolute size-5 rotate-45 bg-brand ${tipClassName}`} aria-hidden="true" />
               </div>
               <div className="mt-6 min-w-0 lg:hidden">
-                <Typography size="md" className="text-muted-foreground">
+                <Typography size="md" className="text-sm text-muted-foreground sm:text-base">
                   {t(`features.${key}.description`)}
                 </Typography>
               </div>

--- a/src/components/templates/Public/Landing/LandingBrokenSection.tsx
+++ b/src/components/templates/Public/Landing/LandingBrokenSection.tsx
@@ -79,7 +79,7 @@ export function LandingBrokenSection() {
                 <span className={`absolute size-5 rotate-45 bg-brand ${tipClassName}`} aria-hidden="true" />
               </div>
               <div className="mt-6 min-w-0 lg:hidden">
-                <Typography size="md" className="text-sm text-muted-foreground sm:text-base">
+                <Typography size="sm" className="text-muted-foreground sm:text-base">
                   {t(`features.${key}.description`)}
                 </Typography>
               </div>

--- a/src/components/templates/Public/Landing/LandingFreedomSection.tsx
+++ b/src/components/templates/Public/Landing/LandingFreedomSection.tsx
@@ -115,7 +115,7 @@ export function LandingFreedomSection() {
               <Typography as="h3" size="lg" className="text-xl">
                 {t(`features.${activeFeature.key}.title`)}
               </Typography>
-              <Typography size="md" className="mt-1 text-sm text-muted-foreground sm:text-base">
+              <Typography size="sm" className="mt-1 text-muted-foreground sm:text-base">
                 {t(`features.${activeFeature.key}.description`)}
               </Typography>
             </div>

--- a/src/components/templates/Public/Landing/LandingFreedomSection.tsx
+++ b/src/components/templates/Public/Landing/LandingFreedomSection.tsx
@@ -115,7 +115,7 @@ export function LandingFreedomSection() {
               <Typography as="h3" size="lg" className="text-xl">
                 {t(`features.${activeFeature.key}.title`)}
               </Typography>
-              <Typography size="md" className="mt-1 text-muted-foreground">
+              <Typography size="md" className="mt-1 text-sm text-muted-foreground sm:text-base">
                 {t(`features.${activeFeature.key}.description`)}
               </Typography>
             </div>

--- a/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
+++ b/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
@@ -49,7 +49,7 @@ export function LandingHowItWorksSection() {
                 <Typography as="h3" size="lg" className="relative text-xl">
                   {t(`features.${key}.title`)}
                 </Typography>
-                <Typography size="md" className="relative mt-1 text-muted-foreground">
+                <Typography size="md" className="relative mt-1 text-sm text-muted-foreground sm:text-base">
                   {t(`features.${key}.description`)}
                 </Typography>
               </div>

--- a/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
+++ b/src/components/templates/Public/Landing/LandingHowItWorksSection.tsx
@@ -49,7 +49,7 @@ export function LandingHowItWorksSection() {
                 <Typography as="h3" size="lg" className="relative text-xl">
                   {t(`features.${key}.title`)}
                 </Typography>
-                <Typography size="md" className="relative mt-1 text-sm text-muted-foreground sm:text-base">
+                <Typography size="sm" className="relative mt-1 text-muted-foreground sm:text-base">
                   {t(`features.${key}.description`)}
                 </Typography>
               </div>


### PR DESCRIPTION
## Summary

DESIGN UPDATES
- Updates the landing hero CTA layout on mobile so Join is full width above Learn and Explore which are reduced in importance.
- Keeps the existing horizontal CTA layout from `sm` and up.
- Increases the landing hero subtitle size on mobile.
- Reduces landing card paragraph text to `sm` on mobile while preserving larger breakpoint sizing.
- Updates affected snapshots.

## Validation

- `npx vitest run src/components/molecules/ActionButtons/ActionButtons.test.tsx -u`
- `npx vitest run src/components/molecules/Home/Home.test.tsx -u`
- `npx eslint src/components/molecules/Home/Home.tsx src/components/molecules/ActionButtons/ActionButtons.tsx`
- `npx eslint src/components/templates/Public/Landing/LandingHowItWorksSection.tsx src/components/templates/Public/Landing/LandingFreedomSection.tsx src/components/templates/Public/Landing/LandingBrokenSection.tsx`
- `git diff --check`