### PR TITLE
fix(CreateProfileForm): update navigation class for improved layout consistency

### DIFF
--- a/src/components/organisms/CreateProfileForm/CreateProfileForm.tsx
+++ b/src/components/organisms/CreateProfileForm/CreateProfileForm.tsx
@@ -212,7 +212,7 @@ export const CreateProfileForm = () => {
           </Container>
         </Card>
         <ProfileNavigation
-          className="onboarding-nav mt-auto lg:pt-0"
+          className="onboarding-nav mt-auto flex-col sm:flex-row lg:pt-0"
           backButtonDisabled={true}
           continueButtonDisabled={isSubmitDisabled}
           continueButtonLoading={state.isSaving}


### PR DESCRIPTION
resolves #1934 

Onboarding registration profile was overflowing and not being in 2 different rows.



Desired behavior:
<img width="369" height="668" alt="Screenshot 2026-07-01 at 16 21 47" src="https://github.com/user-attachments/assets/ef435845-21ea-4224-b215-d953352cbe8c" />




Desktop has not being affected
<img width="1021" height="800" alt="Screenshot 2026-07-01 at 16 24 43" src="https://github.com/user-attachments/assets/1adc6deb-c804-4101-a3f0-5e581e0dec17" />
