### PR TITLE
fix: route shared collection previews to collection pages

### DIFF
--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.test.tsx
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.test.tsx
@@ -5,17 +5,12 @@ import { PostPreviewCard } from './PostPreviewCard';
 
 // Mock hooks
 const mockNavigateToPost = vi.fn();
-const mockRouterPush = vi.fn();
+const mockNavigateToCollection = vi.fn();
 const mockTtlRef = vi.fn();
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: mockRouterPush,
-  }),
-}));
-
 vi.mock('@/hooks/usePostNavigation/usePostNavigation', () => ({
   usePostNavigation: () => ({
     navigateToPost: mockNavigateToPost,
+    navigateToCollection: mockNavigateToCollection,
   }),
 }));
 
@@ -115,7 +110,7 @@ const resolvedCollectionPost = {
 describe('PostPreviewCard', () => {
   beforeEach(() => {
     mockNavigateToPost.mockClear();
-    mockRouterPush.mockClear();
+    mockNavigateToCollection.mockClear();
     mockUsePostDetails.mockReturnValue(resolvedPost);
   });
 
@@ -150,7 +145,7 @@ describe('PostPreviewCard', () => {
     fireEvent.click(card);
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockNavigateToCollection).not.toHaveBeenCalled();
   });
 
   it('navigates to post page on Enter key', () => {
@@ -160,7 +155,7 @@ describe('PostPreviewCard', () => {
     fireEvent.keyDown(card, { key: 'Enter' });
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockNavigateToCollection).not.toHaveBeenCalled();
   });
 
   it('navigates to post page on Space key', () => {
@@ -170,7 +165,7 @@ describe('PostPreviewCard', () => {
     fireEvent.keyDown(card, { key: ' ' });
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockNavigateToCollection).not.toHaveBeenCalled();
   });
 
   it('navigates collection previews to the collection page on click', () => {
@@ -180,7 +175,7 @@ describe('PostPreviewCard', () => {
     const card = screen.getByTestId('card');
     fireEvent.click(card);
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToCollection).toHaveBeenCalledWith('owner123:collection456');
     expect(mockNavigateToPost).not.toHaveBeenCalled();
   });
 
@@ -191,7 +186,7 @@ describe('PostPreviewCard', () => {
     const card = screen.getByTestId('card');
     fireEvent.keyDown(card, { key: 'Enter' });
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToCollection).toHaveBeenCalledWith('owner123:collection456');
     expect(mockNavigateToPost).not.toHaveBeenCalled();
   });
 
@@ -202,7 +197,7 @@ describe('PostPreviewCard', () => {
     const card = screen.getByTestId('card');
     fireEvent.keyDown(card, { key: ' ' });
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToCollection).toHaveBeenCalledWith('owner123:collection456');
     expect(mockNavigateToPost).not.toHaveBeenCalled();
   });
 

--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.test.tsx
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.test.tsx
@@ -5,7 +5,14 @@ import { PostPreviewCard } from './PostPreviewCard';
 
 // Mock hooks
 const mockNavigateToPost = vi.fn();
+const mockRouterPush = vi.fn();
 const mockTtlRef = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
 vi.mock('@/hooks/usePostNavigation/usePostNavigation', () => ({
   usePostNavigation: () => ({
     navigateToPost: mockNavigateToPost,
@@ -100,9 +107,15 @@ const resolvedPost = {
   isLoading: false,
 };
 
+const resolvedCollectionPost = {
+  postDetails: { id: 'owner123:collection456', kind: 'collection' } as never,
+  isLoading: false,
+};
+
 describe('PostPreviewCard', () => {
   beforeEach(() => {
     mockNavigateToPost.mockClear();
+    mockRouterPush.mockClear();
     mockUsePostDetails.mockReturnValue(resolvedPost);
   });
 
@@ -137,6 +150,7 @@ describe('PostPreviewCard', () => {
     fireEvent.click(card);
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it('navigates to post page on Enter key', () => {
@@ -146,6 +160,7 @@ describe('PostPreviewCard', () => {
     fireEvent.keyDown(card, { key: 'Enter' });
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it('navigates to post page on Space key', () => {
@@ -155,6 +170,47 @@ describe('PostPreviewCard', () => {
     fireEvent.keyDown(card, { key: ' ' });
 
     expect(mockNavigateToPost).toHaveBeenCalledWith('test-post-123');
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('navigates collection previews to the collection page on click', () => {
+    mockUsePostDetails.mockReturnValue(resolvedCollectionPost);
+    render(<PostPreviewCard postId="owner123:collection456" />);
+
+    const card = screen.getByTestId('card');
+    fireEvent.click(card);
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToPost).not.toHaveBeenCalled();
+  });
+
+  it('navigates collection previews to the collection page on Enter key', () => {
+    mockUsePostDetails.mockReturnValue(resolvedCollectionPost);
+    render(<PostPreviewCard postId="owner123:collection456" />);
+
+    const card = screen.getByTestId('card');
+    fireEvent.keyDown(card, { key: 'Enter' });
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToPost).not.toHaveBeenCalled();
+  });
+
+  it('navigates collection previews to the collection page on Space key', () => {
+    mockUsePostDetails.mockReturnValue(resolvedCollectionPost);
+    render(<PostPreviewCard postId="owner123:collection456" />);
+
+    const card = screen.getByTestId('card');
+    fireEvent.keyDown(card, { key: ' ' });
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/collections/owner123/collection456');
+    expect(mockNavigateToPost).not.toHaveBeenCalled();
+  });
+
+  it('labels collection previews as collection links', () => {
+    mockUsePostDetails.mockReturnValue(resolvedCollectionPost);
+    render(<PostPreviewCard postId="owner123:collection456" />);
+
+    expect(screen.getByTestId('card')).toHaveAttribute('aria-label', 'View collection');
   });
 
   it('does not navigate on other keys', () => {

--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { getCollectionRoute } from '@/app/routes';
 import { Card, CardContent } from '@/atoms/Card/Card';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { usePostNavigation } from '@/hooks/usePostNavigation/usePostNavigation';
 import { useTtlSubscription } from '@/hooks/useTtlSubscription/useTtlSubscription';
 import { cn } from '@/libs/utils/utils';
-import { parseCompositeId } from '@/models/models.utils';
 import { PostMissing } from '@/molecules/PostMissing/PostMissing';
 import { PostContentBase } from '@/organisms/PostContentBase/PostContentBase';
 import { PostHeader } from '@/organisms/PostHeader/PostHeader';
@@ -35,8 +32,7 @@ import type { PostPreviewCardProps } from './PostPreviewCard.types';
  * - Any nested context where a compact post preview is needed
  */
 export function PostPreviewCard({ postId, className, contrast }: PostPreviewCardProps) {
-  const router = useRouter();
-  const { navigateToPost } = usePostNavigation();
+  const { navigateToPost, navigateToCollection } = usePostNavigation();
   const { postDetails, isLoading } = usePostDetails(postId);
   const { ref: ttlRef } = useTtlSubscription({
     type: 'post',
@@ -52,8 +48,7 @@ export function PostPreviewCard({ postId, className, contrast }: PostPreviewCard
 
   const navigateToPreview = () => {
     if (isCollection) {
-      const { pubky, id } = parseCompositeId(postId);
-      router.push(getCollectionRoute(pubky, id));
+      navigateToCollection(postId);
       return;
     }
 

--- a/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
+++ b/src/components/molecules/PostPreviewCard/PostPreviewCard.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { getCollectionRoute } from '@/app/routes';
 import { Card, CardContent } from '@/atoms/Card/Card';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { usePostNavigation } from '@/hooks/usePostNavigation/usePostNavigation';
 import { useTtlSubscription } from '@/hooks/useTtlSubscription/useTtlSubscription';
 import { cn } from '@/libs/utils/utils';
+import { parseCompositeId } from '@/models/models.utils';
 import { PostMissing } from '@/molecules/PostMissing/PostMissing';
 import { PostContentBase } from '@/organisms/PostContentBase/PostContentBase';
 import { PostHeader } from '@/organisms/PostHeader/PostHeader';
@@ -32,6 +35,7 @@ import type { PostPreviewCardProps } from './PostPreviewCard.types';
  * - Any nested context where a compact post preview is needed
  */
 export function PostPreviewCard({ postId, className, contrast }: PostPreviewCardProps) {
+  const router = useRouter();
   const { navigateToPost } = usePostNavigation();
   const { postDetails, isLoading } = usePostDetails(postId);
   const { ref: ttlRef } = useTtlSubscription({
@@ -44,17 +48,28 @@ export function PostPreviewCard({ postId, className, contrast }: PostPreviewCard
   // PostMissing as a direct Card child (it IS a CardContent) so it isn't nested
   // inside the inner CardContent — matching how PostMain renders PostDeleted.
   const isMissing = postDetails === null && !isLoading;
+  const isCollection = postDetails?.kind === 'collection';
+
+  const navigateToPreview = () => {
+    if (isCollection) {
+      const { pubky, id } = parseCompositeId(postId);
+      router.push(getCollectionRoute(pubky, id));
+      return;
+    }
+
+    navigateToPost(postId);
+  };
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigateToPost(postId);
+    navigateToPreview();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation();
       e.preventDefault();
-      navigateToPost(postId);
+      navigateToPreview();
     }
   };
 
@@ -67,7 +82,7 @@ export function PostPreviewCard({ postId, className, contrast }: PostPreviewCard
       onKeyDown={handleKeyDown}
       role="link"
       tabIndex={0}
-      aria-label="View original post"
+      aria-label={isCollection ? 'View collection' : 'View original post'}
     >
       {isMissing ? (
         <PostMissing />

--- a/src/components/organisms/PostMain/PostMain.test.tsx
+++ b/src/components/organisms/PostMain/PostMain.test.tsx
@@ -288,6 +288,8 @@ describe('PostMain', () => {
     vi.mocked(usePostNavigation).mockReturnValue({
       getPostHref: vi.fn(() => '/post/author/post-abc'),
       navigateToPost: vi.fn(),
+      getCollectionHref: vi.fn(() => '/collections/author/collection-abc'),
+      navigateToCollection: vi.fn(),
       handlePostClick: mockHandlePostClick,
       handlePostAuxClick: mockHandlePostAuxClick,
       handlePostKeyDown: vi.fn(),
@@ -721,6 +723,8 @@ describe('PostMain - Snapshots', () => {
     vi.mocked(usePostNavigation).mockReturnValue({
       getPostHref: vi.fn(() => '/post/author/post-abc'),
       navigateToPost: vi.fn(),
+      getCollectionHref: vi.fn(() => '/collections/author/collection-abc'),
+      navigateToCollection: vi.fn(),
       handlePostClick: vi.fn(),
       handlePostAuxClick: vi.fn(),
       handlePostKeyDown: vi.fn(),
@@ -827,6 +831,8 @@ describe('PostMain - Mobile Snapshots', () => {
     vi.mocked(usePostNavigation).mockReturnValue({
       getPostHref: vi.fn(() => '/post/author/post-abc'),
       navigateToPost: vi.fn(),
+      getCollectionHref: vi.fn(() => '/collections/author/collection-abc'),
+      navigateToCollection: vi.fn(),
       handlePostClick: vi.fn(),
       handlePostAuxClick: vi.fn(),
       handlePostKeyDown: vi.fn(),

--- a/src/hooks/usePostNavigation/usePostNavigation.test.tsx
+++ b/src/hooks/usePostNavigation/usePostNavigation.test.tsx
@@ -88,6 +88,33 @@ describe('usePostNavigation', () => {
     });
   });
 
+  describe('navigateToCollection', () => {
+    it('should return navigateToCollection function', () => {
+      const { result } = renderHook(() => usePostNavigation());
+
+      expect(result.current.navigateToCollection).toBeDefined();
+      expect(typeof result.current.navigateToCollection).toBe('function');
+    });
+
+    it('should navigate to collection detail page with composite ID', () => {
+      const { result } = renderHook(() => usePostNavigation());
+      const compositeCollectionId = 'author123:collection456';
+
+      act(() => {
+        result.current.navigateToCollection(compositeCollectionId);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith('/collections/author123/collection456');
+      expect(mockPush).toHaveBeenCalledTimes(1);
+    });
+
+    it('should build collection href with getCollectionHref', () => {
+      const { result } = renderHook(() => usePostNavigation());
+
+      expect(result.current.getCollectionHref('author123:collection456')).toBe('/collections/author123/collection456');
+    });
+  });
+
   describe('Integration', () => {
     it('should work correctly when used multiple times in different components', () => {
       const { result: result1 } = renderHook(() => usePostNavigation());

--- a/src/hooks/usePostNavigation/usePostNavigation.ts
+++ b/src/hooks/usePostNavigation/usePostNavigation.ts
@@ -1,9 +1,8 @@
 'use client';
 
-import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import type React from 'react';
-import { POST_ROUTES } from '@/app/routes';
+import { getCollectionRoute, POST_ROUTES } from '@/app/routes';
 import { parseCompositeId } from '@/models/models.utils';
 import type { UsePostNavigationResult } from './usePostNavigation.types';
 
@@ -33,62 +32,67 @@ function isInteractiveTarget(target: EventTarget | null): boolean {
 export function usePostNavigation(): UsePostNavigationResult {
   const router = useRouter();
 
-  const getPostHref = useCallback((postId: string) => {
+  const getPostHref = (postId: string) => {
     const { pubky: userId, id: pId } = parseCompositeId(postId);
     return `${POST_ROUTES.POST}/${userId}/${pId}`;
-  }, []);
+  };
 
-  const navigateToPost = useCallback(
-    (postId: string) => {
-      router.push(getPostHref(postId));
-    },
-    [router, getPostHref],
-  );
+  const navigateToPost = (postId: string) => {
+    router.push(getPostHref(postId));
+  };
 
-  const handlePostClick = useCallback(
-    (postId: string, event: React.MouseEvent) => {
-      if (isInteractiveTarget(event.target)) return;
+  const getCollectionHref = (postId: string) => {
+    const { pubky, id } = parseCompositeId(postId);
+    return getCollectionRoute(pubky, id);
+  };
 
-      // Don't navigate if the user is selecting text inside the card.
-      const selection = typeof window !== 'undefined' ? window.getSelection() : null;
-      if (selection && selection.toString().length > 0) return;
+  const navigateToCollection = (postId: string) => {
+    router.push(getCollectionHref(postId));
+  };
 
-      const href = getPostHref(postId);
-      if (event.metaKey || event.ctrlKey || event.shiftKey) {
-        window.open(href, '_blank', 'noopener,noreferrer');
-        return;
-      }
-      router.push(href);
-    },
-    [router, getPostHref],
-  );
+  const handlePostClick = (postId: string, event: React.MouseEvent) => {
+    if (isInteractiveTarget(event.target)) return;
 
-  const handlePostAuxClick = useCallback(
-    (postId: string, event: React.MouseEvent) => {
-      if (event.button !== 1) return;
-      if (isInteractiveTarget(event.target)) return;
-      event.preventDefault();
-      window.open(getPostHref(postId), '_blank', 'noopener,noreferrer');
-    },
-    [getPostHref],
-  );
+    // Don't navigate if the user is selecting text inside the card.
+    const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+    if (selection && selection.toString().length > 0) return;
 
-  const handlePostKeyDown = useCallback(
-    (postId: string, event: React.KeyboardEvent) => {
-      // Only act when the wrapper itself has focus, not a descendant (button, link, input).
-      if (event.target !== event.currentTarget) return;
-      if (event.key !== 'Enter' && event.key !== ' ') return;
-      event.preventDefault();
+    const href = getPostHref(postId);
+    if (event.metaKey || event.ctrlKey || event.shiftKey) {
+      window.open(href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    router.push(href);
+  };
 
-      const href = getPostHref(postId);
-      if (event.metaKey || event.ctrlKey || event.shiftKey) {
-        window.open(href, '_blank', 'noopener,noreferrer');
-        return;
-      }
-      router.push(href);
-    },
-    [router, getPostHref],
-  );
+  const handlePostAuxClick = (postId: string, event: React.MouseEvent) => {
+    if (event.button !== 1) return;
+    if (isInteractiveTarget(event.target)) return;
+    event.preventDefault();
+    window.open(getPostHref(postId), '_blank', 'noopener,noreferrer');
+  };
 
-  return { getPostHref, navigateToPost, handlePostClick, handlePostAuxClick, handlePostKeyDown };
+  const handlePostKeyDown = (postId: string, event: React.KeyboardEvent) => {
+    // Only act when the wrapper itself has focus, not a descendant (button, link, input).
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+
+    const href = getPostHref(postId);
+    if (event.metaKey || event.ctrlKey || event.shiftKey) {
+      window.open(href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    router.push(href);
+  };
+
+  return {
+    getPostHref,
+    navigateToPost,
+    getCollectionHref,
+    navigateToCollection,
+    handlePostClick,
+    handlePostAuxClick,
+    handlePostKeyDown,
+  };
 }

--- a/src/hooks/usePostNavigation/usePostNavigation.types.ts
+++ b/src/hooks/usePostNavigation/usePostNavigation.types.ts
@@ -10,6 +10,14 @@ export interface UsePostNavigationResult {
    */
   navigateToPost: (postId: string) => void;
   /**
+   * Build the collection detail URL for a composite post ID.
+   */
+  getCollectionHref: (postId: string) => string;
+  /**
+   * Navigate to a collection detail page using composite ID.
+   */
+  navigateToCollection: (postId: string) => void;
+  /**
    * Click handler for clickable post wrappers (e.g., feed cards).
    * Plain left click → SPA navigation. Cmd/Ctrl/Shift+Click → opens in a new tab.
    */


### PR DESCRIPTION
fix(posts): route shared collection previews to collection pages

Clicking a collection embedded in a repost or reply preview now opens /collections/:pubky/:id instead of the post detail page. Detect postDetails.kind === 'collection' in PostPreviewCard and branch navigation accordingly, with an updated aria-label for collections.

Centralize collection routing in usePostNavigation via navigateToCollection and getCollectionHref so other components can reuse it without duplicating parseCompositeId and getCollectionRoute. Remove useCallback from the hook now that React Compiler handles memoization.


https://github.com/user-attachments/assets/895620f1-7503-499c-893e-47f8df0160da


Closes #2090