### PR TITLE
feat: Pipeline for public docker images, refactor pipeline for preview images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -137,10 +137,6 @@ jobs:
             NEXT_PUBLIC_DB_NAME=franky
             NEXT_PUBLIC_DEBUG_MODE=false
             NEXT_PUBLIC_APP_VERSION=${{ github.sha }}
-            BASE_URL_SUPPORT=https://chatwoot.example.com
-            SUPPORT_API_ACCESS_TOKEN=your_token_here
-            SUPPORT_ACCOUNT_ID=123
-            SUPPORT_FEEDBACK_INBOX_ID=26
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=synonym-52
             SENTRY_PROJECT=pubky-app

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -93,7 +93,6 @@ jobs:
     uses: ./.github/workflows/build-docker-image.yml
     with:
       platforms: ${{ needs.set_vars_pubky_app.outputs.platforms }}
-      env: ${{ needs.set_vars_pubky_app.outputs.env }}
     secrets: inherit
 
   e2e-test:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,7 +3,6 @@ env:
   pubky_stack_ref: 'staging'
   platforms: 'linux/amd64'
   registry: 'europe-west6-docker.pkg.dev/infra-464608/synonym-private-repo'
-  pubky-app_env: 'testnet'
 
 on:
   workflow_dispatch:
@@ -87,7 +86,6 @@ jobs:
       - name: Set Vars
         id: set_vars
         run: |
-          echo env=${{ env.pubky-app_env }} >> $GITHUB_OUTPUT
           echo platforms=${{ env.platforms }} >> $GITHUB_OUTPUT
 
   rebuild_pubky_app:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,46 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+      contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: pubky/ci-workflows/.github/actions/docker/build_and_push@main
+        with:
+          registry: registry-1.docker.io/synonymsoft
+          context: .
+          push: true
+          latest: true
+          tags: |
+            type=ref,event=tag
+          platforms: |
+            linux/arm64
+            linux/amd64
+          image: pubky-app
+          cache_from: type=gha
+          cache_to: type=gha,mode=max
+          build_args: |
+            NEXT_PUBLIC_DB_VERSION=2
+            NEXT_PUBLIC_DB_NAME=franky
+            NEXT_PUBLIC_DEBUG_MODE=false
+            NEXT_PUBLIC_APP_VERSION=${{ github.sha }}
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,6 @@ ARG NEXT_PUBLIC_APP_VERSION
 # PKARR_RELAYS and TESTNET are intentionally NOT build args. They are runtime-configurable and must
 # be supplied as PUBKY_RUNTIME_* environment variables on the running container (see runner stage
 # and src/libs/runtime-config). This lets a single image be promoted across staging/prod/testnet.
-ARG BASE_URL_SUPPORT
-ARG SUPPORT_API_ACCESS_TOKEN
-ARG SUPPORT_ACCOUNT_ID
-ARG SUPPORT_FEEDBACK_INBOX_ID
 
 # NOTE: Sentry runtime values (DSN, environment, sample rates) are runtime-configurable
 # (PUBKY_RUNTIME_SENTRY_*, see runner stage). Source-map upload is optional: Synonym CI passes


### PR DESCRIPTION
This is a temp solution, in the future we will use single workflow file for building image, this workflow will be reused in pubky-stack, here in e2e, preview, and release workflows.