### PR TITLE
[WoT V1] Reach sidebar UI and profile tag selector

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1142,8 +1142,12 @@
     "reach": {
       "title": "النطاق",
       "all": "الكل",
+      "network": "الشبكة",
       "following": "المتابَعون",
-      "friends": "الاصدقاء"
+      "friends": "الاصدقاء",
+      "me": "انا",
+      "profileTag": "وسم الملف الشخصي",
+      "profileTagLimitReached": "5 وسوم كحد اقصى"
     },
     "sort": {
       "title": "الترتيب",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1147,7 +1147,7 @@
       "friends": "الاصدقاء",
       "me": "انا",
       "profileTag": "وسم الملف الشخصي",
-      "profileTagLimitReached": "5 وسوم كحد اقصى"
+      "profileTagLimitReached": "{max} وسوم كحد اقصى"
     },
     "sort": {
       "title": "الترتيب",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1148,8 +1148,12 @@
     "reach": {
       "title": "Reichweite",
       "all": "Alle",
+      "network": "Netzwerk",
       "following": "Folge ich",
-      "friends": "Freunde"
+      "friends": "Freunde",
+      "me": "Ich",
+      "profileTag": "Profil-Tag",
+      "profileTagLimitReached": "Max. 5 Tags"
     },
     "sort": {
       "title": "Sortieren",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1153,7 +1153,7 @@
       "friends": "Freunde",
       "me": "Ich",
       "profileTag": "Profil-Tag",
-      "profileTagLimitReached": "Max. 5 Tags"
+      "profileTagLimitReached": "Max. {max} Tags"
     },
     "sort": {
       "title": "Sortieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1146,8 +1146,12 @@
     "reach": {
       "title": "Reach",
       "all": "All",
+      "network": "Network",
       "following": "Following",
-      "friends": "Friends"
+      "friends": "Friends",
+      "me": "Me",
+      "profileTag": "profile tag",
+      "profileTagLimitReached": "5 tags max"
     },
     "sort": {
       "title": "Sort",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1151,7 +1151,7 @@
       "friends": "Friends",
       "me": "Me",
       "profileTag": "profile tag",
-      "profileTagLimitReached": "5 tags max"
+      "profileTagLimitReached": "{max} tags max"
     },
     "sort": {
       "title": "Sort",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1153,7 +1153,7 @@
       "friends": "Amigos",
       "me": "Yo",
       "profileTag": "etiqueta de perfil",
-      "profileTagLimitReached": "máximo 5 etiquetas"
+      "profileTagLimitReached": "máximo {max} etiquetas"
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1148,8 +1148,12 @@
     "reach": {
       "title": "Alcance",
       "all": "Todos",
+      "network": "Red",
       "following": "Siguiendo",
-      "friends": "Amigos"
+      "friends": "Amigos",
+      "me": "Yo",
+      "profileTag": "etiqueta de perfil",
+      "profileTagLimitReached": "máximo 5 etiquetas"
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1146,8 +1146,12 @@
     "reach": {
       "title": "Portee",
       "all": "Tous",
+      "network": "Reseau",
       "following": "Abonnements",
-      "friends": "Amis"
+      "friends": "Amis",
+      "me": "Moi",
+      "profileTag": "tag de profil",
+      "profileTagLimitReached": "5 tags max"
     },
     "sort": {
       "title": "Trier",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1151,7 +1151,7 @@
       "friends": "Amis",
       "me": "Moi",
       "profileTag": "tag de profil",
-      "profileTagLimitReached": "5 tags max"
+      "profileTagLimitReached": "{max} tags max"
     },
     "sort": {
       "title": "Trier",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1151,7 +1151,7 @@
       "friends": "Amici",
       "me": "Io",
       "profileTag": "tag profilo",
-      "profileTagLimitReached": "max 5 tag"
+      "profileTagLimitReached": "max {max} tag"
     },
     "sort": {
       "title": "Ordina",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1146,8 +1146,12 @@
     "reach": {
       "title": "Portata",
       "all": "Tutti",
+      "network": "Rete",
       "following": "Seguiti",
-      "friends": "Amici"
+      "friends": "Amici",
+      "me": "Io",
+      "profileTag": "tag profilo",
+      "profileTagLimitReached": "max 5 tag"
     },
     "sort": {
       "title": "Ordina",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1146,8 +1146,12 @@
     "reach": {
       "title": "範囲",
       "all": "すべて",
+      "network": "ネットワーク",
       "following": "フォロー中",
-      "friends": "友達"
+      "friends": "友達",
+      "me": "自分",
+      "profileTag": "プロフィールタグ",
+      "profileTagLimitReached": "最大5タグ"
     },
     "sort": {
       "title": "並べ替え",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1151,7 +1151,7 @@
       "friends": "友達",
       "me": "自分",
       "profileTag": "プロフィールタグ",
-      "profileTagLimitReached": "最大5タグ"
+      "profileTagLimitReached": "最大{max}タグ"
     },
     "sort": {
       "title": "並べ替え",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1146,8 +1146,12 @@
     "reach": {
       "title": "Alcance",
       "all": "Todos",
+      "network": "Rede",
       "following": "Seguindo",
-      "friends": "Amigos"
+      "friends": "Amigos",
+      "me": "Eu",
+      "profileTag": "tag de perfil",
+      "profileTagLimitReached": "maximo 5 tags"
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1151,7 +1151,7 @@
       "friends": "Amigos",
       "me": "Eu",
       "profileTag": "tag de perfil",
-      "profileTagLimitReached": "maximo 5 tags"
+      "profileTagLimitReached": "maximo {max} tags"
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1140,8 +1140,12 @@
     "reach": {
       "title": "范围",
       "all": "全部",
+      "network": "网络",
       "following": "关注",
-      "friends": "好友"
+      "friends": "好友",
+      "me": "我",
+      "profileTag": "个人资料标签",
+      "profileTagLimitReached": "最多5个标签"
     },
     "sort": {
       "title": "排序",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1145,7 +1145,7 @@
       "friends": "好友",
       "me": "我",
       "profileTag": "个人资料标签",
-      "profileTagLimitReached": "最多5个标签"
+      "profileTagLimitReached": "最多{max}个标签"
     },
     "sort": {
       "title": "排序",

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { FilterProfileTags } from './FilterProfileTags';
 
+function getTagInputContainer(container: HTMLElement) {
+  return container.querySelector('div.relative');
+}
+
 describe('FilterProfileTags', () => {
   it('adds a normalized profile tag from the input', async () => {
     const onTagAdd = vi.fn();
@@ -40,6 +44,82 @@ describe('FilterProfileTags', () => {
     render(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} disabled />);
 
     expect(screen.getByPlaceholderText('profile tag')).toBeDisabled();
+  });
+
+  it('collapses the whole tags block when disabled', () => {
+    const { container } = render(
+      <FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} disabled />,
+    );
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass('grid-rows-[0fr]', 'opacity-0', 'pointer-events-none', 'duration-300', 'ease-in-out');
+    expect(wrapper).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('expands the tags block when active', () => {
+    const { container } = render(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} />);
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass('grid-rows-[1fr]', 'opacity-100', 'duration-300', 'ease-in-out');
+    expect(wrapper).not.toHaveClass('pointer-events-none');
+  });
+
+  it('keeps rendering the last selected tags while disabled so they collapse with the block', () => {
+    const { rerender } = render(
+      <FilterProfileTags selectedTags={['bitcoin', 'nostr']} onTagAdd={vi.fn()} onTagRemove={vi.fn()} />,
+    );
+
+    // Parent clears tags and disables at the same time (e.g. switching reach to All/Me).
+    rerender(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} disabled />);
+
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('nostr')).toBeInTheDocument();
+
+    // Re-enabling syncs back to the real (cleared) selection.
+    rerender(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} />);
+
+    expect(screen.queryByText('bitcoin')).not.toBeInTheDocument();
+    expect(screen.queryByText('nostr')).not.toBeInTheDocument();
+  });
+
+  it('keeps the at-limit input the same width as tag chips', () => {
+    const { container } = render(
+      <FilterProfileTags
+        selectedTags={['one', 'two', 'three', 'four', 'five']}
+        onTagAdd={vi.fn()}
+        onTagRemove={vi.fn()}
+      />,
+    );
+
+    const tagInputContainer = getTagInputContainer(container);
+    expect(tagInputContainer).toHaveClass('w-32');
+    expect(tagInputContainer).not.toHaveClass('w-40', 'opacity-60');
+  });
+
+  it('hides the emoji selector when at the tag limit', () => {
+    render(
+      <FilterProfileTags
+        selectedTags={['one', 'two', 'three', 'four', 'five']}
+        onTagAdd={vi.fn()}
+        onTagRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Open emoji picker')).not.toBeInTheDocument();
+  });
+
+  it('renders the at-limit placeholder at full opacity', () => {
+    render(
+      <FilterProfileTags
+        selectedTags={['one', 'two', 'three', 'four', 'five']}
+        onTagAdd={vi.fn()}
+        onTagRemove={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('5 tags max');
+    expect(input).toBeDisabled();
+    expect(input).toHaveClass('placeholder:text-destructive', 'disabled:opacity-100');
   });
 
   it('prevents adding more than five tags', () => {

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FilterProfileTags } from './FilterProfileTags';
+
+describe('FilterProfileTags', () => {
+  it('adds a normalized profile tag from the input', async () => {
+    const onTagAdd = vi.fn();
+
+    render(<FilterProfileTags selectedTags={[]} onTagAdd={onTagAdd} onTagRemove={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText('profile tag');
+    fireEvent.change(input, { target: { value: 'Bitcoin' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onTagAdd).toHaveBeenCalledWith('bitcoin');
+    });
+  });
+
+  it('renders selected tags in a removable stack', () => {
+    const onTagRemove = vi.fn();
+
+    render(<FilterProfileTags selectedTags={['bitcoin', 'nostr']} onTagAdd={vi.fn()} onTagRemove={onTagRemove} />);
+
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('nostr')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Remove bitcoin tag'));
+
+    expect(onTagRemove).toHaveBeenCalledWith('bitcoin');
+  });
+
+  it('shows the shared tag emoji selector', () => {
+    render(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} />);
+
+    expect(screen.getByLabelText('Open emoji picker')).toBeInTheDocument();
+  });
+
+  it('disables the profile tag input when disabled', () => {
+    render(<FilterProfileTags selectedTags={[]} onTagAdd={vi.fn()} onTagRemove={vi.fn()} disabled />);
+
+    expect(screen.getByPlaceholderText('profile tag')).toBeDisabled();
+  });
+
+  it('prevents adding more than five tags', () => {
+    const onTagAdd = vi.fn();
+
+    render(
+      <FilterProfileTags
+        selectedTags={['one', 'two', 'three', 'four', 'five']}
+        onTagAdd={onTagAdd}
+        onTagRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText('5 tags max')).toBeDisabled();
+  });
+});

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
@@ -55,4 +55,12 @@ describe('FilterProfileTags', () => {
 
     expect(screen.getByPlaceholderText('5 tags max')).toBeDisabled();
   });
+
+  it('uses the configured max tag count in the limit placeholder', () => {
+    render(
+      <FilterProfileTags selectedTags={['one', 'two', 'three']} onTagAdd={vi.fn()} onTagRemove={vi.fn()} maxTags={3} />,
+    );
+
+    expect(screen.getByPlaceholderText('3 tags max')).toBeDisabled();
+  });
 });

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Container } from '@/atoms/Container/Container';
 import { cn } from '@/libs/utils/utils';
@@ -16,9 +17,19 @@ export function FilterProfileTags({
   maxTags = HOME_PROFILE_TAGS_MAX_SELECTED,
 }: FilterProfileTagsProps) {
   const t = useTranslations('filters.reach');
-  const isAtLimit = selectedTags.length >= maxTags;
+
+  // The store clears selected tags the moment a gated reach (All/Me) is picked,
+  // which would unmount the chips before the collapse animation can play. Freeze
+  // the last tags shown while disabled so tags and input collapse together.
+  const [frozenTags, setFrozenTags] = useState(selectedTags);
+  if (!disabled && frozenTags !== selectedTags) {
+    setFrozenTags(selectedTags);
+  }
+  const displayTags = disabled ? frozenTags : selectedTags;
+
+  const isAtLimit = displayTags.length >= maxTags;
   const isInputDisabled = disabled || isAtLimit;
-  const existingTags = selectedTags.map((label) => ({ label }));
+  const existingTags = displayTags.map((label) => ({ label }));
 
   const handleTagAdd = (tag: string) => {
     const normalizedTag = tag.trim().toLowerCase();
@@ -29,26 +40,43 @@ export function FilterProfileTags({
   };
 
   return (
-    <Container overrideDefaults className="flex w-full flex-col gap-1 py-1">
-      {selectedTags.map((tag) => (
-        <PostTag key={tag} label={tag} showClose onClose={() => onTagRemove(tag)} className="w-32 justify-between" />
-      ))}
+    <Container
+      overrideDefaults
+      aria-hidden={disabled}
+      className={cn(
+        'grid w-full transition-all duration-300 ease-in-out',
+        disabled ? 'pointer-events-none grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100',
+      )}
+    >
+      <Container overrideDefaults className="overflow-hidden">
+        <Container overrideDefaults className="flex w-full flex-col gap-1 py-1">
+          {displayTags.map((tag) => (
+            <PostTag
+              key={tag}
+              label={tag}
+              showClose
+              onClose={() => onTagRemove(tag)}
+              className="w-32 justify-between"
+            />
+          ))}
 
-      <TagInput
-        onTagAdd={handleTagAdd}
-        placeholder={t('profileTag')}
-        existingTags={existingTags}
-        viewerTags={existingTags}
-        disabled={isInputDisabled}
-        maxTags={maxTags}
-        currentTagsCount={selectedTags.length}
-        limitReachedPlaceholder={t('profileTagLimitReached', { max: maxTags })}
-        enableApiSuggestions
-        excludeFromApiSuggestions={selectedTags}
-        addOnSuggestionClick
-        className={cn('w-32', disabled && 'pointer-events-none opacity-40', isAtLimit && !disabled && 'opacity-60')}
-        inputClassName={disabled ? 'disabled:opacity-100' : undefined}
-      />
+          <TagInput
+            onTagAdd={handleTagAdd}
+            placeholder={t('profileTag')}
+            existingTags={existingTags}
+            viewerTags={existingTags}
+            disabled={isInputDisabled}
+            maxTags={maxTags}
+            currentTagsCount={displayTags.length}
+            limitReachedPlaceholder={t('profileTagLimitReached', { max: maxTags })}
+            showEmojiButton={!isAtLimit}
+            enableApiSuggestions
+            excludeFromApiSuggestions={displayTags}
+            addOnSuggestionClick
+            className="w-32"
+          />
+        </Container>
+      </Container>
     </Container>
   );
 }

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Container } from '@/atoms/Container/Container';
+import { cn } from '@/libs/utils/utils';
+import { PostTag } from '@/molecules/PostTag/PostTag';
+import { TagInput } from '@/molecules/TagInput/TagInput';
+import { HOME_PROFILE_TAGS_MAX_SELECTED } from '@/stores/home/home.types';
+import type { FilterProfileTagsProps } from './FilterProfileTags.types';
+
+export function FilterProfileTags({
+  selectedTags,
+  onTagAdd,
+  onTagRemove,
+  disabled = false,
+  maxTags = HOME_PROFILE_TAGS_MAX_SELECTED,
+}: FilterProfileTagsProps) {
+  const t = useTranslations('filters.reach');
+  const isAtLimit = selectedTags.length >= maxTags;
+  const isInputDisabled = disabled || isAtLimit;
+  const existingTags = selectedTags.map((label) => ({ label }));
+
+  const handleTagAdd = (tag: string) => {
+    const normalizedTag = tag.trim().toLowerCase();
+    if (!normalizedTag || selectedTags.length >= maxTags) {
+      return;
+    }
+    onTagAdd(normalizedTag);
+  };
+
+  return (
+    <Container overrideDefaults className="flex w-full flex-col gap-1 py-1">
+      {selectedTags.map((tag) => (
+        <PostTag key={tag} label={tag} showClose onClose={() => onTagRemove(tag)} className="w-32 justify-between" />
+      ))}
+
+      <TagInput
+        onTagAdd={handleTagAdd}
+        placeholder={t('profileTag')}
+        existingTags={existingTags}
+        viewerTags={existingTags}
+        disabled={isInputDisabled}
+        maxTags={maxTags}
+        currentTagsCount={selectedTags.length}
+        limitReachedPlaceholder={t('profileTagLimitReached')}
+        enableApiSuggestions
+        excludeFromApiSuggestions={selectedTags}
+        addOnSuggestionClick
+        className={cn('w-32', disabled && 'pointer-events-none opacity-40', isAtLimit && !disabled && 'opacity-60')}
+        inputClassName={disabled ? 'disabled:opacity-100' : undefined}
+      />
+    </Container>
+  );
+}

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
@@ -42,7 +42,7 @@ export function FilterProfileTags({
         disabled={isInputDisabled}
         maxTags={maxTags}
         currentTagsCount={selectedTags.length}
-        limitReachedPlaceholder={t('profileTagLimitReached')}
+        limitReachedPlaceholder={t('profileTagLimitReached', { max: maxTags })}
         enableApiSuggestions
         excludeFromApiSuggestions={selectedTags}
         addOnSuggestionClick

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.types.ts
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.types.ts
@@ -1,0 +1,7 @@
+export interface FilterProfileTagsProps {
+  selectedTags: string[];
+  onTagAdd: (tag: string) => void;
+  onTagRemove: (tag: string) => void;
+  disabled?: boolean;
+  maxTags?: number;
+}

--- a/src/components/molecules/Filters/FilterRadioGroup/FilterRadioGroup.tsx
+++ b/src/components/molecules/Filters/FilterRadioGroup/FilterRadioGroup.tsx
@@ -23,6 +23,7 @@ export interface FilterRadioGroupProps<T = string> {
   onClose?: () => void;
   dataCy?: string;
   testId?: string;
+  children?: React.ReactNode;
 }
 
 export function FilterRadioGroup<T extends string = string>({
@@ -34,6 +35,7 @@ export function FilterRadioGroup<T extends string = string>({
   onClose,
   dataCy,
   testId,
+  children,
 }: FilterRadioGroupProps<T>) {
   const headerId = React.useId();
 
@@ -101,6 +103,7 @@ export function FilterRadioGroup<T extends string = string>({
           })}
         </FilterList>
       </Container>
+      {children}
     </FilterRoot>
   );
 }

--- a/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
@@ -43,6 +43,57 @@ describe('FilterReach', () => {
     });
   });
 
+  it('renders V1 Network and Me reach options when enabled', () => {
+    const mockOnTabChange = vi.fn();
+    render(<FilterReach showNetwork showMe onTabChange={mockOnTabChange} />);
+
+    const tabs = [
+      { value: REACH.ALL, label: 'All' },
+      { value: REACH.NETWORK, label: 'Network' },
+      { value: REACH.FOLLOWING, label: 'Following' },
+      { value: REACH.FRIENDS, label: 'Friends' },
+      { value: REACH.ME, label: 'Me' },
+    ];
+
+    tabs.forEach(({ value, label }) => {
+      const element = screen.getByLabelText(label);
+      fireEvent.click(element);
+      expect(mockOnTabChange).toHaveBeenCalledWith(value);
+    });
+  });
+
+  it('renders profile tag selector footer when profile tag props are provided', () => {
+    render(
+      <FilterReach
+        showNetwork
+        showMe
+        selectedTab={REACH.NETWORK}
+        profileTags={['bitcoin']}
+        onProfileTagAdd={vi.fn()}
+        onProfileTagRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('profile tag')).toBeInTheDocument();
+  });
+
+  it('disables profile tag selector footer when profileTagsDisabled is true', () => {
+    render(
+      <FilterReach
+        showNetwork
+        showMe
+        selectedTab={REACH.ALL}
+        profileTags={[]}
+        onProfileTagAdd={vi.fn()}
+        onProfileTagRemove={vi.fn()}
+        profileTagsDisabled
+      />,
+    );
+
+    expect(screen.getByPlaceholderText('profile tag')).toBeDisabled();
+  });
+
   it('has proper ARIA attributes for radio items', () => {
     render(<FilterReach selectedTab={REACH.FOLLOWING} />);
 

--- a/src/components/molecules/Filters/FilterReach/FilterReach.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.tsx
@@ -1,28 +1,56 @@
 'use client';
 
 import * as React from 'react';
-import { HeartHandshake, Radio } from 'lucide-react';
+import { HeartHandshake, Radio, UserRound, Waypoints } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { UsersRound2 } from '@/icons';
 import { REACH, type ReachType } from '@/stores/home/home.types';
+import { FilterProfileTags } from '../FilterProfileTags/FilterProfileTags';
 import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
-import { BaseFilterProps } from '../Filters.types';
+import type { BaseFilterProps, FilterListItem } from '../Filters.types';
+
+interface FilterReachProps extends BaseFilterProps<ReachType> {
+  showNetwork?: boolean;
+  showMe?: boolean;
+  profileTags?: string[];
+  onProfileTagAdd?: (tag: string) => void;
+  onProfileTagRemove?: (tag: string) => void;
+  profileTagsDisabled?: boolean;
+}
 
 export function FilterReach({
   selectedTab,
   defaultSelectedTab = REACH.ALL,
   onTabChange,
   disabled,
-}: BaseFilterProps<ReachType>) {
+  showNetwork = false,
+  showMe = false,
+  profileTags,
+  onProfileTagAdd,
+  onProfileTagRemove,
+  profileTagsDisabled = false,
+}: FilterReachProps) {
   const t = useTranslations('filters.reach');
-  const items = React.useMemo(
-    () => [
+  const items = React.useMemo(() => {
+    const reachItems: FilterListItem<ReachType>[] = [
       {
         key: REACH.ALL,
         label: t('all'),
         icon: Radio,
         disabled,
       },
+    ];
+
+    if (showNetwork) {
+      reachItems.push({
+        key: REACH.NETWORK,
+        label: t('network'),
+        icon: Waypoints,
+        disabled,
+      });
+    }
+
+    reachItems.push(
       {
         key: REACH.FOLLOWING,
         label: t('following'),
@@ -35,9 +63,19 @@ export function FilterReach({
         icon: HeartHandshake,
         disabled,
       },
-    ],
-    [t, disabled],
-  );
+    );
+
+    if (showMe) {
+      reachItems.push({
+        key: REACH.ME,
+        label: t('me'),
+        icon: UserRound,
+        disabled,
+      });
+    }
+
+    return reachItems;
+  }, [t, disabled, showNetwork, showMe]);
   return (
     <FilterRadioGroup
       title={t('title')}
@@ -47,6 +85,15 @@ export function FilterReach({
       onChange={onTabChange}
       testId="filter-reach-radiogroup"
       dataCy="filter-reach-radiogroup"
-    />
+    >
+      {profileTags && onProfileTagAdd && onProfileTagRemove ? (
+        <FilterProfileTags
+          selectedTags={profileTags}
+          onTagAdd={onProfileTagAdd}
+          onTagRemove={onProfileTagRemove}
+          disabled={profileTagsDisabled}
+        />
+      ) : null}
+    </FilterRadioGroup>
   );
 }

--- a/src/components/molecules/TagInput/TagInput.test.tsx
+++ b/src/components/molecules/TagInput/TagInput.test.tsx
@@ -95,6 +95,24 @@ describe('TagInput', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockOnTagAdd).toHaveBeenCalledWith('bitcoin');
   });
+
+  it('does not widen the container when max tags are reached', () => {
+    const { container } = render(
+      <TagInput onTagAdd={mockOnTagAdd} maxTags={5} currentTagsCount={5} className="w-32" />,
+    );
+    const tagInputContainer = container.querySelector('div.relative');
+
+    expect(tagInputContainer).toHaveClass('w-32');
+    expect(tagInputContainer).not.toHaveClass('w-40');
+  });
+
+  it('renders the at-limit placeholder at full opacity', () => {
+    render(<TagInput onTagAdd={mockOnTagAdd} maxTags={5} currentTagsCount={5} limitReachedPlaceholder="5 tags max" />);
+
+    const input = screen.getByPlaceholderText('5 tags max');
+    expect(input).toBeDisabled();
+    expect(input).toHaveClass('placeholder:text-destructive', 'disabled:opacity-100');
+  });
 });
 
 describe('TagInput - Banned Character Sanitization', () => {

--- a/src/components/molecules/TagInput/TagInput.tsx
+++ b/src/components/molecules/TagInput/TagInput.tsx
@@ -163,7 +163,6 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
               isDashedVariant && 'border border-dashed border-input shadow-sm transition-all duration-300',
               onClick && 'cursor-pointer',
               className,
-              isAtLimit && 'w-40',
             )}
             style={style}
             // Adding / typing a tag is the only intent here — never navigation.
@@ -195,7 +194,7 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
                 '-mt-0.5 h-full flex-1 bg-transparent p-0 text-sm leading-8 font-bold caret-white',
                 'border-none shadow-none ring-0 outline-none hover:outline-none focus:ring-0 focus:ring-offset-0 focus:outline-none',
                 'placeholder:font-bold',
-                isAtLimit ? 'placeholder:text-destructive' : 'placeholder:text-input',
+                isAtLimit ? 'placeholder:text-destructive disabled:opacity-100' : 'placeholder:text-input',
                 inputValue ? 'text-foreground' : 'text-input',
                 isDisabled && onClick && 'pointer-events-none',
                 inputClassName,

--- a/src/components/molecules/TagInput/TagInput.tsx
+++ b/src/components/molecules/TagInput/TagInput.tsx
@@ -25,6 +25,7 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
     existingTags = [],
     viewerTags,
     showCloseButton = false,
+    showEmojiButton = true,
     onClose,
     disabled = false,
     maxTags,
@@ -38,6 +39,7 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
     autoFocus = false,
     containerVariant = 'dashed',
     className,
+    inputClassName,
     style,
   },
   ref,
@@ -196,23 +198,26 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
                 isAtLimit ? 'placeholder:text-destructive' : 'placeholder:text-input',
                 inputValue ? 'text-foreground' : 'text-input',
                 isDisabled && onClick && 'pointer-events-none',
+                inputClassName,
               )}
             />
 
-            <Button
-              overrideDefaults={true}
-              onMouseDown={preventBlur}
-              onClick={() => setShowEmojiPicker(true)}
-              className={cn(
-                'inline-flex size-5 cursor-pointer items-center justify-center rounded-full p-1',
-                isDashedVariant && 'shadow-xs-dark hover:shadow-xs-dark',
-                isDisabled && onClick && 'pointer-events-none',
-              )}
-              aria-label="Open emoji picker"
-              disabled={isDisabled}
-            >
-              <Smile className="size-4" strokeWidth={2} />
-            </Button>
+            {showEmojiButton && (
+              <Button
+                overrideDefaults={true}
+                onMouseDown={preventBlur}
+                onClick={() => setShowEmojiPicker(true)}
+                className={cn(
+                  'inline-flex size-5 cursor-pointer items-center justify-center rounded-full p-1',
+                  isDashedVariant && 'shadow-xs-dark hover:shadow-xs-dark',
+                  isDisabled && onClick && 'pointer-events-none',
+                )}
+                aria-label="Open emoji picker"
+                disabled={isDisabled}
+              >
+                <Smile className="size-4" strokeWidth={2} />
+              </Button>
+            )}
 
             {showCloseButton && (
               <Button

--- a/src/components/molecules/TagInput/TagInput.types.ts
+++ b/src/components/molecules/TagInput/TagInput.types.ts
@@ -17,6 +17,8 @@ export interface TagInputProps {
   viewerTags?: TagLabel[];
   /** Whether to show the close button (X) */
   showCloseButton?: boolean;
+  /** Whether to show the emoji picker button */
+  showEmojiButton?: boolean;
   /** Callback when close button is clicked */
   onClose?: () => void;
   /** Whether the input is disabled */
@@ -43,6 +45,8 @@ export interface TagInputProps {
   containerVariant?: TagInputContainerVariant;
   /** Additional className for the container */
   className?: string;
+  /** Additional className for the inner input */
+  inputClassName?: string;
   /** Inline styles for the container */
   style?: React.CSSProperties;
 }

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
@@ -60,6 +60,7 @@ const {
 
 // Mock useHomeStore
 vi.mock('@/stores/home/home.types', () => ({
+  isProfileTagGatedReach: (reach: string) => reach === 'all' || reach === 'me',
   REACH: {
     ALL: 'all',
     NETWORK: 'network',

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
@@ -3,35 +3,69 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { HomeFeedDrawer, HomeFeedDrawerMobile, HomeFeedSidebar } from './HomeFeedSidebar';
 
-const { mockSetContent, mockUseHomeStore, mockFilterContent, mockUseFeedLayoutResolution, mockCurrentUserPubky } =
-  vi.hoisted(() => ({
-    mockSetContent: vi.fn(),
-    mockUseHomeStore: vi.fn(),
-    mockFilterContent: vi.fn(({ disabledTabs, selectedTab }: { disabledTabs?: string[]; selectedTab?: string }) => (
+const {
+  mockSetContent,
+  mockUseHomeStore,
+  mockFilterContent,
+  mockFilterReach,
+  mockUseFeedLayoutResolution,
+  mockCurrentUserPubky,
+} = vi.hoisted(() => ({
+  mockSetContent: vi.fn(),
+  mockUseHomeStore: vi.fn(),
+  mockFilterContent: vi.fn(({ disabledTabs, selectedTab }: { disabledTabs?: string[]; selectedTab?: string }) => (
+    <div
+      data-testid="filter-content"
+      data-disabled-tabs={(disabledTabs ?? []).length ? disabledTabs?.join(',') : undefined}
+      data-selected-tab={selectedTab}
+    >
+      FilterContent
+    </div>
+  )),
+  mockFilterReach: vi.fn(
+    ({
+      selectedTab,
+      showNetwork,
+      showMe,
+      profileTags,
+      profileTagsDisabled,
+    }: {
+      selectedTab?: string;
+      showNetwork?: boolean;
+      showMe?: boolean;
+      profileTags?: string[];
+      profileTagsDisabled?: boolean;
+    }) => (
       <div
-        data-testid="filter-content"
-        data-disabled-tabs={(disabledTabs ?? []).length ? disabledTabs?.join(',') : undefined}
+        data-testid="filter-reach"
         data-selected-tab={selectedTab}
+        data-show-network={showNetwork ? 'true' : undefined}
+        data-show-me={showMe ? 'true' : undefined}
+        data-profile-tags={(profileTags ?? []).join(',')}
+        data-profile-tags-disabled={profileTagsDisabled ? 'true' : undefined}
       >
-        FilterContent
+        FilterReach
       </div>
-    )),
-    mockUseFeedLayoutResolution: vi.fn(() => ({
-      requestedLayout: 'columns',
-      effectiveLayout: 'columns',
-      isVisualRequested: false,
-      isVisualActive: false,
-      isPhoneViewport: false,
-    })),
-    mockCurrentUserPubky: { value: 'viewer-pubky' as string | null },
-  }));
+    ),
+  ),
+  mockUseFeedLayoutResolution: vi.fn(() => ({
+    requestedLayout: 'columns',
+    effectiveLayout: 'columns',
+    isVisualRequested: false,
+    isVisualActive: false,
+    isPhoneViewport: false,
+  })),
+  mockCurrentUserPubky: { value: 'viewer-pubky' as string | null },
+}));
 
 // Mock useHomeStore
 vi.mock('@/stores/home/home.types', () => ({
   REACH: {
     ALL: 'all',
+    NETWORK: 'network',
     FOLLOWING: 'following',
     FRIENDS: 'friends',
+    ME: 'me',
   },
   CONTENT: {
     ALL: 'all',
@@ -86,11 +120,13 @@ vi.mock('@/molecules/Filters/FilterLayout/FilterLayout', () => {
 
 vi.mock('@/molecules/Filters/FilterReach/FilterReach', () => {
   return {
-    FilterReach: ({ selectedTab }: { selectedTab?: string }) => (
-      <div data-testid="filter-reach" data-selected-tab={selectedTab}>
-        FilterReach
-      </div>
-    ),
+    FilterReach: (props: {
+      selectedTab?: string;
+      showNetwork?: boolean;
+      showMe?: boolean;
+      profileTags?: string[];
+      profileTagsDisabled?: boolean;
+    }) => mockFilterReach(props),
   };
 });
 
@@ -112,8 +148,12 @@ beforeEach(() => {
     setSort: vi.fn(),
     content: 'all',
     setContent: mockSetContent,
+    profileTags: [],
+    addProfileTag: vi.fn(),
+    removeProfileTag: vi.fn(),
   });
   mockFilterContent.mockClear();
+  mockFilterReach.mockClear();
   mockUseFeedLayoutResolution.mockReturnValue({
     requestedLayout: 'columns',
     effectiveLayout: 'columns',
@@ -187,6 +227,71 @@ describe('HomeFeedSidebar', () => {
     render(<HomeFeedSidebar />);
 
     expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'all');
+  });
+
+  it('opts Home reach into V1 Network, Me, and profile tag controls', () => {
+    mockUseHomeStore.mockReturnValue({
+      layout: 'columns',
+      setLayout: vi.fn(),
+      reach: 'network',
+      setReach: vi.fn(),
+      sort: 'timeline',
+      setSort: vi.fn(),
+      content: 'all',
+      setContent: mockSetContent,
+      profileTags: ['bitcoin', 'dev'],
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+    });
+
+    render(<HomeFeedSidebar />);
+
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-show-network', 'true');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-show-me', 'true');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-profile-tags', 'bitcoin,dev');
+  });
+
+  it('hides and disables profile tags while effective reach is all', () => {
+    mockUseHomeStore.mockReturnValue({
+      layout: 'columns',
+      setLayout: vi.fn(),
+      reach: 'all',
+      setReach: vi.fn(),
+      sort: 'timeline',
+      setSort: vi.fn(),
+      content: 'all',
+      setContent: mockSetContent,
+      profileTags: ['bitcoin'],
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+    });
+
+    render(<HomeFeedSidebar />);
+
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-profile-tags', '');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-profile-tags-disabled', 'true');
+  });
+
+  it('hides and disables profile tags while effective reach is me until Nexus support ships', () => {
+    mockUseHomeStore.mockReturnValue({
+      layout: 'columns',
+      setLayout: vi.fn(),
+      reach: 'me',
+      setReach: vi.fn(),
+      sort: 'timeline',
+      setSort: vi.fn(),
+      content: 'all',
+      setContent: mockSetContent,
+      profileTags: ['bitcoin'],
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+    });
+
+    render(<HomeFeedSidebar />);
+
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'me');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-profile-tags', '');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-profile-tags-disabled', 'true');
   });
 });
 

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx.snap
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx.snap
@@ -7,7 +7,10 @@ exports[`HomeFeedDrawer - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
+      data-profile-tags=""
       data-selected-tab="following"
+      data-show-me="true"
+      data-show-network="true"
       data-testid="filter-reach"
     >
       FilterReach
@@ -40,7 +43,10 @@ exports[`HomeFeedDrawerMobile - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
+      data-profile-tags=""
       data-selected-tab="following"
+      data-show-me="true"
+      data-show-network="true"
       data-testid="filter-reach"
     >
       FilterReach
@@ -67,7 +73,10 @@ exports[`HomeFeedSidebar - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
+      data-profile-tags=""
       data-selected-tab="following"
+      data-show-me="true"
+      data-show-network="true"
       data-testid="filter-reach"
     >
       FilterReach

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
@@ -33,14 +33,28 @@ function HomeFeedFilters({
   feedVariant = TIMELINE_FEED_VARIANT.HOME,
   variant = 'drawer',
 }: HomeFeedSidebarProps) {
-  const { layout, setLayout, reach, setReach, sort, setSort, content, setContent } = useHomeStore();
+  const {
+    layout,
+    setLayout,
+    reach,
+    setReach,
+    sort,
+    setSort,
+    content,
+    setContent,
+    profileTags,
+    addProfileTag,
+    removeProfileTag,
+  } = useHomeStore();
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const { requireAuth } = useRequireAuth();
   const isAuthenticated = Boolean(currentUserPubky);
   const effectiveReach = isAuthenticated ? reach : REACH.ALL;
+  const areProfileTagsDisabled = effectiveReach === REACH.ALL || effectiveReach === REACH.ME;
+  const effectiveProfileTags = isAuthenticated && !areProfileTagsDisabled ? profileTags : [];
   const { isPhoneViewport, isVisualActive } = useFeedLayoutResolution(feedVariant);
 
-  // "All" reach is public; "Following"/"Friends" require an account, so prompt Join Pubky in Explore mode.
+  // "All" reach is public; other reach options require an account, so prompt Join Pubky in Explore mode.
   const handleReachChange = (value: ReachType) => {
     if (value === REACH.ALL) {
       setReach(value);
@@ -59,7 +73,18 @@ function HomeFeedFilters({
 
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
-      {!hideReachFilter && <FilterReach selectedTab={effectiveReach} onTabChange={handleReachChange} />}
+      {!hideReachFilter && (
+        <FilterReach
+          selectedTab={effectiveReach}
+          onTabChange={handleReachChange}
+          showNetwork
+          showMe
+          profileTags={effectiveProfileTags}
+          onProfileTagAdd={addProfileTag}
+          onProfileTagRemove={removeProfileTag}
+          profileTagsDisabled={areProfileTagsDisabled}
+        />
+      )}
       <FilterSort selectedTab={sort} onTabChange={setSort} />
       {variant === 'sidebar' ? (
         <Container overrideDefaults className="sticky top-[100px] flex w-full flex-col gap-6 self-start">

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
@@ -10,7 +10,7 @@ import { FilterReach } from '@/molecules/Filters/FilterReach/FilterReach';
 import { FilterSort } from '@/molecules/Filters/FilterSort/FilterSort';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
-import { REACH, type ReachType } from '@/stores/home/home.types';
+import { isProfileTagGatedReach, REACH, type ReachType } from '@/stores/home/home.types';
 import {
   resolveVisualFeedContent,
   VISUAL_DISABLED_CONTENT,
@@ -50,7 +50,7 @@ function HomeFeedFilters({
   const { requireAuth } = useRequireAuth();
   const isAuthenticated = Boolean(currentUserPubky);
   const effectiveReach = isAuthenticated ? reach : REACH.ALL;
-  const areProfileTagsDisabled = effectiveReach === REACH.ALL || effectiveReach === REACH.ME;
+  const areProfileTagsDisabled = isProfileTagGatedReach(effectiveReach);
   const effectiveProfileTags = isAuthenticated && !areProfileTagsDisabled ? profileTags : [];
   const { isPhoneViewport, isVisualActive } = useFeedLayoutResolution(feedVariant);
 

--- a/src/core/controllers/user/user.test.ts
+++ b/src/core/controllers/user/user.test.ts
@@ -9,7 +9,6 @@ import { FollowNormalizer } from '@/pipes/follow/follow.normalizer';
 import type { NexusTag, NexusTaggers, NexusUserCounts, NexusUserDetails } from '@/services/nexus/nexus.types';
 import { useHomeStore } from '@/stores/home/home.store';
 import { CONTENT, REACH, SORT } from '@/stores/home/home.types';
-import { getStreamId } from '@/stores/home/home.utils';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { UserController } from './user';
 
@@ -24,17 +23,8 @@ vi.mock('@/stores/home/home.store', async (importOriginal) => {
   };
 });
 
-vi.mock('@/stores/home/home.utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/stores/home/home.utils')>();
-  return {
-    ...actual,
-    getStreamId: vi.fn(),
-  };
-});
-
 const mockUseHomeStore = vi.mocked(useHomeStore);
 const mockUseHomeStoreGetState = vi.mocked(useHomeStore.getState);
-const mockGetStreamId = vi.mocked(getStreamId);
 
 const createMockHomeState = () =>
   asOpaque<ReturnType<typeof useHomeStore.getState>>({
@@ -54,7 +44,6 @@ describe('UserController', () => {
     vi.clearAllMocks();
     mockUseHomeStore.mockReset();
     mockUseHomeStoreGetState.mockReset();
-    mockGetStreamId.mockReset();
   });
 
   afterEach(() => {
@@ -496,7 +485,7 @@ describe('UserController', () => {
     it('should pass activeStreamId when on /home route', async () => {
       const follower = TEST_PUBKY.USER_1;
       const followee = TEST_PUBKY.USER_2;
-      const mockStreamId = 'home:all:all' as PostStreamTypes;
+      const expectedStreamId = 'timeline:all:all' as PostStreamTypes;
 
       const mockFollowJson = { foo: 'bar' } as Record<string, unknown>;
       const mockToJson = vi.fn(() => mockFollowJson);
@@ -514,9 +503,8 @@ describe('UserController', () => {
         value: { pathname: '/home' },
         writable: true,
       });
-      // Mock useHomeStore and getStreamId to return the mock stream ID
+      // Mock useHomeStore so the controller can derive the active stream ID.
       mockUseHomeStoreGetState.mockReturnValue(createMockHomeState());
-      mockGetStreamId.mockReturnValue(mockStreamId);
       const followSpy = vi.spyOn(UserApplication, 'commitFollow').mockResolvedValue(undefined);
 
       await UserController.commitFollow(HttpMethod.PUT, { follower, followee });
@@ -527,7 +515,7 @@ describe('UserController', () => {
         followJson: mockFollowJson,
         follower,
         followee,
-        activeStreamId: mockStreamId,
+        activeStreamId: expectedStreamId,
       });
     });
   });

--- a/src/core/controllers/user/user.ts
+++ b/src/core/controllers/user/user.ts
@@ -18,8 +18,9 @@ import type {
   NexusUserRelationship,
 } from '@/services/nexus/nexus.types';
 import type { TUserTaggersParams, TUserTagsParams } from '@/services/nexus/user/user.types';
+import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
-import { getStreamId } from '@/stores/home/home.utils';
+import { getHomeStreamIdFromFilters } from '@/stores/home/home.utils';
 
 export class UserController {
   private constructor() {} // Prevent instantiation
@@ -202,7 +203,8 @@ export class UserController {
 
     try {
       const homeState = useHomeStore.getState();
-      return getStreamId(homeState.sort, homeState.reach, homeState.content);
+      const currentUserPubky = useAuthStore.getState().currentUserPubky;
+      return getHomeStreamIdFromFilters(homeState.sort, homeState.reach, homeState.content, currentUserPubky);
     } catch (error) {
       Logger.warn('Failed to get active stream ID', { error });
       return null;

--- a/src/core/coordinators/streams/stream.ts
+++ b/src/core/coordinators/streams/stream.ts
@@ -19,8 +19,9 @@ import { buildCompositeId } from '@/models/models.utils';
 import { buildPostReplyStreamId, type PostStreamId } from '@/models/stream/post/postStream.types';
 import { StreamSorting } from '@/services/nexus/nexus.types';
 import { breakDownStreamId } from '@/services/nexus/stream/posts/postStream.utils';
+import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
-import { getStreamId } from '@/stores/home/home.utils';
+import { getHomeStreamIdFromFilters } from '@/stores/home/home.utils';
 
 /**
  * StreamCoordinator
@@ -178,7 +179,8 @@ export class StreamCoordinator extends Coordinator<StreamCoordinatorConfig, Stre
     // Home route: build from home store state
     if (this.state.currentRoute === APP_ROUTES.HOME) {
       const { sort, reach, content } = useHomeStore.getState();
-      this.streamState.currentStreamId = getStreamId(sort, reach, content);
+      const currentUserPubky = useAuthStore.getState().currentUserPubky;
+      this.streamState.currentStreamId = getHomeStreamIdFromFilters(sort, reach, content, currentUserPubky);
       Logger.debug(`Built ${APP_ROUTES.HOME} streamId`, { streamId: this.streamState.currentStreamId });
     }
     // Post route: extract from URL and build reply stream ID

--- a/src/core/services/nexus/stream/posts/postStream.api.ts
+++ b/src/core/services/nexus/stream/posts/postStream.api.ts
@@ -51,6 +51,11 @@ export const postStreamApi = {
   friends: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.FRIENDS, STREAM_PREFIX.POSTS_KEYS),
 
+  wot: (params: TStreamWithObserverParams) => buildPostStreamUrl(params, StreamSource.WOT, STREAM_PREFIX.POSTS_KEYS),
+
+  wot_domain: (params: TStreamWithObserverParams) =>
+    buildPostStreamUrl(params, StreamSource.WOT_DOMAIN, STREAM_PREFIX.POSTS_KEYS),
+
   bookmarks: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.BOOKMARKS, STREAM_PREFIX.POSTS_KEYS),
 

--- a/src/core/services/nexus/stream/posts/postStream.constants.ts
+++ b/src/core/services/nexus/stream/posts/postStream.constants.ts
@@ -1,1 +1,2 @@
 export const POST_STREAM_TAG_DELIMITER = ',';
+export const POST_STREAM_WOT_DEFAULT_DEPTH = 2;

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -45,6 +45,10 @@ function callStreamEndpoint(
       return postStreamApi.followers(params as TStreamWithObserverParams);
     case 'friends':
       return postStreamApi.friends(params as TStreamWithObserverParams);
+    case 'wot':
+      return postStreamApi.wot(params as TStreamWithObserverParams);
+    case 'wot_domain':
+      return postStreamApi.wot_domain(params as TStreamWithObserverParams);
     case 'bookmarks':
       return postStreamApi.bookmarks(params as TStreamWithObserverParams);
     case 'post_replies':
@@ -110,6 +114,18 @@ describe('Stream API URL Generation', () => {
         endpoint: 'friends' as const,
         params: { observer_id: mockObserverId, tags: 'dev,opensource', kind: StreamKind.SHORT },
         expectedInUrl: ['source=friends', `observer_id=${mockObserverId}`, 'tags=dev%2Copensource', 'kind=short'],
+      },
+      {
+        name: 'wot',
+        endpoint: 'wot' as const,
+        params: { observer_id: mockObserverId, depth: 2, kind: StreamKind.LONG },
+        expectedInUrl: ['source=wot', `observer_id=${mockObserverId}`, 'depth=2', 'kind=long'],
+      },
+      {
+        name: 'wot_domain',
+        endpoint: 'wot_domain' as const,
+        params: { observer_id: mockObserverId, depth: 2, domain_tags: 'bitcoiner,dev' },
+        expectedInUrl: ['source=wot_domain', `observer_id=${mockObserverId}`, 'depth=2', 'domain_tags=bitcoiner%2Cdev'],
       },
       {
         name: 'bookmarks',
@@ -397,6 +413,24 @@ describe('createPostStreamParams', () => {
       expect(result.params.viewer_id).toBe(mockViewerId);
       expect(result.params.limit).toBe(20);
       expect(result.invokeEndpoint).toBe(StreamSource.BOOKMARKS);
+    });
+  });
+
+  describe('WoT streams', () => {
+    it('should set default depth for timeline:wot streams', () => {
+      const result = createPostStreamParams({
+        streamId: 'timeline:wot:all' as PostStreamId,
+        streamTail: 0,
+        streamHead: 0,
+        limit: 20,
+        viewerId: mockViewerId,
+      });
+
+      expect(result.params.sorting).toBe(StreamSorting.TIMELINE);
+      expect(result.params.depth).toBe(2);
+      expect(result.params.viewer_id).toBe(mockViewerId);
+      expect(result.params.limit).toBe(20);
+      expect(result.invokeEndpoint).toBe(StreamSource.WOT);
     });
   });
 
@@ -723,6 +757,11 @@ describe('breakDownStreamId', () => {
       const result = breakDownStreamId('timeline:following:short' as PostStreamId);
       expect(result).toEqual(['timeline', StreamSource.FOLLOWING, 'short', undefined]);
     });
+
+    it('should parse wot source', () => {
+      const result = breakDownStreamId('timeline:wot:all' as PostStreamId);
+      expect(result).toEqual(['timeline', StreamSource.WOT, 'all', undefined]);
+    });
   });
 
   describe('Replies pattern', () => {
@@ -823,6 +862,13 @@ describe('NexusPostStreamService', () => {
         expectedInUrl: ['source=friends', 'observer_id=viewer-pubky-id', 'tags=tech%2Cdev'],
       },
       {
+        name: 'WOT',
+        invokeEndpoint: StreamSource.WOT,
+        params: { limit: 15, viewer_id: mockViewerId, depth: 2 },
+        extraParams: {},
+        expectedInUrl: ['source=wot', 'observer_id=viewer-pubky-id', 'depth=2'],
+      },
+      {
         name: 'BOOKMARKS',
         invokeEndpoint: StreamSource.BOOKMARKS,
         params: { limit: 25, viewer_id: mockViewerId, sorting: StreamSorting.TIMELINE },
@@ -905,6 +951,20 @@ describe('NexusPostStreamService', () => {
       {
         name: 'BOOKMARKS requires viewer_id',
         invokeEndpoint: StreamSource.BOOKMARKS,
+        params: { limit: 10 }, // Missing viewer_id
+        extraParams: {},
+        expectedError: 'Viewer ID is required',
+      },
+      {
+        name: 'WOT requires viewer_id',
+        invokeEndpoint: StreamSource.WOT,
+        params: { limit: 10 }, // Missing viewer_id
+        extraParams: {},
+        expectedError: 'Viewer ID is required',
+      },
+      {
+        name: 'WOT_DOMAIN requires viewer_id',
+        invokeEndpoint: StreamSource.WOT_DOMAIN,
         params: { limit: 10 }, // Missing viewer_id
         extraParams: {},
         expectedError: 'Viewer ID is required',

--- a/src/core/services/nexus/stream/posts/postStream.ts
+++ b/src/core/services/nexus/stream/posts/postStream.ts
@@ -46,10 +46,12 @@ export class NexusPostStreamService {
         break;
       case StreamSource.FOLLOWING:
       case StreamSource.FRIENDS:
+      case StreamSource.WOT:
+      case StreamSource.WOT_DOMAIN:
       case StreamSource.BOOKMARKS:
         // TODO: from now, always is going to be
         if (!params.viewer_id) {
-          throw new Error('Viewer ID is required for friends stream');
+          throw new Error(`Viewer ID is required for ${invokeEndpoint} stream`);
         }
         nexusEndpoint = postStreamApi[invokeEndpoint]({ ...params, observer_id: params.viewer_id });
         break;

--- a/src/core/services/nexus/stream/posts/postStream.types.ts
+++ b/src/core/services/nexus/stream/posts/postStream.types.ts
@@ -12,6 +12,8 @@ export enum StreamSource {
   FOLLOWING = 'following',
   FOLLOWERS = 'followers',
   FRIENDS = 'friends',
+  WOT = 'wot',
+  WOT_DOMAIN = 'wot_domain',
   BOOKMARKS = 'bookmarks',
   REPLIES = 'post_replies',
   AUTHOR = 'author',
@@ -51,6 +53,8 @@ export type TStreamBase = TPaginationParams &
     kind?: StreamKind;
     order?: StreamOrder;
     tags?: string; // Max 5 tags
+    depth?: number;
+    domain_tags?: string; // Max 5 profile/domain tags
   };
 
 // Specific parameter types for each source

--- a/src/core/services/nexus/stream/posts/postStream.utils.ts
+++ b/src/core/services/nexus/stream/posts/postStream.utils.ts
@@ -6,7 +6,10 @@ import type {
   TSetStreamPaginationParams,
 } from '@/services/local/stream/posts/post.types';
 import { StreamSorting } from '@/services/nexus/nexus.types';
-import { POST_STREAM_TAG_DELIMITER } from '@/services/nexus/stream/posts/postStream.constants';
+import {
+  POST_STREAM_TAG_DELIMITER,
+  POST_STREAM_WOT_DEFAULT_DEPTH,
+} from '@/services/nexus/stream/posts/postStream.constants';
 import {
   StreamKind,
   StreamOrder,
@@ -39,6 +42,9 @@ export function createPostStreamParams({
   params.viewer_id = viewerId ?? undefined;
   params.sorting = parseSorting(sorting);
   params.tags = tags;
+  if (invokeEndpoint === StreamSource.WOT || invokeEndpoint === StreamSource.WOT_DOMAIN) {
+    params.depth = POST_STREAM_WOT_DEFAULT_DEPTH;
+  }
   // REPLIES and COLLECTION use the third segment for an entity id (postId), not a kind.
   if (content && invokeEndpoint !== StreamSource.REPLIES && invokeEndpoint !== StreamSource.COLLECTION) {
     params.kind = parseContent(content);

--- a/src/core/stores/home/home.actions.ts
+++ b/src/core/stores/home/home.actions.ts
@@ -1,5 +1,37 @@
 import { ZustandSet } from '../stores.types';
-import { HomeActions, HomeActionTypes, homeInitialState, HomeStore } from './home.types';
+import {
+  HOME_PROFILE_TAGS_MAX_SELECTED,
+  HomeActions,
+  HomeActionTypes,
+  homeInitialState,
+  HomeStore,
+  REACH,
+  type ReachType,
+} from './home.types';
+
+function normalizeProfileTag(profileTag: string): string {
+  return profileTag.trim().toLowerCase();
+}
+
+function normalizeProfileTags(profileTags: string[]): string[] {
+  const normalizedTags = new Set<string>();
+
+  for (const profileTag of profileTags) {
+    const normalizedTag = normalizeProfileTag(profileTag);
+    if (normalizedTag) {
+      normalizedTags.add(normalizedTag);
+    }
+    if (normalizedTags.size >= HOME_PROFILE_TAGS_MAX_SELECTED) {
+      break;
+    }
+  }
+
+  return Array.from(normalizedTags);
+}
+
+function shouldClearProfileTagsForReach(reach: ReachType): boolean {
+  return reach === REACH.ALL || reach === REACH.ME;
+}
 
 // Actions/Mutators - State modification functions
 export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
@@ -12,11 +44,52 @@ export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
   },
 
   setReach: (reach) => {
-    set({ reach }, false, HomeActionTypes.SET_HOME_REACH);
+    set(
+      { reach, ...(shouldClearProfileTagsForReach(reach) ? { profileTags: [] } : {}) },
+      false,
+      HomeActionTypes.SET_HOME_REACH,
+    );
   },
 
   setContent: (content) => {
     set({ content }, false, HomeActionTypes.SET_HOME_CONTENT);
+  },
+
+  setProfileTags: (profileTags) => {
+    set({ profileTags: normalizeProfileTags(profileTags) }, false, HomeActionTypes.SET_HOME_PROFILE_TAGS);
+  },
+
+  addProfileTag: (profileTag) => {
+    set(
+      (state) => {
+        const normalizedTag = normalizeProfileTag(profileTag);
+        if (
+          !normalizedTag ||
+          state.profileTags.length >= HOME_PROFILE_TAGS_MAX_SELECTED ||
+          state.profileTags.some((tag) => tag.toLowerCase() === normalizedTag)
+        ) {
+          return { profileTags: state.profileTags };
+        }
+        return { profileTags: [...state.profileTags, normalizedTag] };
+      },
+      false,
+      HomeActionTypes.ADD_HOME_PROFILE_TAG,
+    );
+  },
+
+  removeProfileTag: (profileTag) => {
+    set(
+      (state) => {
+        const normalizedTag = normalizeProfileTag(profileTag);
+        return { profileTags: state.profileTags.filter((tag) => tag.toLowerCase() !== normalizedTag) };
+      },
+      false,
+      HomeActionTypes.REMOVE_HOME_PROFILE_TAG,
+    );
+  },
+
+  clearProfileTags: () => {
+    set({ profileTags: [] }, false, HomeActionTypes.CLEAR_HOME_PROFILE_TAGS);
   },
 
   reset: () => {

--- a/src/core/stores/home/home.actions.ts
+++ b/src/core/stores/home/home.actions.ts
@@ -1,3 +1,4 @@
+import { sanitizeTagInput } from '@/libs/utils/utils';
 import { ZustandSet } from '../stores.types';
 import {
   HOME_PROFILE_TAGS_MAX_SELECTED,
@@ -5,12 +6,11 @@ import {
   HomeActionTypes,
   homeInitialState,
   HomeStore,
-  REACH,
-  type ReachType,
+  isProfileTagGatedReach,
 } from './home.types';
 
 function normalizeProfileTag(profileTag: string): string {
-  return profileTag.trim().toLowerCase();
+  return sanitizeTagInput(profileTag.trim()).toLowerCase();
 }
 
 function normalizeProfileTags(profileTags: string[]): string[] {
@@ -29,10 +29,6 @@ function normalizeProfileTags(profileTags: string[]): string[] {
   return Array.from(normalizedTags);
 }
 
-function shouldClearProfileTagsForReach(reach: ReachType): boolean {
-  return reach === REACH.ALL || reach === REACH.ME;
-}
-
 // Actions/Mutators - State modification functions
 export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
   setLayout: (layout) => {
@@ -45,7 +41,7 @@ export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
 
   setReach: (reach) => {
     set(
-      { reach, ...(shouldClearProfileTagsForReach(reach) ? { profileTags: [] } : {}) },
+      { reach, ...(isProfileTagGatedReach(reach) ? { profileTags: [] } : {}) },
       false,
       HomeActionTypes.SET_HOME_REACH,
     );
@@ -66,7 +62,7 @@ export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
         if (
           !normalizedTag ||
           state.profileTags.length >= HOME_PROFILE_TAGS_MAX_SELECTED ||
-          state.profileTags.some((tag) => tag.toLowerCase() === normalizedTag)
+          state.profileTags.includes(normalizedTag)
         ) {
           return { profileTags: state.profileTags };
         }
@@ -81,7 +77,7 @@ export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
     set(
       (state) => {
         const normalizedTag = normalizeProfileTag(profileTag);
-        return { profileTags: state.profileTags.filter((tag) => tag.toLowerCase() !== normalizedTag) };
+        return { profileTags: state.profileTags.filter((tag) => tag !== normalizedTag) };
       },
       false,
       HomeActionTypes.REMOVE_HOME_PROFILE_TAG,

--- a/src/core/stores/home/home.store.test.ts
+++ b/src/core/stores/home/home.store.test.ts
@@ -179,12 +179,28 @@ describe('HomeStore', () => {
       expect(useHomeStore.getState().profileTags).toHaveLength(HOME_PROFILE_TAGS_MAX_SELECTED);
     });
 
+    it('should strip Nexus-invalid tag label characters and preserve emoji', () => {
+      const store = useHomeStore.getState();
+
+      store.setProfileTags(['Bit:coin', 'dev,tag', 'light ning', '🔥']);
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin', 'devtag', 'lightning', '🔥']);
+    });
+
     it('should add a normalized profile tag', () => {
       const store = useHomeStore.getState();
 
       store.addProfileTag('Bitcoin');
 
       expect(useHomeStore.getState().profileTags).toEqual(['bitcoin']);
+    });
+
+    it('should strip Nexus-invalid characters when adding a profile tag', () => {
+      const store = useHomeStore.getState();
+
+      store.addProfileTag('Bit:coin,🔥');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin🔥']);
     });
 
     it('should prevent duplicate profile tags', () => {

--- a/src/core/stores/home/home.store.test.ts
+++ b/src/core/stores/home/home.store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useHomeStore } from './home.store';
-import { CONTENT, homeInitialState, LAYOUT, REACH, SORT } from './home.types';
+import { CONTENT, HOME_PROFILE_TAGS_MAX_SELECTED, homeInitialState, LAYOUT, REACH, SORT } from './home.types';
 
 describe('HomeStore', () => {
   beforeEach(() => {
@@ -16,6 +16,7 @@ describe('HomeStore', () => {
       expect(state.sort).toBe(SORT.TIMELINE);
       expect(state.reach).toBe(REACH.ALL);
       expect(state.content).toBe(CONTENT.ALL);
+      expect(state.profileTags).toEqual([]);
     });
 
     it('should match homeInitialState', () => {
@@ -25,6 +26,7 @@ describe('HomeStore', () => {
       expect(state.sort).toBe(homeInitialState.sort);
       expect(state.reach).toBe(homeInitialState.reach);
       expect(state.content).toBe(homeInitialState.content);
+      expect(state.profileTags).toEqual(homeInitialState.profileTags);
     });
   });
 
@@ -102,11 +104,25 @@ describe('HomeStore', () => {
       expect(useHomeStore.getState().reach).toBe(REACH.FOLLOWING);
     });
 
+    it('should set reach to network', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.NETWORK);
+      expect(useHomeStore.getState().reach).toBe(REACH.NETWORK);
+    });
+
     it('should set reach to friends', () => {
       const store = useHomeStore.getState();
 
       store.setReach(REACH.FRIENDS);
       expect(useHomeStore.getState().reach).toBe(REACH.FRIENDS);
+    });
+
+    it('should set reach to me', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.ME);
+      expect(useHomeStore.getState().reach).toBe(REACH.ME);
     });
 
     it('should change reach multiple times', () => {
@@ -120,6 +136,90 @@ describe('HomeStore', () => {
 
       store.setReach(REACH.ALL);
       expect(useHomeStore.getState().reach).toBe(REACH.ALL);
+    });
+
+    it('should clear profile tags when reach changes to all', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.NETWORK);
+      store.addProfileTag('bitcoin');
+      store.addProfileTag('dev');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin', 'dev']);
+
+      store.setReach(REACH.ALL);
+
+      expect(useHomeStore.getState().reach).toBe(REACH.ALL);
+      expect(useHomeStore.getState().profileTags).toEqual([]);
+    });
+
+    it('should clear profile tags when reach changes to me while profile tags are gated', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.NETWORK);
+      store.addProfileTag('bitcoin');
+      store.addProfileTag('dev');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin', 'dev']);
+
+      store.setReach(REACH.ME);
+
+      expect(useHomeStore.getState().reach).toBe(REACH.ME);
+      expect(useHomeStore.getState().profileTags).toEqual([]);
+    });
+  });
+
+  describe('Profile Tag Management', () => {
+    it('should set normalized unique profile tags up to the max', () => {
+      const store = useHomeStore.getState();
+
+      store.setProfileTags(['Bitcoin', 'bitcoin', 'Nostr', 'Dev', 'Design', 'Lightning', 'Extra']);
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin', 'nostr', 'dev', 'design', 'lightning']);
+      expect(useHomeStore.getState().profileTags).toHaveLength(HOME_PROFILE_TAGS_MAX_SELECTED);
+    });
+
+    it('should add a normalized profile tag', () => {
+      const store = useHomeStore.getState();
+
+      store.addProfileTag('Bitcoin');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin']);
+    });
+
+    it('should prevent duplicate profile tags', () => {
+      const store = useHomeStore.getState();
+
+      store.addProfileTag('Bitcoin');
+      store.addProfileTag('bitcoin');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin']);
+    });
+
+    it('should prevent adding more than five profile tags', () => {
+      const store = useHomeStore.getState();
+
+      ['one', 'two', 'three', 'four', 'five', 'six'].forEach((tag) => store.addProfileTag(tag));
+
+      expect(useHomeStore.getState().profileTags).toEqual(['one', 'two', 'three', 'four', 'five']);
+    });
+
+    it('should remove a profile tag case-insensitively', () => {
+      const store = useHomeStore.getState();
+
+      store.setProfileTags(['bitcoin', 'nostr']);
+      store.removeProfileTag('BITCOIN');
+
+      expect(useHomeStore.getState().profileTags).toEqual(['nostr']);
+    });
+
+    it('should clear profile tags', () => {
+      const store = useHomeStore.getState();
+
+      store.setProfileTags(['bitcoin', 'nostr']);
+      store.clearProfileTags();
+
+      expect(useHomeStore.getState().profileTags).toEqual([]);
     });
   });
 

--- a/src/core/stores/home/home.store.ts
+++ b/src/core/stores/home/home.store.ts
@@ -20,6 +20,7 @@ export const useHomeStore = create<HomeStore>()(
           sort: state.sort,
           reach: state.reach,
           content: state.content,
+          profileTags: state.profileTags,
         }),
       },
     ),

--- a/src/core/stores/home/home.types.ts
+++ b/src/core/stores/home/home.types.ts
@@ -14,10 +14,14 @@ export const SORT = {
 // Like this, the reach value will invoke the specific API endpoint
 export const REACH = {
   ALL: 'all',
+  NETWORK: 'network',
   FOLLOWING: 'following',
   FRIENDS: 'friends',
-  //ME: 'me',
+  ME: 'me',
 } as const;
+
+// Nexus domain_tags API limit.
+export const HOME_PROFILE_TAGS_MAX_SELECTED = 5;
 
 export enum CONTENT {
   ALL = 'all',
@@ -41,6 +45,7 @@ export interface HomeState {
   sort: SortType;
   reach: ReachType;
   content: ContentType;
+  profileTags: string[];
 }
 
 export interface HomeActions {
@@ -48,6 +53,10 @@ export interface HomeActions {
   setSort: (sort: SortType) => void;
   setReach: (reach: ReachType) => void;
   setContent: (content: ContentType) => void;
+  setProfileTags: (profileTags: string[]) => void;
+  addProfileTag: (profileTag: string) => void;
+  removeProfileTag: (profileTag: string) => void;
+  clearProfileTags: () => void;
   reset: () => void;
 }
 
@@ -59,6 +68,7 @@ export const homeInitialState: HomeState = {
   sort: SORT.TIMELINE,
   reach: REACH.ALL,
   content: CONTENT.ALL,
+  profileTags: [],
 };
 
 // Action types for DevTools
@@ -67,5 +77,9 @@ export enum HomeActionTypes {
   SET_HOME_SORT = 'SET_HOME_SORT',
   SET_HOME_REACH = 'SET_HOME_REACH',
   SET_HOME_CONTENT = 'SET_HOME_CONTENT',
+  SET_HOME_PROFILE_TAGS = 'SET_HOME_PROFILE_TAGS',
+  ADD_HOME_PROFILE_TAG = 'ADD_HOME_PROFILE_TAG',
+  REMOVE_HOME_PROFILE_TAG = 'REMOVE_HOME_PROFILE_TAG',
+  CLEAR_HOME_PROFILE_TAGS = 'CLEAR_HOME_PROFILE_TAGS',
   RESET_HOME = 'RESET_HOME',
 }

--- a/src/core/stores/home/home.types.ts
+++ b/src/core/stores/home/home.types.ts
@@ -23,6 +23,10 @@ export const REACH = {
 // Nexus domain_tags API limit.
 export const HOME_PROFILE_TAGS_MAX_SELECTED = 5;
 
+export function isProfileTagGatedReach(reach: ReachType): boolean {
+  return reach === REACH.ALL || reach === REACH.ME;
+}
+
 export enum CONTENT {
   ALL = 'all',
   SHORT = 'short',

--- a/src/core/stores/home/home.utils.test.ts
+++ b/src/core/stores/home/home.utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { PostStreamTypes } from '@/models/stream/post/postStream.types';
 import { CONTENT, ContentType, REACH, ReachType, SORT, SortType } from './home.types';
-import { getStreamId, getStreamIdFromFilters, matchesFilters, parseStreamId } from './home.utils';
+import {
+  getHomeStreamIdFromFilters,
+  getStreamId,
+  getStreamIdFromFilters,
+  matchesFilters,
+  parseStreamId,
+} from './home.utils';
 
 describe('filters.utils', () => {
   describe('getStreamIdFromFilters', () => {
@@ -28,9 +34,20 @@ describe('filters.utils', () => {
         expect(streamId).toBe('timeline:following:all');
       });
 
+      it('should map "network" reach to wot source', () => {
+        const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL);
+        expect(streamId).toBe('timeline:wot:all');
+      });
+
       it('should map "friends" reach', () => {
         const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.FRIENDS, CONTENT.ALL);
         expect(streamId).toBe('timeline:friends:all');
+      });
+
+      it('should require viewer-aware helper for "me" reach', () => {
+        expect(() => getStreamIdFromFilters(SORT.TIMELINE, REACH.ME, CONTENT.ALL)).toThrow(
+          'Me reach requires the current user id',
+        );
       });
     });
 
@@ -108,6 +125,11 @@ describe('filters.utils', () => {
       expect(streamId).toBe('timeline:friends:all');
     });
 
+    it('should return wot source stream id for Network reach', () => {
+      const streamId = getStreamId(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL);
+      expect(streamId).toBe('timeline:wot:all');
+    });
+
     it('should return PostStreamTypes.TIMELINE_ALL_IMAGE', () => {
       const streamId = getStreamId(SORT.TIMELINE, REACH.ALL, CONTENT.IMAGES);
       expect(streamId).toBe(PostStreamTypes.TIMELINE_ALL_IMAGE);
@@ -124,6 +146,26 @@ describe('filters.utils', () => {
       const streamId = getStreamId(SORT.ENGAGEMENT, REACH.FOLLOWING, CONTENT.VIDEOS);
       expect(streamId).toBe(PostStreamTypes.POPULARITY_FOLLOWING_VIDEO);
       expect(streamId).toBe('total_engagement:following:video');
+    });
+  });
+
+  describe('getHomeStreamIdFromFilters', () => {
+    it('should force all reach when no user is authenticated', () => {
+      const streamId = getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, null);
+
+      expect(streamId).toBe(PostStreamTypes.TIMELINE_ALL_ALL);
+    });
+
+    it('should build author stream for me reach with all content', () => {
+      const streamId = getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.ME, CONTENT.ALL, 'viewer-pubky');
+
+      expect(streamId).toBe('author:viewer-pubky');
+    });
+
+    it('should build author stream with content kind for me reach', () => {
+      const streamId = getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.ME, CONTENT.IMAGES, 'viewer-pubky');
+
+      expect(streamId).toBe('viewer-pubky:author:image');
     });
   });
 
@@ -183,6 +225,15 @@ describe('filters.utils', () => {
           sort: SORT.ENGAGEMENT,
           reach: REACH.FRIENDS,
           content: CONTENT.IMAGES,
+        });
+      });
+
+      it('should parse timeline:wot:all as Network reach', () => {
+        const result = parseStreamId('timeline:wot:all');
+        expect(result).toEqual({
+          sort: SORT.TIMELINE,
+          reach: REACH.NETWORK,
+          content: CONTENT.ALL,
         });
       });
 
@@ -253,6 +304,7 @@ describe('filters.utils', () => {
     it('should convert filters -> streamId -> filters consistently', () => {
       const testCases: Array<[typeof SORT.TIMELINE | typeof SORT.ENGAGEMENT, string, string]> = [
         [SORT.TIMELINE, REACH.ALL, CONTENT.ALL],
+        [SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL],
         [SORT.TIMELINE, REACH.FOLLOWING, CONTENT.IMAGES],
         [SORT.ENGAGEMENT, REACH.FRIENDS, CONTENT.VIDEOS],
         [SORT.ENGAGEMENT, REACH.ALL, CONTENT.LINKS],

--- a/src/core/stores/home/home.utils.ts
+++ b/src/core/stores/home/home.utils.ts
@@ -1,4 +1,6 @@
+import type { Pubky } from '@/models/models.types';
 import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
 import { CONTENT, type ContentType, REACH, type ReachType, SORT, type SortType } from './home.types';
 
 // ============================================
@@ -23,11 +25,14 @@ const SORT_TO_SORTING = {
 const SORTING_TO_SORT = reverseMapping(SORT_TO_SORTING);
 
 /** Maps REACH filter to streamId SOURCE part */
+type SourceMappedReachType = Exclude<ReachType, typeof REACH.ME>;
+
 const REACH_TO_SOURCE = {
   [REACH.ALL]: 'all',
+  [REACH.NETWORK]: 'wot',
   [REACH.FOLLOWING]: 'following',
   [REACH.FRIENDS]: 'friends',
-} as const satisfies Record<ReachType, string>;
+} as const satisfies Record<SourceMappedReachType, string>;
 
 /** Maps streamId SOURCE part to REACH filter (auto-generated) */
 const SOURCE_TO_REACH = reverseMapping(REACH_TO_SOURCE);
@@ -61,6 +66,10 @@ const KIND_TO_CONTENT = reverseMapping(CONTENT_TO_KIND);
  * getStreamIdFromFilters('recent', 'friends', 'posts') // => 'timeline:friends:short'
  */
 export function getStreamIdFromFilters(sort: SortType, reach: ReachType, content: ContentType): string {
+  if (reach === REACH.ME) {
+    throw new Error('Me reach requires the current user id. Use getHomeStreamIdFromFilters instead.');
+  }
+
   const sorting = SORT_TO_SORTING[sort];
   const source = REACH_TO_SOURCE[reach];
   const kind = CONTENT_TO_KIND[content];
@@ -83,6 +92,26 @@ export function getStreamId(sort: SortType, reach: ReachType, content: ContentTy
 
   // The streamId string matches the enum value exactly, so we can cast directly
   return streamId as PostStreamTypes;
+}
+
+export function getHomeStreamIdFromFilters(
+  sort: SortType,
+  reach: ReachType,
+  content: ContentType,
+  currentUserPubky?: Pubky | null,
+): PostStreamTypes {
+  const effectiveReach = currentUserPubky ? reach : REACH.ALL;
+
+  if (effectiveReach === REACH.ME) {
+    const kind = CONTENT_TO_KIND[content];
+    const streamId =
+      kind === 'all'
+        ? `${StreamSource.AUTHOR}:${currentUserPubky}`
+        : `${currentUserPubky}:${StreamSource.AUTHOR}:${kind}`;
+    return streamId as PostStreamTypes;
+  }
+
+  return getStreamId(sort, effectiveReach, content);
 }
 
 /**

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
@@ -183,8 +183,10 @@ describe('useStreamIdFromFilters', () => {
     // Test each reach option
     const reachOptions = [
       { reach: REACH.ALL, expected: 'timeline:all:all' },
+      { reach: REACH.NETWORK, expected: 'timeline:wot:all' },
       { reach: REACH.FOLLOWING, expected: 'timeline:following:all' },
       { reach: REACH.FRIENDS, expected: 'timeline:friends:all' },
+      { reach: REACH.ME, expected: 'author:viewer-pubky' },
     ];
 
     reachOptions.forEach(({ reach, expected }) => {
@@ -192,6 +194,18 @@ describe('useStreamIdFromFilters', () => {
       const { result } = renderHook(() => useStreamIdFromFilters());
       expect(result.current).toBe(expected);
     });
+  });
+
+  it('should build content-specific author stream when reach is me', () => {
+    const { result: setReach } = renderHook(() => useHomeStore((state) => state.setReach));
+    const { result: setContent } = renderHook(() => useHomeStore((state) => state.setContent));
+
+    setReach.current(REACH.ME);
+    setContent.current(CONTENT.IMAGES);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+
+    expect(result.current).toBe('viewer-pubky:author:image');
   });
 
   it('should handle all content types', () => {

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
@@ -2,7 +2,7 @@ import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
 import { type ContentType, REACH } from '@/stores/home/home.types';
-import { getStreamId } from '@/stores/home/home.utils';
+import { getHomeStreamIdFromFilters } from '@/stores/home/home.utils';
 
 /**
  * Custom hook that returns the current streamId based on global filter state
@@ -36,5 +36,5 @@ export function useStreamIdFromFilters(contentOverride?: ContentType): PostStrea
   const effectiveReach = currentUserPubky ? reach : REACH.ALL;
   const effectiveContent = contentOverride ?? content;
 
-  return getStreamId(sort, effectiveReach, effectiveContent);
+  return getHomeStreamIdFromFilters(sort, effectiveReach, effectiveContent, currentUserPubky);
 }


### PR DESCRIPTION
## Summary
- Fixes #2147.
- Adds the V1 Reach sidebar UI for WoT: `Network`, `Me`, and a profile-tag selector under Reach.
- Wires the base `Network` reach to the WoT stream source and plain `Me` to the existing author stream.
- Adds profile-tag UI/state only. Profile/domain tag stream identity and Nexus `wot_domain` requests are intentionally handled by #2148 and #2149.

## Changes
- Extends `FilterReach` with optional `Network` and `Me` options and embeds the new `FilterProfileTags` footer via `FilterRadioGroup` children.
- Adds `FilterProfileTags` with a vertical selected-tag stack, shared tag input behavior, API suggestions, emoji support, and the 5-tag `domain_tags` API cap.
- Persists selected `profileTags` in the home store with add/remove/clear actions; tags are disabled and reset for `All`, and also for `Me` until pubky/pubky-nexus#981 / #2150 ships.
- Maps `REACH.NETWORK` to `source=wot` for the base Network feed and maps `REACH.ME` to the existing author stream.
- Localizes new Reach/profile-tag strings across message locales and expands unit/snapshot coverage for sidebar, reach, store, stream helpers, and profile-tag input behavior.


https://github.com/user-attachments/assets/d68a8e1e-a484-4e54-a9f8-1a89af58c083


## Explicitly out of scope for this PR
- Encoding selected profile/domain tags into stream/cache identity (#2148).
- Building `source=wot_domain` stream IDs or Nexus requests with `domain_tags` (#2149).
- Enabling `Me + profile tags` before Nexus support ships (#2150 / pubky-nexus#981).
- Empty-state copy/CTA behavior for WoT/domain feeds (#2151).

## Test plan
- [ ] Open the Home sidebar (desktop) and drawer/mobile variants: Reach shows `All`, `Network`, `Following`, `Friends`, `Me`.
- [ ] Select `Network`, `Following`, or `Friends` while signed in: profile tag input is enabled; add/remove tags; verify max 5 selected tags.
- [ ] Add emoji profile tags via the shared tag emoji selector and via suggestions/free input.
- [ ] Switch to `All` or `Me`: selected profile tags clear and the input is disabled at reduced opacity.
- [ ] In Explore mode, selecting non-`All` reach prompts auth instead of changing reach.

## Notes
- Multiple selected profile tags use OR semantics, but actual domain-feed query behavior lands in #2148/#2149.
- `Me + profile tags` remains disabled until pubky-nexus#981 resolves.
- Figma: https://www.figma.com/design/01ZvjSPZnKTNmaEWz0yJsq/shadcn_ui-PUBKY?node-id=19902-14534&m=dev
