### PR TITLE
fix: advance skip-stream pagination by raw count, not visible count

### DIFF
--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx
@@ -1,13 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { useLiveQuery } from 'dexie-react-hooks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS, COLLECTIONS_SECTION_PAGE_SIZE } from '@/config/collections';
-import { BookmarkController } from '@/controllers/bookmark/bookmark';
-import { PostController } from '@/controllers/post/post';
 import { StreamPostsController } from '@/controllers/stream/posts/posts';
 import type { TReadPostStreamChunkResponse } from '@/controllers/stream/posts/posts.types';
-import { Logger } from '@/libs/logger/logger';
-import type { PostDetailsModelSchema } from '@/models/post/details/postDetails.schema';
 import { buildDiscoverCollectionsStreamId } from '@/models/stream/post/postStream.types';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { DiscoverCollections } from './DiscoverCollections';
@@ -16,17 +10,21 @@ import { DiscoverCollections } from './DiscoverCollections';
 // Mocks
 // ---------------------------------------------------------------------------
 
-let mockAuthState: { hasHydrated: boolean; currentUserPubky: string | null } = {
-  hasHydrated: false,
-  currentUserPubky: null,
-};
+let mockAuthState: { hasHydrated: boolean } = { hasHydrated: false };
+
+// Captured args from the (mocked) infinite-scroll hook so tests can drive auto-load
+// without a real IntersectionObserver.
+let capturedInfiniteScroll: { onLoadMore: () => void; hasMore: boolean; isLoading: boolean } | undefined;
 
 vi.mock('next-intl', () => ({
   useTranslations: (namespace?: string) => (key: string) => `${namespace ?? ''}.${key}`,
 }));
 
-vi.mock('dexie-react-hooks', () => ({
-  useLiveQuery: vi.fn(),
+vi.mock('@/hooks/useInfiniteScroll/useInfiniteScroll', () => ({
+  useInfiniteScroll: (opts: { onLoadMore: () => void; hasMore: boolean; isLoading: boolean }) => {
+    capturedInfiniteScroll = opts;
+    return { sentinelRef: vi.fn() };
+  },
 }));
 
 vi.mock('@/controllers/stream/posts/posts', () => ({
@@ -37,24 +35,8 @@ vi.mock('@/controllers/stream/posts/posts', () => ({
   },
 }));
 
-vi.mock('@/controllers/bookmark/bookmark', () => ({
-  BookmarkController: {
-    getAll: vi.fn(),
-  },
-}));
-
-vi.mock('@/controllers/post/post', () => ({
-  PostController: {
-    getDetailsByIds: vi.fn(),
-  },
-}));
-
 vi.mock('@/stores/auth/auth.store', () => ({
   useAuthStore: (selector: (state: typeof mockAuthState) => unknown) => selector(mockAuthState),
-}));
-
-vi.mock('@/libs/logger/logger', () => ({
-  Logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
 const mockToast = vi.fn();
@@ -71,21 +53,8 @@ vi.mock('@/molecules/AvatarStack/AvatarStack.skeleton', () => ({
 }));
 
 vi.mock('@/organisms/Collections/CollectionCard/CollectionCard', () => ({
-  CollectionCard: ({
-    authorPubky,
-    postId,
-    initialIsBookmarked,
-  }: {
-    authorPubky: string;
-    postId: string;
-    initialIsBookmarked?: boolean;
-  }) => (
-    <div
-      data-testid="collection-card"
-      data-author-pubky={authorPubky}
-      data-post-id={postId}
-      data-initial-bookmarked={String(!!initialIsBookmarked)}
-    />
+  CollectionCard: ({ authorPubky, postId }: { authorPubky: string; postId: string }) => (
+    <div data-testid="collection-card" data-author-pubky={authorPubky} data-post-id={postId} />
   ),
 }));
 
@@ -97,37 +66,29 @@ vi.mock('@/organisms/Collections/CollectionCard/CollectionCard.skeleton', () => 
 // Helpers
 // ---------------------------------------------------------------------------
 
-const collectionContent = (items: string[] = ['item:1']) =>
-  JSON.stringify({ name: 'Test Collection', items, description: '', cover_image: '' });
-
-const mockUseLiveQuery = vi.mocked(useLiveQuery);
 const mockGetOrFetchStreamSlice = vi.mocked(StreamPostsController.getOrFetchStreamSlice);
 const mockPrepareStreamForInitialLoad = vi.mocked(StreamPostsController.prepareStreamForInitialLoad);
 const mockGetCachedLastPostTimestamp = vi.mocked(StreamPostsController.getCachedLastPostTimestamp);
-const mockBookmarkGetAll = vi.mocked(BookmarkController.getAll);
-const mockGetDetailsByIds = vi.mocked(PostController.getDetailsByIds);
 
 function makeSlice({
   nextPageIds = [],
   reachedEnd = true,
-  timestamp = 0,
+  nextCursor = 0,
 }: {
   nextPageIds?: string[];
   reachedEnd?: boolean;
-  timestamp?: number;
+  nextCursor?: number;
 } = {}) {
-  return asOpaque<TReadPostStreamChunkResponse>({ nextPageIds, reachedEnd, timestamp });
+  return asOpaque<TReadPostStreamChunkResponse>({ nextPageIds, reachedEnd, nextCursor });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockAuthState = { hasHydrated: false, currentUserPubky: null };
-  mockUseLiveQuery.mockReturnValue(undefined);
+  capturedInfiniteScroll = undefined;
+  mockAuthState = { hasHydrated: false };
   mockPrepareStreamForInitialLoad.mockResolvedValue(undefined);
   mockGetCachedLastPostTimestamp.mockResolvedValue(0);
   mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ reachedEnd: true }));
-  mockBookmarkGetAll.mockResolvedValue([]);
-  mockGetDetailsByIds.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -137,103 +98,73 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+// Own / bookmarked / empty filtering for this stream lives in the shared stream layer (deleted
+// is dropped there for every feed; see post.ts `filterStreamPosts` + the `getOrFetchStreamSlice`
+// filter callback), so the component just renders `postIds`. Those filters are unit-tested in the
+// application layer.
 
 describe('DiscoverCollections', () => {
-  it('pre-hydration: renders title + AvatarStackSkeleton, no cards, no fetch', () => {
-    mockAuthState = { hasHydrated: false, currentUserPubky: null };
+  it('pre-hydration: renders title + skeletons and never fetches', () => {
+    mockAuthState = { hasHydrated: false };
 
     render(<DiscoverCollections />);
 
     expect(screen.getByText('collections.discover.title')).toBeInTheDocument();
     expect(screen.getByTestId('avatar-stack-skeleton')).toHaveAttribute('data-count', '3');
     expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
+    // The data layer (hook) is not mounted until hydration, so no fetch fires.
     expect(mockPrepareStreamForInitialLoad).not.toHaveBeenCalled();
     expect(mockGetOrFetchStreamSlice).not.toHaveBeenCalled();
   });
 
-  it('post-hydration: filters out own collections from the slice', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(
-      makeSlice({ nextPageIds: ['other:p1', 'me:p2', 'other:p3'], reachedEnd: true }),
-    );
-    mockBookmarkGetAll.mockResolvedValue([]);
+  it('post-hydration: fetches the discover stream at offset 0 and renders the returned ids', async () => {
+    mockAuthState = { hasHydrated: true };
+    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:p1', 'b:p2'], reachedEnd: true }));
 
     await act(async () => {
       render(<DiscoverCollections />);
     });
 
-    const expectedStreamId = buildDiscoverCollectionsStreamId();
+    const streamId = buildDiscoverCollectionsStreamId();
     await waitFor(() => {
-      expect(mockPrepareStreamForInitialLoad).toHaveBeenCalledWith({ streamId: expectedStreamId });
-      expect(mockGetCachedLastPostTimestamp).toHaveBeenCalledWith({ streamId: expectedStreamId });
+      expect(mockPrepareStreamForInitialLoad).toHaveBeenCalledWith({ streamId });
     });
+    // Discover is skip-paginated: the initial fetch starts at offset 0.
+    expect(mockGetOrFetchStreamSlice).toHaveBeenCalledWith(expect.objectContaining({ streamId, streamTail: 0 }));
 
     await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(2);
-      expect(cards[0]).toHaveAttribute('data-post-id', 'p1');
-      expect(cards[1]).toHaveAttribute('data-post-id', 'p3');
+      expect(screen.getAllByTestId('collection-card')).toHaveLength(2);
     });
   });
 
-  it('filters out already-bookmarked ids using BookmarkController.getAll()', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(
-      makeSlice({ nextPageIds: ['otherA:p1', 'otherB:p2'], reachedEnd: true }),
-    );
-    mockBookmarkGetAll.mockResolvedValue(['otherA:p1']);
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-author-pubky', 'otherB');
-      expect(cards[0]).toHaveAttribute('data-post-id', 'p2');
-    });
-  });
-
-  it('triggers backfill when an entire slice is filtered out and reachedEnd is false', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    // First slice: all own → filtered out. Second slice: a usable id.
+  it('auto-loads: wires loadMore + hasMore into infinite scroll and resumes from the returned cursor', async () => {
+    mockAuthState = { hasHydrated: true };
     mockGetOrFetchStreamSlice
-      .mockResolvedValueOnce(makeSlice({ nextPageIds: ['me:p1'], reachedEnd: false, timestamp: 10 }))
-      .mockResolvedValueOnce(makeSlice({ nextPageIds: ['other:p2'], reachedEnd: true, timestamp: 11 }));
+      .mockResolvedValueOnce(makeSlice({ nextPageIds: ['a:p1'], reachedEnd: false, nextCursor: 20 }))
+      .mockResolvedValueOnce(makeSlice({ nextPageIds: ['b:more'], reachedEnd: true, nextCursor: 21 }));
 
     await act(async () => {
       render(<DiscoverCollections />);
     });
 
     await waitFor(() => {
-      expect(mockGetOrFetchStreamSlice.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByTestId('collection-card').length).toBeGreaterThan(0);
     });
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-post-id', 'p2');
-    });
-  });
-
-  it('caps backfill at COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS when every slice is fully filtered', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    // Every slice is own-only and reachedEnd:false → backfill should be bounded.
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['me:p1'], reachedEnd: false, timestamp: 1 }));
+    expect(capturedInfiniteScroll?.hasMore).toBe(true);
 
     await act(async () => {
-      render(<DiscoverCollections />);
+      capturedInfiniteScroll?.onLoadMore();
     });
 
     await waitFor(() => {
-      expect(mockGetOrFetchStreamSlice).toHaveBeenCalledTimes(COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS);
+      expect(mockGetOrFetchStreamSlice.mock.calls.length).toBeGreaterThan(1);
     });
-    // Spinner clears even with no visible cards.
-    expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
+    // Resumes from the raw offset threaded back by the first page (20), not a visible-count cursor.
+    expect(mockGetOrFetchStreamSlice.mock.calls.at(-1)?.[0]).toMatchObject({ streamTail: 20 });
   });
 
-  it('renders empty state when loading: false, reachedEnd: true, and no visible cards', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
+  it('renders the empty state when the stream is exhausted with nothing to show', async () => {
+    mockAuthState = { hasHydrated: true };
     mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: [], reachedEnd: true }));
 
     await act(async () => {
@@ -244,154 +175,10 @@ describe('DiscoverCollections', () => {
       expect(screen.getByText('collections.discover.empty')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
-    expect(screen.queryByText('collections.showMore')).not.toBeInTheDocument();
   });
 
-  it('clicking Show More invokes another slice fetch using the last cursor', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    // First slice fills a page (>= COLLECTIONS_SECTION_PAGE_SIZE) so backfill
-    // stops after one round and Show More remains visible.
-    const firstSliceIds = Array.from({ length: COLLECTIONS_SECTION_PAGE_SIZE }, (_, i) => `other:p${i}`);
-    const lastIdOfFirstSlice = firstSliceIds[firstSliceIds.length - 1];
-    mockGetOrFetchStreamSlice.mockResolvedValueOnce(
-      makeSlice({ nextPageIds: firstSliceIds, reachedEnd: false, timestamp: 50 }),
-    );
-    mockGetOrFetchStreamSlice.mockResolvedValueOnce(
-      makeSlice({ nextPageIds: ['other:more'], reachedEnd: true, timestamp: 60 }),
-    );
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    const button = await screen.findByRole('button', { name: 'collections.showMore' });
-    const callsBefore = mockGetOrFetchStreamSlice.mock.calls.length;
-    await act(async () => {
-      button.click();
-    });
-    await waitFor(() => {
-      expect(mockGetOrFetchStreamSlice.mock.calls.length).toBeGreaterThan(callsBefore);
-    });
-
-    // The follow-up call should carry the cursor from the first call's result.
-    // Discover is an engagement-sorted stream (`total_engagement:all:collection`),
-    // so `streamTail` is a *skip offset* (= raw posts pulled so far), NOT the
-    // returned `last_post_score` timestamp. After one slice of
-    // `COLLECTIONS_SECTION_PAGE_SIZE` raw IDs, the next skip is that length.
-    const lastCallArgs = mockGetOrFetchStreamSlice.mock.calls.at(-1)?.[0];
-    expect(lastCallArgs).toMatchObject({
-      lastPostId: lastIdOfFirstSlice,
-      streamTail: COLLECTIONS_SECTION_PAGE_SIZE,
-      limit: COLLECTIONS_SECTION_PAGE_SIZE,
-    });
-  });
-
-  it('live-overlay subtracts ids that were locally bookmarked mid-session', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2'], reachedEnd: true }));
-    // Fetch-time bookmark set is empty; live overlay later includes 'a:1'.
-    mockBookmarkGetAll.mockResolvedValue([]);
-    // Two `useLiveQuery` calls run inside the component: the bookmarks overlay
-    // (deps: `[]`) and the deletions overlay (deps: `[visibleIds]`). Branch on
-    // deps so only the bookmarks overlay sees 'a:1' and the deletions overlay
-    // gets an empty `Set` (no live-deleted ids in this scenario).
-    mockUseLiveQuery.mockImplementation((_fn: unknown, deps?: unknown[]) =>
-      Array.isArray(deps) && deps.length === 0 ? ['a:1'] : new Set<string>(),
-    );
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-post-id', '2');
-      expect(cards[0]).toHaveAttribute('data-author-pubky', 'b');
-    });
-  });
-
-  it('fetch-time filter drops slice ids whose local PostDetails is tombstoned', async () => {
-    // Defense-in-depth against Nexus eventually-consistent streams: if a slice
-    // returns an id whose local PostDetails has `content === '[DELETED]'`,
-    // the fetch-time filter must skip it before it lands in `visibleIds`.
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2'], reachedEnd: true }));
-    mockGetDetailsByIds.mockResolvedValue([
-      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: '[DELETED]' }),
-      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent() }),
-    ]);
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-author-pubky', 'b');
-      expect(cards[0]).toHaveAttribute('data-post-id', '2');
-    });
-  });
-
-  it('fetch-time filter drops slice ids whose local PostDetails has zero items', async () => {
-    // Fourth filter layer (after own / followed / deleted): collections with
-    // an empty `items` array have nothing to discover, so they shouldn't reach
-    // `visibleIds`. Unparseable content (null envelope) is treated the same as
-    // empty — defensive against malformed content drifting in from Nexus.
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2', 'c:3'], reachedEnd: true }));
-    mockGetDetailsByIds.mockResolvedValue([
-      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: collectionContent([]) }),
-      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent(['x:1']) }),
-      asOpaque<PostDetailsModelSchema>({ id: 'c:3', kind: 'collection', content: 'not-json' }),
-    ]);
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-author-pubky', 'b');
-      expect(cards[0]).toHaveAttribute('data-post-id', '2');
-    });
-  });
-
-  it('live-overlay subtracts ids that have flipped to [DELETED] mid-session', async () => {
-    // Mirror the bookmarks-overlay test but for the deletions overlay: the
-    // second `useLiveQuery` returns the set of locally-deleted ids in the
-    // visible window, and `displayIds` must exclude them.
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'b:2'], reachedEnd: true }));
-    mockBookmarkGetAll.mockResolvedValue([]);
-    // Fetch-time details are clean (live content); deletion only happens
-    // mid-session and is surfaced by the live overlay.
-    mockGetDetailsByIds.mockResolvedValue([
-      asOpaque<PostDetailsModelSchema>({ id: 'a:1', kind: 'collection', content: collectionContent() }),
-      asOpaque<PostDetailsModelSchema>({ id: 'b:2', kind: 'collection', content: collectionContent() }),
-    ]);
-    // Two live queries — bookmarks (deps: []) returns []; deletions (deps:
-    // [visibleIds]) returns the deleted-id Set.
-    mockUseLiveQuery.mockImplementation((_fn: unknown, deps?: unknown[]) =>
-      Array.isArray(deps) && deps.length === 0 ? [] : new Set<string>(['a:1']),
-    );
-
-    await act(async () => {
-      render(<DiscoverCollections />);
-    });
-
-    await waitFor(() => {
-      const cards = screen.getAllByTestId('collection-card');
-      expect(cards).toHaveLength(1);
-      expect(cards[0]).toHaveAttribute('data-author-pubky', 'b');
-      expect(cards[0]).toHaveAttribute('data-post-id', '2');
-    });
-  });
-
-  it('AvatarStack pubkys are derived from the unique authors of displayIds', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
+  it('derives AvatarStack pubkys from the visible cards', async () => {
+    mockAuthState = { hasHydrated: true };
     mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:1', 'a:2', 'b:3'], reachedEnd: true }));
 
     await act(async () => {
@@ -399,13 +186,12 @@ describe('DiscoverCollections', () => {
     });
 
     await waitFor(() => {
-      const stack = screen.getByTestId('avatar-stack');
-      expect(stack).toHaveAttribute('data-pubkys', 'a,b');
+      expect(screen.getByTestId('avatar-stack')).toHaveAttribute('data-pubkys', 'a,b');
     });
   });
 
-  it('on slice failure: logs error, fires the load-failed toast, hides Show More, and clears loading', async () => {
-    mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
+  it('on fetch failure: fires the load-failed toast and surfaces the empty state', async () => {
+    mockAuthState = { hasHydrated: true };
     mockGetOrFetchStreamSlice.mockRejectedValue(new Error('boom'));
 
     await act(async () => {
@@ -413,54 +199,40 @@ describe('DiscoverCollections', () => {
     });
 
     await waitFor(() => {
-      expect(Logger.error).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith({ variant: 'error', description: 'collections.loadFailed' });
     });
-    // Mirror of the `MyCollections` onError toast — keeps failure UX
-    // consistent across the three Collections sections.
-    expect(mockToast).toHaveBeenCalledWith({
-      variant: 'error',
-      description: 'collections.loadFailed',
-    });
-    // No spinner, no Show More, no cards.
-    expect(screen.queryByText('collections.showMore')).not.toBeInTheDocument();
     expect(screen.queryByTestId('collection-card')).not.toBeInTheDocument();
-    // Empty state surfaces.
     expect(screen.getByText('collections.discover.empty')).toBeInTheDocument();
   });
 
   describe('DiscoverCollections - Snapshots', () => {
     it('matches the snapshot for the pre-hydration skeleton state', () => {
-      mockAuthState = { hasHydrated: false, currentUserPubky: null };
-
+      mockAuthState = { hasHydrated: false };
       const { container } = render(<DiscoverCollections />);
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    it('matches the snapshot for the populated state (post-filter cards + Show More)', async () => {
-      mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
+    it('matches the snapshot for the populated state', async () => {
+      mockAuthState = { hasHydrated: true };
       mockGetOrFetchStreamSlice.mockResolvedValue(
-        makeSlice({ nextPageIds: ['authorA:p1', 'authorB:p2'], reachedEnd: false, timestamp: 100 }),
+        makeSlice({ nextPageIds: ['authorA:p1', 'authorB:p2'], reachedEnd: false, nextCursor: 2 }),
       );
-      mockBookmarkGetAll.mockResolvedValue([]);
 
       const { container } = await act(async () => render(<DiscoverCollections />));
       await waitFor(() => {
         expect(screen.getAllByTestId('collection-card')).toHaveLength(2);
       });
-
       expect(container.firstChild).toMatchSnapshot();
     });
 
     it('matches the snapshot for the exhausted-empty state', async () => {
-      mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-      mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: [], reachedEnd: true, timestamp: 0 }));
-      mockBookmarkGetAll.mockResolvedValue([]);
+      mockAuthState = { hasHydrated: true };
+      mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: [], reachedEnd: true }));
 
       const { container } = await act(async () => render(<DiscoverCollections />));
       await waitFor(() => {
         expect(screen.getByText('collections.discover.empty')).toBeInTheDocument();
       });
-
       expect(container.firstChild).toMatchSnapshot();
     });
   });

--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx.snap
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`DiscoverCollections > DiscoverCollections - Snapshots > matches the sna
 </div>
 `;
 
-exports[`DiscoverCollections > DiscoverCollections - Snapshots > matches the snapshot for the populated state (post-filter cards + Show More) 1`] = `
+exports[`DiscoverCollections > DiscoverCollections - Snapshots > matches the snapshot for the populated state 1`] = `
 <div
   class="flex w-full flex-col gap-4"
   data-testid="container"
@@ -55,30 +55,19 @@ exports[`DiscoverCollections > DiscoverCollections - Snapshots > matches the sna
   >
     <div
       data-author-pubky="authorA"
-      data-initial-bookmarked="false"
       data-post-id="p1"
       data-testid="collection-card"
     />
     <div
       data-author-pubky="authorB"
-      data-initial-bookmarked="false"
       data-post-id="p2"
       data-testid="collection-card"
     />
   </div>
   <div
-    class="flex w-full justify-center"
+    class="flex w-full justify-center py-2"
     data-testid="container"
-  >
-    <button
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-brand/16 text-brand hover:!bg-brand/30 border-brand h-8 gap-1.5 px-3 has-[>svg]:px-3.5"
-      data-size="sm"
-      data-slot="button"
-      data-variant="default"
-    >
-      collections.showMore
-    </button>
-  </div>
+  />
 </div>
 `;
 

--- a/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
+++ b/src/components/organisms/Collections/DiscoverCollections/DiscoverCollections.tsx
@@ -1,24 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { useLiveQuery } from 'dexie-react-hooks';
 import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Heading } from '@/atoms/Heading/Heading';
 import { Typography } from '@/atoms/Typography/Typography';
-import {
-  COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS,
-  COLLECTIONS_SECTION_PAGE_SIZE,
-  COLLECTIONS_SECTION_SKELETON_COUNT,
-} from '@/config/collections';
-import { BookmarkController } from '@/controllers/bookmark/bookmark';
-import { PostController } from '@/controllers/post/post';
-import { StreamPostsController } from '@/controllers/stream/posts/posts';
-import { Logger } from '@/libs/logger/logger';
-import { parseCollectionContent } from '@/libs/post/collectionContent';
-import { isPostDeleted } from '@/libs/utils/utils';
+import { COLLECTIONS_SECTION_PAGE_SIZE, COLLECTIONS_SECTION_SKELETON_COUNT } from '@/config/collections';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
+import { useStreamPagination } from '@/hooks/useStreamPagination/useStreamPagination';
 import { parseCompositeId } from '@/models/models.utils';
 import { buildDiscoverCollectionsStreamId } from '@/models/stream/post/postStream.types';
 import { AvatarStack } from '@/molecules/AvatarStack/AvatarStack';
@@ -29,342 +18,71 @@ import { CollectionCardSkeleton } from '@/organisms/Collections/CollectionCard/C
 import { uniqueAuthors } from '@/organisms/Collections/collections.utils';
 import { useAuthStore } from '@/stores/auth/auth.store';
 
-interface DiscoverCursor {
-  lastPostId: string | undefined;
-  // For the engagement-sorted Discover stream (`total_engagement:all:collection`)
-  // `streamTail` is a *skip offset* — the running count of raw post IDs already
-  // pulled from the stream — NOT a timestamp / engagement score. See
-  // `createPostStreamParams` (engagement sorting branch) and the equivalent
-  // engagement handling in `useStreamPagination` (`cursorValue =
-  // postIdsRef.current.length`). Using `result.timestamp` here (which is
-  // `last_post_score` for engagement streams) breaks Show More: Nexus skips
-  // by the engagement score, yielding overlap or empty pages, and the backfill
-  // loop can't make progress.
-  streamTail: number;
+function DiscoverHeader({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('collections');
+  return (
+    <Container overrideDefaults className="flex items-center gap-3">
+      <Heading level={2} size="lg" className="font-light text-muted-foreground">
+        {t('discover.title')}
+      </Heading>
+      {children}
+    </Container>
+  );
 }
 
-const EMPTY_CURSOR: DiscoverCursor = { lastPostId: undefined, streamTail: 0 };
-
 /**
- * DiscoverCollections
+ * "Discover Collections": pages the global engagement stream (`total_engagement:all:collection`)
+ * via the shared `useStreamPagination` + `useInfiniteScroll` (auto-load, like every other feed).
+ * The viewer's own, already-bookmarked, and empty collections are filtered for this stream in the
+ * shared stream layer (deleted posts are already dropped there for every feed; see `filterStreamPosts`
+ * and the `getOrFetchStreamSlice` filter callback), so `postIds` is already the visible list: no
+ * component overlay, and `reachedEnd` bounds pagination exactly like the Popularity/Home walk past a
+ * muted region.
  *
- * "Discover Collections" section. Pulls the global engagement-sorted
- * collection-kind post stream (`total_engagement:all:collection`) and
- * filters out:
- *   - The current user's own collections.
- *   - Collections the current user has already bookmarked (followed).
- *   - Collections whose local PostDetails is tombstoned (`'[DELETED]'`).
- *   - Collections with zero items (nothing to discover).
- *
- * Filtering happens in two layers:
- *
- *   1. **Fetch-time filter** — read `BookmarkController.getAll()`
- *      synchronously after `getOrFetchStreamSlice` resolves and drop own
- *      + already-bookmarked ids before they ever enter `visibleIds`.
- *      This is the structural filter that prevents an unfiltered-flash on
- *      initial render (a `useLiveQuery`-driven id list would have that
- *      problem; ours doesn't).
- *
- *   2. **Render-time subtractive overlay** — `useLiveQuery` subscribes
- *      to the local `bookmarks` table and yields a set of currently
- *      bookmarked composite ids. `displayIds` is `visibleIds` minus that
- *      set. The overlay is monotonically subtractive (it can only remove,
- *      never add unfiltered cards), so it cannot reintroduce the
- *      unfiltered-flash class of bug fixed in QA #1/#3. Its job is to
- *      keep Discover semantically honest: when the user follows a card
- *      — here, from another section, or from a future surface — the
- *      card disappears from Discover without a reload.
- *
- * If the user follows every visible card mid-session, the grid empties
- * but Show More remains until `reachedEnd` (the global engagement stream
- * is exhausted). This is intentional: it reads as "you've followed
- * everything we showed you — click for more candidates."
- *
- * Backfill loop bounded by `COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS` —
- * each user-initiated action (initial mount or "Show more" click) will
- * pull up to that many slices if the fetch-time filter empties the page.
+ * The data layer is gated on auth hydration so the viewer is settled before the first fetch and
+ * own-collection filtering applies from the first paint.
  */
 export function DiscoverCollections() {
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  if (!hasHydrated) {
+    return (
+      <Container overrideDefaults className="flex w-full flex-col gap-4">
+        <DiscoverHeader>
+          <AvatarStackSkeleton count={3} size="md" />
+        </DiscoverHeader>
+        <Container overrideDefaults className="grid w-full grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-6">
+          {Array.from({ length: COLLECTIONS_SECTION_SKELETON_COUNT }).map((_, index) => (
+            <CollectionCardSkeleton key={`discover-collections-skeleton-${index}`} />
+          ))}
+        </Container>
+      </Container>
+    );
+  }
+  return <DiscoverCollectionsContent />;
+}
+
+function DiscoverCollectionsContent() {
   const t = useTranslations('collections');
   const { toast } = useToast();
-  const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
-  // Gate the initial fetch on auth hydration so we never fire a fetch under a
-  // transient `currentUserPubky === null` and then re-fire it with the real
-  // pubky once the store rehydrates — that race surfaces as a flash of
-  // unfiltered cards followed by the empty state.
-  const hasHydrated = useAuthStore((state) => state.hasHydrated);
   const streamId = buildDiscoverCollectionsStreamId();
 
-  const [visibleIds, setVisibleIds] = useState<string[]>([]);
-  const cursorRef = useRef<DiscoverCursor>(EMPTY_CURSOR);
-  const [reachedEnd, setReachedEnd] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  // Ref of currently-visible IDs, read inside the async fetch loop so we
-  // don't have to re-create the function on every successful append.
-  const visibleIdsRef = useRef<string[]>([]);
-  visibleIdsRef.current = visibleIds;
-
-  // Cancellation token for the in-flight initial fetch. When the effect
-  // re-fires (StrictMode double-invoke, or genuine viewer switch), the old
-  // fetch's closure sees `cancelled.current === true` and skips its state
-  // writes — only the latest run wins. This is the React-recommended
-  // pattern for fetch-in-effect (see https://react.dev/reference/react/useEffect
-  // "Fetching data with Effects"). It replaces an earlier ref-guard
-  // workaround that prevented the second fetch from running at all but
-  // fought StrictMode instead of cooperating with it.
-  const inFlightInitialRef = useRef<{ cancelled: boolean } | null>(null);
-
-  /**
-   * One user-initiated action: pulls slices until we have at least one
-   * page-size of visible (post-filter) IDs, the stream is exhausted, or
-   * the backfill cap hits.
-   *
-   * Optionally takes a `token` that the caller can flip to `cancelled` to
-   * make the run a no-op on its final state-write (used by the initial-load
-   * effect to handle StrictMode double-invoke and real viewer-switch
-   * re-fires).
-   */
-  const runUserAction = async ({ isInitial, token }: { isInitial: boolean; token?: { cancelled: boolean } }) => {
-    if (token?.cancelled) return;
-    if (isInitial) {
-      setLoading(true);
-    } else {
-      setLoadingMore(true);
-    }
-
-    // Use a *local* cursor inside this run — don't trample `cursorRef`
-    // until we're sure we won the race. The ref is only committed at the
-    // end if the run wasn't cancelled. This keeps concurrent runs from
-    // corrupting each other's pagination state under StrictMode.
-    let localCursor: DiscoverCursor = isInitial ? EMPTY_CURSOR : cursorRef.current;
-
-    try {
-      const collected: string[] = [];
-      let exhausted = false;
-
-      for (let round = 0; round < COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS; round += 1) {
-        if (isInitial && round === 0) {
-          // First mount: clear stale cache + sync any unread posts in case
-          // the engagement stream changed across sessions. Mirrors
-          // `useStreamPagination.fetchStreamSlice(isInitialLoad=true)`.
-          await StreamPostsController.prepareStreamForInitialLoad({ streamId });
-          if (token?.cancelled) return;
-          // Engagement streams aren't persisted to `posts_streams` (see
-          // `PostStreamApplication.fetchStreamFromNexus`), so the cached
-          // timestamp is always 0 here — but we keep the call for parity
-          // with `useStreamPagination.fetchStreamSlice(isInitialLoad=true)`
-          // in case the stream class ever changes. The skip cursor starts at 0.
-          await StreamPostsController.getCachedLastPostTimestamp({ streamId });
-          if (token?.cancelled) return;
-          localCursor = { lastPostId: undefined, streamTail: 0 };
-        }
-
-        const result = await StreamPostsController.getOrFetchStreamSlice({
-          streamId,
-          lastPostId: localCursor.lastPostId,
-          streamTail: localCursor.streamTail,
-          limit: COLLECTIONS_SECTION_PAGE_SIZE,
-        });
-        if (token?.cancelled) return;
-
-        // Walk the raw slice and collect up to `COLLECTIONS_SECTION_PAGE_SIZE`
-        // post-filter IDs. We track how many raw IDs we actually walked
-        // through (`rawConsumed`) so the skip cursor advances only by what we
-        // consumed — candidates past the cap on the last round get re-fetched
-        // on the next Show More instead of being silently dropped.
-        //
-        // Discover is an engagement-sorted stream: `streamTail` is a skip
-        // offset (count of raw post IDs already pulled from the stream), not
-        // a timestamp. Do NOT use `result.timestamp` (= `last_post_score`,
-        // an engagement score) for this cursor.
-        let rawConsumed = 0;
-        let reachedPageCap = false;
-        if (result.nextPageIds.length > 0) {
-          // Read the local bookmark set after persist has committed.
-          // Filter own + already-bookmarked + deleted + empty collections.
-          const bookmarkedIds = new Set(await BookmarkController.getAll());
-          if (token?.cancelled) return;
-          // Slice post details to identify already-deleted and empty
-          // collections in this batch. Mirrors the timeline's `isPostDeleted`
-          // guard in `useVisualFeedTiles` and FollowedCollections' live-query
-          // filter; the empty-items check drops collections with nothing to
-          // discover.
-          const sliceDetails = await PostController.getDetailsByIds({ compositeIds: result.nextPageIds });
-          if (token?.cancelled) return;
-          const deletedIds = new Set<string>();
-          const emptyIds = new Set<string>();
-          for (let i = 0; i < result.nextPageIds.length; i += 1) {
-            const detail = sliceDetails[i];
-            if (!detail) continue;
-            if (isPostDeleted(detail.content)) {
-              deletedIds.add(result.nextPageIds[i]);
-              continue;
-            }
-            if ((parseCollectionContent(detail.content)?.items?.length ?? 0) === 0) {
-              emptyIds.add(result.nextPageIds[i]);
-            }
-          }
-          const alreadyVisible = new Set([...visibleIdsRef.current, ...collected]);
-
-          for (const id of result.nextPageIds) {
-            rawConsumed += 1;
-            if (alreadyVisible.has(id)) continue;
-            if (bookmarkedIds.has(id)) continue;
-            if (deletedIds.has(id)) continue;
-            if (emptyIds.has(id)) continue;
-            if (isOwnCollection(id, currentUserPubky)) continue;
-            collected.push(id);
-            alreadyVisible.add(id);
-            if (collected.length >= COLLECTIONS_SECTION_PAGE_SIZE) {
-              reachedPageCap = true;
-              break;
-            }
-          }
-        }
-
-        // Advance the cursor by raw posts actually walked. When the filter
-        // empties the slice (rawConsumed === result.nextPageIds.length, none
-        // collected), this still progresses so the next backfill round
-        // doesn't re-fetch the same slice.
-        const nextLastId = rawConsumed > 0 ? result.nextPageIds[rawConsumed - 1] : localCursor.lastPostId;
-        localCursor = {
-          lastPostId: nextLastId,
-          streamTail: localCursor.streamTail + rawConsumed,
-        };
-
-        if (result.reachedEnd) {
-          exhausted = true;
-          break;
-        }
-        if (reachedPageCap) {
-          break;
-        }
-      }
-
-      if (token?.cancelled) return;
-
-      // Commit cursor + state only after winning the race.
-      cursorRef.current = localCursor;
-      setReachedEnd(exhausted);
-      setVisibleIds((prev) => (isInitial ? collected : [...prev, ...collected]));
-    } catch (error) {
-      Logger.error('[DiscoverCollections] Failed to fetch slice', { error });
-      if (token?.cancelled) return;
-      // Mirror `MyCollections`' `useStreamPagination({ onError })` toast so the
-      // three Collections sections fail consistently from the user's POV.
-      toast({
-        variant: 'error',
-        description: t('loadFailed'),
-      });
-      // Give up on this action so the spinner clears.
-      setReachedEnd(true);
-    } finally {
-      if (token?.cancelled) return;
-      if (isInitial) {
-        setLoading(false);
-      } else {
-        setLoadingMore(false);
-      }
-    }
-  };
-
-  // Initial load — wait until the auth store has rehydrated so we filter
-  // against the *settled* `currentUserPubky` from the very first fetch.
-  //
-  // Uses the cancellation-token pattern: on effect cleanup (StrictMode
-  // re-run or real dep change) the previous run is flagged `cancelled` and
-  // skips all of its remaining `set*` calls and cursor commits. Only the
-  // latest run survives — no interleaved double-fetch corruption.
-  useEffect(() => {
-    if (!hasHydrated) return;
-
-    // Mark any previous in-flight run as cancelled.
-    if (inFlightInitialRef.current) {
-      inFlightInitialRef.current.cancelled = true;
-    }
-    const token = { cancelled: false };
-    inFlightInitialRef.current = token;
-
-    setVisibleIds([]);
-    cursorRef.current = EMPTY_CURSOR;
-    setReachedEnd(false);
-    void runUserAction({ isInitial: true, token });
-
-    return () => {
-      token.cancelled = true;
-    };
-    // `runUserAction` is intentionally excluded: it closes over refs
-    // (`inFlightInitialRef`, `cursorRef`) and is recreated on every render, so
-    // including it would re-fire this initial-load effect on every state update
-    // and restart the fetch mid-stream. The auth/stream identity deps below are
-    // the only triggers we want.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasHydrated, currentUserPubky, streamId]);
-
-  // Live-reactive subtractive overlay: subscribe to the local bookmark id
-  // set so any Follow performed elsewhere in the app (e.g. from the Followed
-  // section's Unfollow CTA being toggled back on, or from a future surface)
-  // removes the corresponding card here without a reload. While the live
-  // query is still resolving (`undefined`) we render `visibleIds` unfiltered
-  // — safe because the fetch-time filter has already excluded everything
-  // currently bookmarked, so there's nothing for the overlay to remove on
-  // first paint.
-  const bookmarkedLive = useLiveQuery(() => BookmarkController.getAll(), []);
-  const bookmarkedSet = bookmarkedLive ? new Set(bookmarkedLive) : null;
-  // Live overlay for deletions + empty collections: subscribes to `post_details`
-  // (via `getDetailsByIds`) for the current visible set and returns the subset
-  // whose content has flipped to '[DELETED]' OR whose item count has fallen to
-  // zero. Catches mid-session changes — e.g. an author deletes a collection or
-  // removes its last item on another device — so the card disappears from
-  // Discover without a reload. The fetch-time filter covers the cold path; this
-  // overlay covers the live path.
-  const hideLive = useLiveQuery(async () => {
-    if (visibleIds.length === 0) return new Set<string>();
-    const details = await PostController.getDetailsByIds({ compositeIds: visibleIds });
-    const hide = new Set<string>();
-    for (let i = 0; i < visibleIds.length; i += 1) {
-      const detail = details[i];
-      if (!detail) continue;
-      if (isPostDeleted(detail.content)) {
-        hide.add(visibleIds[i]);
-        continue;
-      }
-      if ((parseCollectionContent(detail.content)?.items?.length ?? 0) === 0) {
-        hide.add(visibleIds[i]);
-      }
-    }
-    return hide;
-  }, [visibleIds]);
-  const hideSet = hideLive ?? null;
-  const displayIds = visibleIds.filter((id) => {
-    if (bookmarkedSet && bookmarkedSet.has(id)) return false;
-    if (hideSet && hideSet.has(id)) return false;
-    return true;
+  const { postIds, loading, loadingMore, hasMore, loadMore } = useStreamPagination({
+    streamId,
+    limit: COLLECTIONS_SECTION_PAGE_SIZE,
+    onError: () => toast({ variant: 'error', description: t('loadFailed') }),
   });
 
-  // Unique authors of currently-visible cards (the AvatarStack caps it).
-  const headerPubkys = uniqueAuthors(displayIds);
+  const { sentinelRef } = useInfiniteScroll({ onLoadMore: loadMore, hasMore, isLoading: loadingMore });
 
-  const showShowMore = !reachedEnd && !loading;
-  // Discover always starts empty (no live-query fast path) — show skeletons
-  // for the entire initial-load duration, including any backfill rounds.
-  const showSkeletons = loading && displayIds.length === 0;
-  // Truly-exhausted empty state: stream reachedEnd AND nothing left to show
-  // after the live overlay subtracts followed cards. If the user has
-  // followed everything we surfaced mid-session, `reachedEnd` may still be
-  // false and Show More will be visible instead — that's intentional.
-  const showEmpty = !loading && reachedEnd && displayIds.length === 0;
+  const headerPubkys = uniqueAuthors(postIds);
+  const showSkeletons = loading && postIds.length === 0;
+  const showEmpty = !loading && !hasMore && postIds.length === 0;
 
   return (
     <Container overrideDefaults className="flex w-full flex-col gap-4">
-      <Container overrideDefaults className="flex items-center gap-3">
-        <Heading level={2} size="lg" className="font-light text-muted-foreground">
-          {t('discover.title')}
-        </Heading>
+      <DiscoverHeader>
         {showSkeletons ? <AvatarStackSkeleton count={3} size="md" /> : <AvatarStack pubkys={headerPubkys} />}
-      </Container>
+      </DiscoverHeader>
 
       {showEmpty ? (
         <Typography overrideDefaults className="text-sm text-muted-foreground">
@@ -376,36 +94,19 @@ export function DiscoverCollections() {
             ? Array.from({ length: COLLECTIONS_SECTION_SKELETON_COUNT }).map((_, index) => (
                 <CollectionCardSkeleton key={`discover-collections-skeleton-${index}`} />
               ))
-            : displayIds.map((compositeId) => {
+            : postIds.map((compositeId) => {
                 const { pubky, id } = parseCompositeId(compositeId);
                 return <CollectionCard key={compositeId} authorPubky={pubky} postId={id} />;
               })}
         </Container>
       )}
 
-      {showShowMore && (
-        <Container overrideDefaults className="flex w-full justify-center">
-          <Button
-            variant="default"
-            size="sm"
-            onClick={() => void runUserAction({ isInitial: false })}
-            disabled={loadingMore}
-          >
-            {loadingMore && <Loader2 className="size-4 animate-spin" />}
-            {t('showMore')}
-          </Button>
+      {/* Auto-load sentinel, gated on !showSkeletons so it isn't observed during the initial load. */}
+      {!showEmpty && !showSkeletons && hasMore && (
+        <Container ref={sentinelRef} overrideDefaults className="flex w-full justify-center py-2">
+          {loadingMore && <Loader2 className="size-4 animate-spin text-muted-foreground" />}
         </Container>
       )}
     </Container>
   );
-}
-
-function isOwnCollection(compositeId: string, currentUserPubky: string | null): boolean {
-  if (!currentUserPubky) return false;
-  try {
-    const { pubky } = parseCompositeId(compositeId);
-    return pubky === currentUserPubky;
-  } catch {
-    return false;
-  }
 }

--- a/src/components/organisms/Collections/FollowedCollections/FollowedCollections.test.tsx
+++ b/src/components/organisms/Collections/FollowedCollections/FollowedCollections.test.tsx
@@ -107,13 +107,13 @@ const mockGetDetailsByIds = vi.mocked(PostController.getDetailsByIds);
 function makeSlice({
   nextPageIds = [],
   reachedEnd = true,
-  timestamp = 0,
+  nextCursor = 0,
 }: {
   nextPageIds?: string[];
   reachedEnd?: boolean;
-  timestamp?: number;
+  nextCursor?: number;
 } = {}) {
-  return asOpaque<TReadPostStreamChunkResponse>({ nextPageIds, reachedEnd, timestamp });
+  return asOpaque<TReadPostStreamChunkResponse>({ nextPageIds, reachedEnd, nextCursor });
 }
 
 beforeEach(() => {
@@ -150,7 +150,9 @@ describe('FollowedCollections', () => {
 
   it('post-hydration: seeds the followed-collections stream and persists slice via the controller', async () => {
     mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:p1'], reachedEnd: true, timestamp: 123 }));
+    mockGetOrFetchStreamSlice.mockResolvedValue(
+      makeSlice({ nextPageIds: ['a:p1'], reachedEnd: true, nextCursor: 123 }),
+    );
 
     await act(async () => {
       render(<FollowedCollections />);
@@ -294,10 +296,12 @@ describe('FollowedCollections', () => {
     });
   });
 
-  it('shows Show More when reachedEnd is false; clicking fetches another slice', async () => {
+  it('shows Show More when reachedEnd is false; clicking resumes from the threaded nextCursor', async () => {
     mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
     mockUseLiveQuery.mockReturnValue(['a:p1']);
-    mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: ['a:p1'], reachedEnd: false, timestamp: 42 }));
+    mockGetOrFetchStreamSlice.mockResolvedValue(
+      makeSlice({ nextPageIds: ['a:p1'], reachedEnd: false, nextCursor: 42 }),
+    );
 
     await act(async () => {
       render(<FollowedCollections />);
@@ -313,6 +317,9 @@ describe('FollowedCollections', () => {
     await waitFor(() => {
       expect(mockGetOrFetchStreamSlice.mock.calls.length).toBeGreaterThan(callsBefore);
     });
+    // The follow-up fetch must resume from the cursor threaded back by the first page (42),
+    // proving the timestamp->nextCursor rename actually feeds pagination.
+    expect(mockGetOrFetchStreamSlice.mock.calls.at(-1)?.[0]).toMatchObject({ streamTail: 42 });
   });
 
   it('on seed-fetch failure: logs an error, fires the load-failed toast, and hides Show More (reachedEnd flips true)', async () => {
@@ -348,7 +355,7 @@ describe('FollowedCollections', () => {
       mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
       mockUseLiveQuery.mockReturnValue(['authorA:p1', 'authorB:p2']);
       mockGetOrFetchStreamSlice.mockResolvedValue(
-        makeSlice({ nextPageIds: ['authorA:p1', 'authorB:p2'], reachedEnd: false, timestamp: 100 }),
+        makeSlice({ nextPageIds: ['authorA:p1', 'authorB:p2'], reachedEnd: false, nextCursor: 100 }),
       );
 
       const { container } = await act(async () => render(<FollowedCollections />));
@@ -362,7 +369,7 @@ describe('FollowedCollections', () => {
     it('matches the snapshot for the empty state (live query empty, seed resolved)', async () => {
       mockAuthState = { hasHydrated: true, currentUserPubky: 'me' };
       mockUseLiveQuery.mockReturnValue([]);
-      mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: [], reachedEnd: true, timestamp: 0 }));
+      mockGetOrFetchStreamSlice.mockResolvedValue(makeSlice({ nextPageIds: [], reachedEnd: true, nextCursor: 0 }));
 
       const { container } = await act(async () => render(<FollowedCollections />));
       await waitFor(() => {

--- a/src/components/organisms/Collections/FollowedCollections/FollowedCollections.tsx
+++ b/src/components/organisms/Collections/FollowedCollections/FollowedCollections.tsx
@@ -89,7 +89,7 @@ export function FollowedCollections() {
       const nextLastId = result.nextPageIds[result.nextPageIds.length - 1];
       cursorRef.current = {
         lastPostId: nextLastId ?? cursorRef.current.lastPostId,
-        streamTail: result.timestamp ?? cursorRef.current.streamTail,
+        streamTail: result.nextCursor ?? cursorRef.current.streamTail,
       };
       setReachedEnd(result.reachedEnd === true);
     } catch (error) {

--- a/src/config/collections.ts
+++ b/src/config/collections.ts
@@ -9,20 +9,6 @@
 export const COLLECTIONS_SECTION_PAGE_SIZE = 20;
 
 /**
- * Safety cap for Discover's dedupe backfill loop — max number of additional
- * slices we pull per user-initiated action (initial mount or "Show more"
- * click) when post-filter visible count is below page size, before giving up
- * and rendering whatever we have.
- *
- * Why this exists: each Discover slice may have many items that get hidden
- * by the per-card filter (own collection, already bookmarked). Without
- * backfill, an unlucky page could render zero visible cards. The cap
- * prevents runaway fetching when most of the user's social graph already
- * follows everything on the feed.
- */
-export const COLLECTIONS_DISCOVER_BACKFILL_MAX_ROUNDS = 3;
-
-/**
  * Max number of unique author avatars to show in a section header's stacked
  * avatar group before collapsing the rest behind a `+N` overflow chip.
  */

--- a/src/core/application/stream/posts/muting/mute-pagination.test.ts
+++ b/src/core/application/stream/posts/muting/mute-pagination.test.ts
@@ -155,13 +155,13 @@ describe('Mute filtering with stream pagination', () => {
               `${mutedUserId}:post-9`,
             ],
             cacheMissPostIds: [],
-            timestamp: undefined,
+            nextCursor: undefined,
           };
         } else {
           return {
             nextPageIds: Array.from({ length: 10 }, (_, i) => `${validUserId}:post-${10 + i}`),
             cacheMissPostIds: [],
-            timestamp: BASE_TIMESTAMP + 19,
+            nextCursor: BASE_TIMESTAMP + 19,
           };
         }
       });
@@ -181,7 +181,7 @@ describe('Mute filtering with stream pagination', () => {
       });
 
       expect(result.posts).toHaveLength(10);
-      expect(result.timestamp).toBeDefined();
+      expect(result.nextCursor).toBeDefined();
 
       // Verify posts are in order and include expected posts
       const validPostNumbers = result.posts.map((id) => {
@@ -222,7 +222,7 @@ describe('Mute filtering with stream pagination', () => {
 
       expect(mockFetch).not.toHaveBeenCalled();
       expect(result.posts).toHaveLength(10);
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 9);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 9);
     });
   });
 
@@ -245,7 +245,7 @@ describe('Mute filtering with stream pagination', () => {
             ...Array.from({ length: 9 }, (_, i) => `${mutedUserId}:post-${fetchCount * 10 + i}`),
           ],
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + fetchCount * 10,
+          nextCursor: BASE_TIMESTAMP + fetchCount * 10,
         };
       });
 
@@ -274,11 +274,11 @@ describe('Mute filtering with stream pagination', () => {
           return {
             nextPageIds: ['author:post-1', 'author:post-2', 'author:post-3'],
             cacheMissPostIds: [],
-            timestamp: BASE_TIMESTAMP + 3,
+            nextCursor: BASE_TIMESTAMP + 3,
             reachedEnd: true, // Nexus returned 3 posts when we asked for 10
           };
         }
-        return { nextPageIds: [], cacheMissPostIds: [], timestamp: undefined, reachedEnd: true };
+        return { nextPageIds: [], cacheMissPostIds: [], nextCursor: undefined, reachedEnd: true };
       });
 
       const result = await queue.collect(streamId, {
@@ -297,7 +297,7 @@ describe('Mute filtering with stream pagination', () => {
       const mockFetch = vi.fn(async () => ({
         nextPageIds: Array.from({ length: 10 }, (_, i) => `author:post-${i}`),
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 10,
+        nextCursor: BASE_TIMESTAMP + 10,
         reachedEnd: false, // Returned exactly limit, more posts may exist
       }));
 
@@ -350,7 +350,7 @@ describe('Mute filtering with stream pagination', () => {
         return {
           nextPageIds: posts,
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + globalPostIndex,
+          nextCursor: BASE_TIMESTAMP + globalPostIndex,
         };
       });
 
@@ -365,7 +365,7 @@ describe('Mute filtering with stream pagination', () => {
       });
 
       expect(result1.posts.length).toBeGreaterThanOrEqual(10);
-      expect(result1.timestamp).toBeDefined();
+      expect(result1.nextCursor).toBeDefined();
 
       if (result1.posts.length < 10) {
         expect(result1.reachedEnd).toBe(false);
@@ -374,12 +374,12 @@ describe('Mute filtering with stream pagination', () => {
       // Second page
       const result2 = await queue.collect(streamId, {
         limit: 10,
-        cursor: result1.timestamp!,
+        cursor: result1.nextCursor!,
         filter: muteFilter,
         fetch: mockFetch,
       });
 
-      expect(result2.timestamp).toBeDefined();
+      expect(result2.nextCursor).toBeDefined();
 
       // Verify no duplicate posts between pages
       const allPosts = [...result1.posts, ...result2.posts];
@@ -399,13 +399,13 @@ describe('Mute filtering with stream pagination', () => {
           return {
             nextPageIds: Array.from({ length: 10 }, (_, i) => `${mutedUserId}:post-${fetchCount * 10 + i}`),
             cacheMissPostIds: [],
-            timestamp: BASE_TIMESTAMP + fetchCount * 10,
+            nextCursor: BASE_TIMESTAMP + fetchCount * 10,
           };
         }
         return {
           nextPageIds: Array.from({ length: 10 }, (_, i) => `${validUserId}:post-${fetchCount * 10 + i}`),
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + fetchCount * 10,
+          nextCursor: BASE_TIMESTAMP + fetchCount * 10,
         };
       });
 
@@ -475,8 +475,8 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
 
       expect(result.nextPageIds).toHaveLength(10);
       // KEY FIX: timestamp should be defined for full cache hits
-      expect(result.timestamp).toBeDefined();
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 9); // indexed_at of post-10
+      expect(result.nextCursor).toBeDefined();
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 9); // indexed_at of post-10
     });
 
     it('should allow cursor to advance correctly after full cache hit', async () => {
@@ -502,14 +502,14 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
       });
 
       expect(result1.nextPageIds).toHaveLength(10);
-      expect(result1.timestamp).toBeDefined();
+      expect(result1.nextCursor).toBeDefined();
 
       // Second page should use the timestamp as cursor
       const result2 = await PostStreamApplication.getOrFetchStreamSlice({
         streamId,
         limit: 10,
         streamHead: 0,
-        streamTail: result1.timestamp!,
+        streamTail: result1.nextCursor!,
         lastPostId: result1.nextPageIds[result1.nextPageIds.length - 1],
         viewerId: 'user-viewer' as Pubky,
       });
@@ -544,7 +544,7 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
       });
 
       expect(result.nextPageIds).toHaveLength(10);
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 9);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 9);
       expect(NexusPostStreamService.fetch).toHaveBeenCalled();
     });
 
@@ -627,7 +627,7 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
         streamId,
         limit: 10,
         streamHead: 0,
-        streamTail: result1.timestamp!,
+        streamTail: result1.nextCursor!,
         lastPostId: result1.nextPageIds[result1.nextPageIds.length - 1],
         viewerId: 'user-viewer' as Pubky,
       });
@@ -681,7 +681,7 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
 
       // Should have filtered out muted posts
       expect(result.nextPageIds.every((id) => !id.startsWith(MUTED_AUTHOR))).toBe(true);
-      expect(result.timestamp).toBeDefined();
+      expect(result.nextCursor).toBeDefined();
     });
   });
 
@@ -774,7 +774,7 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
       });
 
       expect(result1.nextPageIds.every((id) => !id.startsWith(MUTED_AUTHOR))).toBe(true);
-      expect(result1.timestamp).toBeDefined();
+      expect(result1.nextCursor).toBeDefined();
 
       // Unmute mid-scroll
       await clearMutedUsers();
@@ -785,14 +785,14 @@ describe('PostStreamApplication: Cache and Nexus transitions with muting', () =>
         streamId,
         limit: 5,
         streamHead: 0,
-        streamTail: result1.timestamp!,
+        streamTail: result1.nextCursor!,
         lastPostId: result1.nextPageIds[result1.nextPageIds.length - 1],
         viewerId: 'user-viewer' as Pubky,
       });
 
       // Key assertions: pagination continues correctly after unmuting
       expect(result2.nextPageIds.length).toBeGreaterThan(0);
-      expect(result2.timestamp).toBeDefined();
+      expect(result2.nextCursor).toBeDefined();
 
       // Note: Some overlap is acceptable when unmuting mid-scroll because
       // previously filtered posts become visible. The important thing is

--- a/src/core/application/stream/posts/muting/post-stream-queue.test.ts
+++ b/src/core/application/stream/posts/muting/post-stream-queue.test.ts
@@ -97,7 +97,7 @@ describe('PostStreamQueue', () => {
         return {
           nextPageIds: posts,
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + batch * 30,
+          nextCursor: BASE_TIMESTAMP + batch * 30,
         };
       });
 
@@ -114,7 +114,7 @@ describe('PostStreamQueue', () => {
       result1.posts.forEach((id) => allReturnedPosts.add(id));
 
       // Call 2: Should use queue (10 posts) + fetch more (10 new posts)
-      params.cursor = result1.timestamp!;
+      params.cursor = result1.nextCursor!;
       const result2 = await queue.collect(streamId, params);
       expect(result2.posts).toHaveLength(20);
 
@@ -151,7 +151,7 @@ describe('PostStreamQueue', () => {
       const mockFetch1 = vi.fn(async () => ({
         nextPageIds: Array.from({ length: 30 }, (_, i) => `author1:post-${i}`),
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 30,
+        nextCursor: BASE_TIMESTAMP + 30,
       }));
 
       const result1 = await queue.collect(streamId, {
@@ -170,12 +170,12 @@ describe('PostStreamQueue', () => {
       const mockFetch2 = vi.fn(async () => ({
         nextPageIds: Array.from({ length: 20 }, (_, i) => `author1:post-${30 + i}`),
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 50,
+        nextCursor: BASE_TIMESTAMP + 50,
       }));
 
       const result2 = await queue.collect(streamId, {
         limit: 20,
-        cursor: result1.timestamp!,
+        cursor: result1.nextCursor!,
         filter: filterMuted,
         fetch: mockFetch2,
       });
@@ -201,7 +201,7 @@ describe('PostStreamQueue', () => {
               ...Array.from({ length: 5 }, (_, i) => `muted:post-${i}`),
             ],
             cacheMissPostIds: [],
-            timestamp: BASE_TIMESTAMP + 19,
+            nextCursor: BASE_TIMESTAMP + 19,
           };
         } else {
           // Second batch: some duplicates from first batch + new posts
@@ -213,7 +213,7 @@ describe('PostStreamQueue', () => {
               ...Array.from({ length: 5 }, (_, i) => `muted:post-${i + 5}`), // Muted
             ],
             cacheMissPostIds: [],
-            timestamp: BASE_TIMESTAMP + 39,
+            nextCursor: BASE_TIMESTAMP + 39,
           };
         }
       });
@@ -261,7 +261,7 @@ describe('PostStreamQueue', () => {
       const mockFetch1 = vi.fn(async () => ({
         nextPageIds: Array.from({ length: 30 }, (_, i) => `post-${i}`),
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 29, // Timestamp of last post in fetch result
+        nextCursor: BASE_TIMESTAMP + 29, // Timestamp of last post in fetch result
       }));
 
       const result1 = await queue.collect(streamId, {
@@ -274,7 +274,7 @@ describe('PostStreamQueue', () => {
       expect(result1.posts).toHaveLength(20);
       expect(result1.posts[19]).toBe('post-19'); // Last post returned
       // When fetching, timestamp comes from the fetch result (last post fetched)
-      expect(result1.timestamp).toBe(BASE_TIMESTAMP + 29);
+      expect(result1.nextCursor).toBe(BASE_TIMESTAMP + 29);
 
       // Second call: Use queue (10 posts), early return
       // Should NOT fetch from Nexus since queue has enough
@@ -282,7 +282,7 @@ describe('PostStreamQueue', () => {
 
       const result2 = await queue.collect(streamId, {
         limit: 10,
-        cursor: result1.timestamp!,
+        cursor: result1.nextCursor!,
         filter: (posts) => posts,
         fetch: mockFetch2,
       });
@@ -292,7 +292,7 @@ describe('PostStreamQueue', () => {
       expect(result2.posts[0]).toBe('post-20'); // Should continue from post-20
       expect(result2.posts[9]).toBe('post-29');
       // When early returning from queue, timestamp is calculated from last returned post
-      expect(result2.timestamp).toBe(BASE_TIMESTAMP + 29); // Timestamp of post-29
+      expect(result2.nextCursor).toBe(BASE_TIMESTAMP + 29); // Timestamp of post-29
 
       // Verify no gap: result1 ends at post-19, result2 starts at post-20
       const allPosts = [...result1.posts, ...result2.posts];
@@ -326,7 +326,7 @@ describe('PostStreamQueue', () => {
         return {
           nextPageIds: posts,
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + start + 24,
+          nextCursor: BASE_TIMESTAMP + start + 24,
         };
       });
 
@@ -340,7 +340,7 @@ describe('PostStreamQueue', () => {
         fetch: mockFetch,
       });
       allReturnedPosts.push(...result1.posts);
-      cursor = result1.timestamp!;
+      cursor = result1.nextCursor!;
 
       // Call 2
       const result2 = await queue.collect(streamId, {
@@ -350,7 +350,7 @@ describe('PostStreamQueue', () => {
         fetch: mockFetch,
       });
       allReturnedPosts.push(...result2.posts);
-      cursor = result2.timestamp!;
+      cursor = result2.nextCursor!;
 
       // Call 3
       const result3 = await queue.collect(streamId, {
@@ -379,7 +379,7 @@ describe('PostStreamQueue', () => {
       const mockFetch = vi.fn(async () => ({
         nextPageIds: ['post1', 'post2', 'post3'],
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 3,
+        nextCursor: BASE_TIMESTAMP + 3,
       }));
 
       const result = await queue.collect(streamId, {
@@ -401,7 +401,7 @@ describe('PostStreamQueue', () => {
       const mockFetch = vi.fn(async () => ({
         nextPageIds: ['valid:post1', 'valid:post2', 'valid:post3'],
         cacheMissPostIds: [],
-        timestamp: BASE_TIMESTAMP + 10,
+        nextCursor: BASE_TIMESTAMP + 10,
       }));
 
       const result = await queue.collect(streamId, {
@@ -424,7 +424,7 @@ describe('PostStreamQueue', () => {
         return {
           nextPageIds: Array.from({ length: 20 }, (_, i) => `muted:post-${callCount}-${i}`),
           cacheMissPostIds: [],
-          timestamp: BASE_TIMESTAMP + callCount * 20,
+          nextCursor: BASE_TIMESTAMP + callCount * 20,
         };
       });
 
@@ -453,7 +453,7 @@ describe('PostStreamQueue', () => {
             ...Array.from({ length: 10 }, (_, i) => `muted:post-${start + i}`),
           ],
           cacheMissPostIds: ['cache-miss-1', 'cache-miss-2', `cache-miss-batch-${fetchCount}`],
-          timestamp: BASE_TIMESTAMP + start + 19,
+          nextCursor: BASE_TIMESTAMP + start + 19,
         };
       });
 
@@ -526,6 +526,115 @@ describe('PostStreamQueue', () => {
     it('should return undefined for empty posts array', async () => {
       const timestamp = await queue['getLastPostTimestamp']([], 10);
       expect(timestamp).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // Skip-paginated streams (engagement + single-collection) - filter resilience
+  // ============================================================================
+
+  describe('Skip-paginated streams advance by raw count, not visible count', () => {
+    // total_engagement:all:collection is the Discover Collections stream; the Hot feed is
+    // total_engagement:all:all. Both page by `skip` and get last_post_score: null from Nexus.
+    const skipStreamId = 'total_engagement:all:collection' as PostStreamId;
+
+    it('advances the skip offset past a fully-filtered page instead of re-requesting it', async () => {
+      // Page at offset 0: 20 raw ids ALL filtered out (muted / own / bookmarked).
+      // Page at offset 20: 20 valid ids.
+      const seenCursors: number[] = [];
+      const mockFetch = vi.fn(async (cursor: number) => {
+        seenCursors.push(cursor);
+        const allFiltered = cursor === 0;
+        return {
+          nextPageIds: Array.from({ length: 20 }, (_, i) =>
+            allFiltered ? `muted:post-${i}` : `valid:post-${cursor + i}`,
+          ),
+          cacheMissPostIds: [],
+          nextCursor: undefined, // skip streams carry no score cursor (Nexus sends null)
+        };
+      });
+
+      const result = await queue.collect(skipStreamId, {
+        limit: 20,
+        cursor: 0,
+        filter: (posts) => posts.filter((p) => !p.startsWith('muted:')),
+        fetch: mockFetch,
+      });
+
+      // The fully-filtered first page still advanced the offset 0 -> 20, so the second
+      // fetch requested offset 20 (the NEXT page), not 0 again. This is the whole fix.
+      expect(seenCursors).toEqual([0, 20]);
+      expect(result.posts).toHaveLength(20);
+      expect(result.posts.every((id) => id.startsWith('valid:'))).toBe(true);
+      // Resume cursor is the raw offset consumed (two 20-id pages).
+      expect(result.nextCursor).toBe(40);
+      expect(result.reachedEnd).toBe(false);
+    });
+
+    it('keeps advancing across successive collect calls (no stall under constant filtering)', async () => {
+      // Every page is 50% filtered; the offset must move by the full raw page each time.
+      const mockFetch = vi.fn(async (cursor: number) => ({
+        nextPageIds: [
+          ...Array.from({ length: 10 }, (_, i) => `muted:post-${cursor + i}`),
+          ...Array.from({ length: 10 }, (_, i) => `valid:post-${cursor + 10 + i}`),
+        ],
+        cacheMissPostIds: [],
+        nextCursor: undefined,
+      }));
+
+      const first = await queue.collect(skipStreamId, {
+        limit: 20,
+        cursor: 0,
+        filter: (posts) => posts.filter((p) => !p.startsWith('muted:')),
+        fetch: mockFetch,
+      });
+      expect(first.nextCursor).toBe(40); // 20 valid needed two raw pages: 0 -> 20 -> 40
+
+      const second = await queue.collect(skipStreamId, {
+        limit: 20,
+        cursor: first.nextCursor!,
+        filter: (posts) => posts.filter((p) => !p.startsWith('muted:')),
+        fetch: mockFetch,
+      });
+      expect(second.nextCursor).toBe(80);
+
+      // No overlap between the two collects.
+      const firstSet = new Set(first.posts);
+      expect(second.posts.some((id) => firstSet.has(id))).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // Score streams (timeline) - filter-resilient backfill
+  // ============================================================================
+
+  describe('Score streams backfill past bursts of filtered posts', () => {
+    it('walks a score stream past an All-feed collection flood instead of returning empty', async () => {
+      // First two pages are all collections (filtered out); the third has real posts.
+      const timelineId = 'timeline:all:all' as PostStreamId;
+      const mockFetch = vi.fn(async (cursor: number) => {
+        const isFlood = cursor > BASE_TIMESTAMP - 20;
+        return {
+          nextPageIds: Array.from({ length: 10 }, (_, i) =>
+            isFlood ? `collection:c-${cursor}-${i}` : `user:post-${cursor}-${i}`,
+          ),
+          cacheMissPostIds: [],
+          nextCursor: cursor - 10, // descending score cursor
+        };
+      });
+
+      const result = await queue.collect(timelineId, {
+        limit: 10,
+        cursor: BASE_TIMESTAMP,
+        filter: (posts) => posts.filter((p) => !p.startsWith('collection:')),
+        fetch: mockFetch,
+      });
+
+      expect(result.posts).toHaveLength(10);
+      expect(result.posts.every((id) => id.startsWith('user:'))).toBe(true);
+      // Walked three raw pages to fill the page (two flooded + one real), advancing by score.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP - 30);
     });
   });
 });

--- a/src/core/application/stream/posts/muting/post-stream-queue.ts
+++ b/src/core/application/stream/posts/muting/post-stream-queue.ts
@@ -1,12 +1,12 @@
 import { Logger } from '@/libs/logger/logger';
-import type { PostStreamId } from '@/models/stream/post/postStream.types';
+import { advanceCursor, isSkipPaginatedStream, type PostStreamId } from '@/models/stream/post/postStream.types';
 import { LocalPostService } from '@/services/local/post/post';
 import { TQueueEntry } from '../post.types';
 import { CollectParams, CollectResult } from './post-stream-queue.types';
 
 // Safety valve to prevent infinite loops when filters remove many posts.
-// At 20 iterations with limit=30, we scan up to 600 posts before giving up.
-// This handles extreme cases like a muted user having 500+ consecutive posts.
+// At 20 iterations with a 10-post limit we scan up to 200 raw posts before giving up.
+// This handles extreme cases like a muted user having 200+ consecutive posts.
 const MAX_FETCH_ITERATIONS = 20;
 
 /**
@@ -49,16 +49,16 @@ export class PostStreamQueue {
     const seen = new Set(posts);
     let cursor = savedQueue?.cursor ?? params.cursor;
 
-    // If queue has enough, return early with correct timestamp
+    // Serve from the overflow buffer without touching the backend cursor. Skip streams
+    // resume by the saved offset; score streams from the last served post's own score.
     if (posts.length >= limit) {
-      const timestamp = await this.getLastPostTimestamp(posts, limit);
-      // Returning from queue means we haven't reached end of stream
-      return this.finalize(streamId, posts, limit, cursor, [], timestamp, false);
+      const nextCursor = isSkipPaginatedStream(streamId) ? cursor : await this.getLastPostTimestamp(posts, limit);
+      return this.finalize(streamId, posts, limit, cursor, [], nextCursor, false);
     }
 
     // Fetch until we have enough
     const allCacheMissIds = new Set<string>();
-    let latestTimestamp: number | undefined;
+    let latestScore: number | undefined;
     let fetchCount = 0;
     let reachedEnd = false;
 
@@ -81,9 +81,10 @@ export class PostStreamQueue {
         allCacheMissIds.add(id);
       }
 
-      if (result.timestamp !== undefined) {
-        cursor = result.timestamp;
-        latestTimestamp = result.timestamp;
+      // Advance by raw ids returned, never by how many survived the filter above.
+      cursor = advanceCursor(streamId, cursor, { ids: result.nextPageIds, lastScore: result.nextCursor });
+      if (result.nextCursor != null) {
+        latestScore = result.nextCursor;
       }
 
       // Stop if we've reached end of stream (propagated from Nexus response)
@@ -95,7 +96,10 @@ export class PostStreamQueue {
       }
     }
 
-    return this.finalize(streamId, posts, limit, cursor, Array.from(allCacheMissIds), latestTimestamp, reachedEnd);
+    // Skip streams resume by raw offset; score streams by the last real score (undefined if
+    // none, so the caller keeps its cursor rather than resetting).
+    const nextCursor = isSkipPaginatedStream(streamId) ? cursor : latestScore;
+    return this.finalize(streamId, posts, limit, cursor, Array.from(allCacheMissIds), nextCursor, reachedEnd);
   }
 
   /**
@@ -130,13 +134,13 @@ export class PostStreamQueue {
     limit: number,
     cursor: number,
     cacheMissIds: string[],
-    timestamp: number | undefined,
+    nextCursor: number | undefined,
     reachedEnd: boolean,
   ): CollectResult {
     const toReturn = posts.slice(0, limit);
     const toSave = posts.slice(limit);
 
-    // Only save non-empty queues, delete entry if queue is empty
+    // Save overflow keyed by the raw backend position (`cursor`), not the returned nextCursor.
     if (toSave.length > 0) {
       this.save(streamId, toSave, cursor);
     } else {
@@ -146,8 +150,7 @@ export class PostStreamQueue {
     return {
       posts: toReturn,
       cacheMissIds,
-      cursor,
-      timestamp,
+      nextCursor,
       reachedEnd,
     };
   }

--- a/src/core/application/stream/posts/muting/post-stream-queue.types.ts
+++ b/src/core/application/stream/posts/muting/post-stream-queue.types.ts
@@ -14,8 +14,9 @@ export interface CollectParams {
 export interface CollectResult {
   posts: string[];
   cacheMissIds: string[];
-  cursor: number;
-  timestamp: number | undefined;
+  /** Opaque resume cursor: raw `skip` offset for skip streams, `last_post_score` for
+   * score streams. Advanced only by raw backend data, never by post-filter count. */
+  nextCursor: number | undefined;
   /** True only if Nexus returned fewer posts than limit (actual end of stream).
    * False if we hit MAX_FETCH_ITERATIONS or filled the limit. */
   reachedEnd: boolean;

--- a/src/core/application/stream/posts/post.test.ts
+++ b/src/core/application/stream/posts/post.test.ts
@@ -11,6 +11,7 @@ import { DELETED } from '@/models/post/details/postDetails.constants';
 import { PostRelationshipsModel } from '@/models/post/relationships/postRelationships';
 import {
   buildAuthorCollectionsStreamId,
+  buildDiscoverCollectionsStreamId,
   type PostStreamId,
   PostStreamTypes,
 } from '@/models/stream/post/postStream.types';
@@ -382,7 +383,7 @@ describe('PostStreamApplication', () => {
       expect(result.nextPageIds).toHaveLength(10);
       expect(result.nextPageIds).toEqual(postIds.slice(0, 10));
       expect(result.cacheMissPostIds).toEqual([]);
-      expect(result.timestamp).toBeUndefined();
+      expect(result.nextCursor).toBeUndefined();
     });
 
     it('returns the bookmark-time cursor on a full cache hit for bookmark streams', async () => {
@@ -406,7 +407,7 @@ describe('PostStreamApplication', () => {
 
       expect(result.nextPageIds).toHaveLength(10);
       // 10th entry (index 9) → its bookmark time, NOT its post indexed_at (BASE + 9).
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 5000 + 9);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 5000 + 9);
     });
 
     it('should fetch from Nexus when cache is empty', async () => {
@@ -424,7 +425,7 @@ describe('PostStreamApplication', () => {
 
       expect(result.nextPageIds).toHaveLength(5);
       expectPostIds(result.nextPageIds, 1, 5);
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 4);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 4);
       expect(result.cacheMissPostIds).toHaveLength(5);
       expect(result.cacheMissPostIds).toEqual(result.nextPageIds);
 
@@ -451,7 +452,7 @@ describe('PostStreamApplication', () => {
 
       expect(result.nextPageIds).toHaveLength(5);
       expectPostIds(result.nextPageIds, 6, 5);
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 9);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 9);
 
       const cached = await PostStreamModel.findById(streamId);
       expect(cached?.stream).toHaveLength(10);
@@ -545,7 +546,7 @@ describe('PostStreamApplication', () => {
       expect(result.nextPageIds).toEqual(postIds);
       expect(result.cacheMissPostIds).toEqual([]);
       // Full cache hit returns timestamp of last post for pagination cursor advancement
-      expect(result.timestamp).toBe(BASE_TIMESTAMP + 9);
+      expect(result.nextCursor).toBe(BASE_TIMESTAMP + 9);
       // Full cache hit should not fetch from Nexus
       expect(nexusFetchSpy).not.toHaveBeenCalled();
     });
@@ -675,7 +676,7 @@ describe('PostStreamApplication', () => {
 
       expect(result.nextPageIds).toHaveLength(0);
       expect(result.cacheMissPostIds).toEqual([]);
-      expect(result.timestamp).toBeUndefined();
+      expect(result.nextCursor).toBeUndefined();
       // Note: When limit is 0, getStreamFromCache returns empty immediately and doesn't fetch from Nexus
       expect(nexusFetchSpy).not.toHaveBeenCalled();
     });
@@ -3036,6 +3037,139 @@ describe('PostStreamApplication', () => {
       // Verify: Reply count should still be 1 (not double-counted)
       const parentCounts = await PostCountsModel.findById(parentPostCompositeId);
       expect(parentCounts?.replies).toBe(1);
+    });
+  });
+
+  describe('Discover Collections filtering', () => {
+    const DISCOVER = buildDiscoverCollectionsStreamId();
+    const VIEWER = 'viewer-pubky' as Pubky;
+    const EMPTY_KEY_STREAM = { post_keys: [], last_post_score: null };
+
+    const createCollectionDetail = async (postId: string, items: string[]) => {
+      await PostDetailsModel.create({
+        id: postId,
+        content: JSON.stringify({ name: 'Test', items, description: '', cover_image: '' }),
+        kind: 'collection',
+        indexed_at: BASE_TIMESTAMP,
+        uri: `https://pubky.app/${DEFAULT_AUTHOR}/pub/pubky.app/posts/${postId}`,
+        attachments: null,
+      });
+    };
+
+    it('filterStreamPosts drops empty collections on the discover stream', async () => {
+      const full = `${DEFAULT_AUTHOR}:full-collection`;
+      const empty = `${DEFAULT_AUTHOR}:empty-collection`;
+      const missing = `${DEFAULT_AUTHOR}:missing-collection`;
+      await createCollectionDetail(full, ['item:1']);
+      await createCollectionDetail(empty, []);
+      // `missing` has no cached details -> fail-open (kept so the cache miss can resolve).
+
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: DISCOVER,
+        postIds: [full, empty, missing],
+      });
+      expect(result).toEqual([full, missing]);
+    });
+
+    it('filterStreamPosts keeps empty collections on a non-discover collection stream', async () => {
+      const full = `${DEFAULT_AUTHOR}:full-collection`;
+      const empty = `${DEFAULT_AUTHOR}:empty-collection`;
+      await createCollectionDetail(full, ['item:1']);
+      await createCollectionDetail(empty, []);
+
+      // timeline:all:collection is a collection stream but not discover, so empties survive.
+      const result = await PostStreamApplication.filterStreamPosts({
+        streamId: PostStreamTypes.TIMELINE_ALL_COLLECTION as PostStreamId,
+        postIds: [full, empty],
+      });
+      expect(result).toEqual([full, empty]);
+    });
+
+    it('filterStreamPosts drops a deleted collection on the discover stream', async () => {
+      const live = `${DEFAULT_AUTHOR}:live-collection`;
+      const deleted = `${DEFAULT_AUTHOR}:deleted-collection`;
+      await createCollectionDetail(live, ['item:1']);
+      await PostDetailsModel.create({
+        id: deleted,
+        content: DELETED,
+        kind: 'collection',
+        indexed_at: BASE_TIMESTAMP,
+        uri: `https://pubky.app/${DEFAULT_AUTHOR}/pub/pubky.app/posts/${deleted}`,
+        attachments: null,
+      });
+
+      const result = await PostStreamApplication.filterStreamPosts({ streamId: DISCOVER, postIds: [live, deleted] });
+      expect(result).toEqual([live]);
+    });
+
+    it('filterDiscoverOwnAndBookmarked drops the viewer own and already-bookmarked collections', () => {
+      const ids = [`${VIEWER}:c1`, 'other:c2', 'other:c3'];
+      const result = PostStreamApplication.filterDiscoverOwnAndBookmarked(ids, VIEWER, new Set(['other:c3']));
+      expect(result).toEqual(['other:c2']);
+    });
+
+    it('filterDiscoverOwnAndBookmarked keeps a not-owned, not-bookmarked collection for a real viewer', () => {
+      const ids = [`${VIEWER}:own`, 'other:keep', 'other:bookmarked'];
+      const result = PostStreamApplication.filterDiscoverOwnAndBookmarked(ids, VIEWER, new Set(['other:bookmarked']));
+      expect(result).toEqual(['other:keep']);
+    });
+
+    it('filterDiscoverOwnAndBookmarked keeps a malformed id instead of throwing out of the filter', () => {
+      // A junk id from Nexus (no delimiter) must be kept, not throw and fail the whole fetch.
+      const ids = ['malformed-no-delimiter', 'other:keep'];
+      expect(PostStreamApplication.filterDiscoverOwnAndBookmarked(ids, VIEWER, new Set())).toEqual(ids);
+    });
+
+    it('filterDiscoverOwnAndBookmarked keeps everything with no viewer and nothing bookmarked', () => {
+      const ids = ['a:c1', 'b:c2'];
+      expect(PostStreamApplication.filterDiscoverOwnAndBookmarked(ids, null, new Set())).toEqual(ids);
+    });
+
+    it('getOrFetchStreamSlice applies own/bookmarked/empty for the discover stream end-to-end', async () => {
+      const own = `${VIEWER}:own-collection`;
+      const bookmarked = 'other:bookmarked-collection';
+      const empty = 'other:empty-collection';
+      const keep = 'other:full-collection';
+      await createCollectionDetail(own, ['x']);
+      await createCollectionDetail(bookmarked, ['x']);
+      await createCollectionDetail(empty, []);
+      await createCollectionDetail(keep, ['x']);
+      await BookmarkModel.create({ id: bookmarked, created_at: BASE_TIMESTAMP });
+
+      vi.spyOn(NexusPostStreamService, 'fetch')
+        .mockResolvedValueOnce({ post_keys: [own, bookmarked, empty, keep], last_post_score: null })
+        .mockResolvedValue(EMPTY_KEY_STREAM);
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: DISCOVER,
+        limit: 20,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId: VIEWER,
+      });
+
+      expect(result.nextPageIds).toEqual([keep]);
+    });
+
+    it('does not apply own/bookmarked filtering to non-discover streams (no viewer-post data loss)', async () => {
+      const ownPost = `${VIEWER}:post-own`;
+      const bookmarkedPost = 'other:post-bookmarked';
+      await BookmarkModel.create({ id: bookmarkedPost, created_at: BASE_TIMESTAMP });
+      await createStreamWithPosts([]);
+
+      vi.spyOn(NexusPostStreamService, 'fetch')
+        .mockResolvedValueOnce({ post_keys: [ownPost, bookmarkedPost], last_post_score: BASE_TIMESTAMP })
+        .mockResolvedValue(EMPTY_KEY_STREAM);
+
+      const result = await PostStreamApplication.getOrFetchStreamSlice({
+        streamId: PostStreamTypes.TIMELINE_ALL_ALL as PostStreamId,
+        limit: 20,
+        streamHead: 0,
+        streamTail: 0,
+        viewerId: VIEWER,
+      });
+
+      expect(result.nextPageIds).toEqual([ownPost, bookmarkedPost]);
     });
   });
 });

--- a/src/core/application/stream/posts/post.ts
+++ b/src/core/application/stream/posts/post.ts
@@ -16,15 +16,17 @@ import {
 } from '@/controllers/stream/posts/post.constants';
 import type { TStreamIdParams } from '@/controllers/stream/posts/posts.types';
 import { Logger } from '@/libs/logger/logger';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { BookmarkModel } from '@/models/bookmark/bookmark';
 import { CompositeIdDomain, type Pubky } from '@/models/models.types';
-import { buildCompositeId, buildCompositeIdFromPubkyUri } from '@/models/models.utils';
+import { buildCompositeId, buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
 import { PostDetailsModel } from '@/models/post/details/postDetails';
 import type { PostRelationshipsModelSchema } from '@/models/post/relationships/postRelationships.schema';
 import {
   isAuthorStreamSkippingMuteFilter,
   isBookmarkStream,
   isDeletedRetainingStream,
+  isDiscoverCollectionsStream,
   isSkipPaginatedStream,
   type PostStreamId,
 } from '@/models/stream/post/postStream.types';
@@ -131,7 +133,48 @@ export class PostStreamApplication {
     const visiblePostIds = isDeletedRetainingStream(streamId)
       ? postIds
       : await LocalPostService.filterDeletedPosts(postIds);
-    return await this.filterCollectionsFromStream({ streamId, postIds: visiblePostIds });
+    const afterCollections = await this.filterCollectionsFromStream({ streamId, postIds: visiblePostIds });
+    // Discover drops empty collections (nothing to discover). Lives here so it is re-applied by
+    // the controller's post-hydration second pass, catching ids that were fail-open on details.
+    return isDiscoverCollectionsStream(streamId) ? this.filterEmptyCollections(afterCollections) : afterCollections;
+  }
+
+  /** Drop collections with zero items. Fail-open when local details are missing. */
+  private static async filterEmptyCollections(postIds: string[]): Promise<string[]> {
+    if (postIds.length === 0) return postIds;
+    const details = await PostDetailsModel.findByIdsPreserveOrder(postIds);
+    return postIds.filter((_id, index) => {
+      const detail = details[index];
+      if (!detail) return true;
+      return (parseCollectionContent(detail.content)?.items?.length ?? 0) > 0;
+    });
+  }
+
+  /**
+   * Discover-only, id-based filters that need no post details: drop the viewer's own collections
+   * and ones they have already bookmarked. Deterministic, so it runs once in the fetch loop and
+   * never needs the post-hydration second pass.
+   */
+  static filterDiscoverOwnAndBookmarked(
+    postIds: string[],
+    viewerId: Pubky | null,
+    bookmarkedIds: Set<string>,
+  ): string[] {
+    return postIds.filter((id) => {
+      if (bookmarkedIds.has(id)) return false;
+      if (viewerId) {
+        // A malformed id parses to null and is treated as not-own (kept), so one bad id from
+        // Nexus can't throw out of this filter and fail the whole fetch.
+        let ownerPubky: Pubky | null = null;
+        try {
+          ownerPubky = parseCompositeId(id).pubky;
+        } catch {
+          ownerPubky = null;
+        }
+        if (ownerPubky === viewerId) return false;
+      }
+      return true;
+    });
   }
 
   /**
@@ -269,16 +312,24 @@ export class PostStreamApplication {
       ? new Set((await LocalStreamUsersService.findById(UserStreamTypes.MUTED))?.stream ?? [])
       : new Set<Pubky>();
 
+    // Discover Collections filters out the viewer's own and already-bookmarked collections in the
+    // shared stream layer (like mute/deleted), so the section paginates like any other feed.
+    const isDiscover = isDiscoverCollectionsStream(streamId);
+    const bookmarkedIds = isDiscover ? new Set(await BookmarkModel.findAll()) : new Set<string>();
+
     let isFirstFetch = true;
     let lastReturnedPostId: string | undefined = lastPostId;
 
-    const { posts, cacheMissIds, timestamp, reachedEnd } = await postStreamQueue.collect(streamId, {
+    const { posts, cacheMissIds, nextCursor, reachedEnd } = await postStreamQueue.collect(streamId, {
       limit,
       cursor: streamTail,
       filter: async (posts) => {
-        // First filter muted users (sync), then filter deleted posts (async)
+        // Muted users (sync), then deleted/kind/empty (async), then Discover's own/bookmarked.
         const afterMuteFilter = MuteFilter.filterPosts(posts, mutedUserIds);
-        return PostStreamApplication.filterStreamPosts({ streamId, postIds: afterMuteFilter });
+        const standard = await PostStreamApplication.filterStreamPosts({ streamId, postIds: afterMuteFilter });
+        return isDiscover
+          ? PostStreamApplication.filterDiscoverOwnAndBookmarked(standard, viewerId, bookmarkedIds)
+          : standard;
       },
       fetch: async (cursor) => {
         // Continue reading from cache using lastReturnedPostId to track position
@@ -318,7 +369,7 @@ export class PostStreamApplication {
     return {
       nextPageIds: posts,
       cacheMissPostIds: cacheMissIds,
-      timestamp,
+      nextCursor,
       reachedEnd,
     };
   }
@@ -403,11 +454,11 @@ export class PostStreamApplication {
       if (cachedStream) {
         const cachedStreamChunk = await this.getStreamFromCache({ lastPostId, limit, cachedStream });
 
-        // Full cache hit, return with proper timestamp for pagination
+        // Full cache hit, return with proper cursor for pagination
         if (cachedStreamChunk.length === limit) {
           const lastCachedPostId = cachedStreamChunk[cachedStreamChunk.length - 1];
-          const timestamp = await this.getStreamCursorTimestamp(streamId, lastCachedPostId);
-          return { nextPageIds: cachedStreamChunk, cacheMissPostIds: [], timestamp, reachedEnd: false };
+          const nextCursor = await this.getStreamCursorTimestamp(streamId, lastCachedPostId);
+          return { nextPageIds: cachedStreamChunk, cacheMissPostIds: [], nextCursor, reachedEnd: false };
         }
 
         // Partial cache hit, fetch missing posts from Nexus and combine
@@ -534,7 +585,7 @@ export class PostStreamApplication {
     const nextStreamTail = (await this.getStreamCursorTimestamp(streamId, lastCachedPostId)) ?? streamTail;
 
     // Fetch remaining posts from Nexus
-    const { nextPageIds, cacheMissPostIds, timestamp, reachedEnd } = await this.fetchStreamFromNexus({
+    const { nextPageIds, cacheMissPostIds, nextCursor, reachedEnd } = await this.fetchStreamFromNexus({
       streamId,
       limit: remainingLimit,
       streamTail: nextStreamTail,
@@ -549,7 +600,7 @@ export class PostStreamApplication {
     return {
       nextPageIds: uniquePostIds,
       cacheMissPostIds,
-      timestamp,
+      nextCursor,
       // Propagate reachedEnd from Nexus - don't recalculate from deduped length
       reachedEnd: reachedEnd ?? false,
     };
@@ -583,7 +634,9 @@ export class PostStreamApplication {
       order,
     });
     const postStreamChunk = await NexusPostStreamService.fetch({ invokeEndpoint, params, extraParams });
-    const { last_post_score: timestamp, post_keys: compositePostIds } = postStreamChunk;
+    // `last_post_score` is null for skip streams; normalize to undefined (advanceCursor derives
+    // their offset from the raw page instead).
+    const { last_post_score: rawScore, post_keys: compositePostIds } = postStreamChunk;
 
     // Do not persist skip-paginated streams (engagement + single-collection items) to the
     // timestamp-keyed local stream cache; they always page from Nexus by offset.
@@ -604,7 +657,12 @@ export class PostStreamApplication {
     const cacheMissPostIds = await this.getNotPersistedPostsInCache(compositePostIds);
 
     // reachedEnd is true when Nexus returned fewer posts than requested (actual end of stream)
-    return { nextPageIds: compositePostIds, cacheMissPostIds, timestamp, reachedEnd: compositePostIds.length < limit };
+    return {
+      nextPageIds: compositePostIds,
+      cacheMissPostIds,
+      nextCursor: rawScore ?? undefined,
+      reachedEnd: compositePostIds.length < limit,
+    };
   }
 
   // Delegate to service for cache miss detection

--- a/src/core/application/stream/posts/post.types.ts
+++ b/src/core/application/stream/posts/post.types.ts
@@ -24,7 +24,9 @@ export interface TInitialStreamParams {
 export interface TPostStreamChunkResponse {
   nextPageIds: string[];
   cacheMissPostIds: string[];
-  timestamp: number | undefined;
+  /** Opaque resume cursor: raw `skip` offset for skip streams, `last_post_score` for score
+   * streams. Advanced only by raw backend data, never by the visible count. */
+  nextCursor: number | undefined;
   /** True only if we've reached the actual end of the stream (Nexus returned fewer posts than limit).
    * False if we hit MAX_FETCH_ITERATIONS or filled the limit. */
   reachedEnd?: boolean;

--- a/src/core/controllers/stream/posts/post.test.ts
+++ b/src/core/controllers/stream/posts/post.test.ts
@@ -24,12 +24,12 @@ describe('StreamPostsController', () => {
   describe('getOrFetchStreamSlice', () => {
     it('should return posts when no cache misses', async () => {
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp,
+        nextCursor,
       });
 
       const fetchMissingPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus');
@@ -50,19 +50,19 @@ describe('StreamPostsController', () => {
       expect(fetchMissingPostsSpy).not.toHaveBeenCalled();
       expect(result).toEqual({
         nextPageIds,
-        timestamp,
+        nextCursor,
       });
     });
 
     it('should fetch missing posts and re-filter stream posts when cacheMissPostIds exist', async () => {
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
       const cacheMissPostIds = ['user-1:post-3', 'user-1:post-4'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds,
-        timestamp,
+        nextCursor,
       });
 
       const fetchMissingPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue();
@@ -89,19 +89,19 @@ describe('StreamPostsController', () => {
       expect(filterStreamPostsSpy).toHaveBeenCalledWith({ streamId, postIds: nextPageIds });
       expect(result).toEqual({
         nextPageIds,
-        timestamp,
+        nextCursor,
       });
     });
 
     it('should remove posts hidden by stream filters after cache-miss fetch', async () => {
       const nextPageIds = ['user-1:post-1', 'user-1:post-2', 'user-1:post-3'];
       const cacheMissPostIds = ['user-1:post-2'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds,
-        timestamp,
+        nextCursor,
       });
 
       vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue();
@@ -114,7 +114,7 @@ describe('StreamPostsController', () => {
       });
 
       expect(result.nextPageIds).toEqual(['user-1:post-1', 'user-1:post-3']);
-      expect(result.timestamp).toBe(timestamp);
+      expect(result.nextCursor).toBe(nextCursor);
     });
 
     it('should pass lastPostId and streamTail to getOrFetchStreamSlice', async () => {
@@ -125,7 +125,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: 1000005,
+        nextCursor: 1000005,
       });
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -143,7 +143,7 @@ describe('StreamPostsController', () => {
         viewerId,
       });
       expect(result.nextPageIds).toEqual(nextPageIds);
-      expect(result.timestamp).toBe(1000005);
+      expect(result.nextCursor).toBe(1000005);
     });
 
     it('should use default limit when not provided', async () => {
@@ -151,7 +151,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: undefined,
+        nextCursor: undefined,
       });
 
       await StreamPostsController.getOrFetchStreamSlice({
@@ -171,12 +171,12 @@ describe('StreamPostsController', () => {
 
     it('should not fetch missing posts when cacheMissPostIds is empty array', async () => {
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp,
+        nextCursor,
       });
 
       const fetchMissingPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus');
@@ -189,13 +189,13 @@ describe('StreamPostsController', () => {
       expect(fetchMissingPostsSpy).not.toHaveBeenCalled();
     });
 
-    it('should handle undefined timestamp in response', async () => {
+    it('should handle undefined nextCursor in response', async () => {
       const nextPageIds = ['user-1:post-1'];
 
       vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: undefined,
+        nextCursor: undefined,
       });
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -203,7 +203,7 @@ describe('StreamPostsController', () => {
         streamTail: 0,
       });
 
-      expect(result.timestamp).toBeUndefined();
+      expect(result.nextCursor).toBeUndefined();
       expect(result.nextPageIds).toEqual(nextPageIds);
     });
 
@@ -215,12 +215,12 @@ describe('StreamPostsController', () => {
       });
 
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp,
+        nextCursor,
       });
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -239,7 +239,7 @@ describe('StreamPostsController', () => {
       });
       expect(result).toEqual({
         nextPageIds,
-        timestamp,
+        nextCursor,
       });
     });
 
@@ -278,13 +278,13 @@ describe('StreamPostsController', () => {
     it('should fetch missing posts and propagate errors if fetch fails', async () => {
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
       const cacheMissPostIds = ['user-1:post-3', 'user-1:post-4'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       // Mock getOrFetchStreamSlice to return cache misses
       vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds,
-        timestamp,
+        nextCursor,
       });
 
       // Mock fetchMissingPostsFromNexus to throw error
@@ -316,7 +316,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: 1000005,
+        nextCursor: 1000005,
       });
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -343,7 +343,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: undefined,
+        nextCursor: undefined,
       });
 
       await StreamPostsController.getOrFetchStreamSlice({
@@ -367,12 +367,12 @@ describe('StreamPostsController', () => {
     it('should handle engagement:all:images streamId', async () => {
       const engagementStreamId = 'engagement:all:images' as PostStreamTypes;
       const nextPageIds = ['user-1:post-1', 'user-1:post-2'];
-      const timestamp = 1000000;
+      const nextCursor = 1000000;
 
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp,
+        nextCursor,
       });
 
       const result = await StreamPostsController.getOrFetchStreamSlice({
@@ -390,7 +390,7 @@ describe('StreamPostsController', () => {
       });
       expect(result).toEqual({
         nextPageIds,
-        timestamp,
+        nextCursor,
       });
     });
   });
@@ -556,7 +556,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: undefined,
+        nextCursor: undefined,
       });
 
       await StreamPostsController.getOrFetchStreamSlice({
@@ -581,7 +581,7 @@ describe('StreamPostsController', () => {
       const getOrFetchStreamSliceSpy = vi.spyOn(PostStreamApplication, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds,
         cacheMissPostIds: [],
-        timestamp: undefined,
+        nextCursor: undefined,
       });
 
       await StreamPostsController.getOrFetchStreamSlice({

--- a/src/core/controllers/stream/posts/posts.ts
+++ b/src/core/controllers/stream/posts/posts.ts
@@ -28,15 +28,15 @@ export class StreamPostsController {
    * Retrieves or fetches a slice of posts from a stream.
    *
    * @param params - Parameters for the stream slice request
-   * @param params.streamId - Unique identifier for the stream (e.g., 'timeline:all:all', 'engagement:all:images')
+   * @param params.streamId - Unique identifier for the stream (e.g., 'timeline:all:all', 'total_engagement:all:all')
    * @param params.streamHead - Identifier of the newest post in the current page for pagination.
-   * @param params.streamTail - Identifier of the last post in the current page for pagination. timestamp (timeline mode) or skip (engagement mode)
+   * @param params.streamTail - Resume cursor for the current page: last_post_score (timeline mode) or skip offset (engagement mode).
    * @param params.lastPostId - Post ID of the last post in the current page. We use to get the chunk of the stream from the cache.
    * @param params.limit - Limit of posts to fetch. Default is NEXUS_POSTS_PER_PAGE.
    *
    * @returns Promise resolving to stream slice response containing:
    * - nextPageIds: Array of post IDs for the current page
-   * - timestamp: Timestamp for pagination of the next page
+   * - nextCursor: opaque resume cursor for the next page (score for timeline, skip offset for engagement)
    *
    * // Get next page using the last post ID
    * const nextPage = await StreamPostsController.getOrFetchStreamSlice({
@@ -46,7 +46,7 @@ export class StreamPostsController {
    * });
    * // Get next page (5th page) of engagement stream
    * const nextPage = await StreamPostsController.getOrFetchStreamSlice({
-   *   streamId: 'engagement:all:images',
+   *   streamId: 'total_engagement:all:all',
    *   streamTail: 40
    * });
    * ```
@@ -62,15 +62,17 @@ export class StreamPostsController {
     // selectCurrentUserPubky() throws an error when user is not authenticated;
     // access currentUserPubky directly to get null instead (unauthenticated users can view profile posts)
     const viewerId = useAuthStore.getState().currentUserPubky;
-    const { nextPageIds, cacheMissPostIds, timestamp, reachedEnd } = await PostStreamApplication.getOrFetchStreamSlice({
-      streamId,
-      limit,
-      streamHead,
-      streamTail,
-      lastPostId,
-      viewerId,
-      order,
-    });
+    const { nextPageIds, cacheMissPostIds, nextCursor, reachedEnd } = await PostStreamApplication.getOrFetchStreamSlice(
+      {
+        streamId,
+        limit,
+        streamHead,
+        streamTail,
+        lastPostId,
+        viewerId,
+        order,
+      },
+    );
     // Query nexus to get the cacheMissPostIds
     if (cacheMissPostIds.length > 0) {
       // TODO: When TTL is implemented, we can return to void
@@ -81,9 +83,9 @@ export class StreamPostsController {
       // Second-pass: cache-miss details are now resolved,
       // re-filter to catch posts that were fail-open in the first pass.
       const validIds = await PostStreamApplication.filterStreamPosts({ streamId, postIds: nextPageIds });
-      return { nextPageIds: validIds, timestamp, reachedEnd };
+      return { nextPageIds: validIds, nextCursor, reachedEnd };
     }
-    return { nextPageIds, timestamp, reachedEnd };
+    return { nextPageIds, nextCursor, reachedEnd };
   }
 
   /**

--- a/src/core/controllers/stream/posts/posts.types.ts
+++ b/src/core/controllers/stream/posts/posts.types.ts
@@ -18,7 +18,9 @@ export type TStreamIdParams = {
 
 export type TReadPostStreamChunkResponse = {
   nextPageIds: string[];
-  timestamp: number | undefined;
+  /** Opaque resume cursor (raw `skip` offset for skip streams, score for score streams).
+   * Advanced only by raw backend data, never by the post-filter visible count. */
+  nextCursor: number | undefined;
   /** True only if we've reached the actual end of the stream.
    * False if we hit MAX_FETCH_ITERATIONS or filled the limit. */
   reachedEnd?: boolean;

--- a/src/core/coordinators/streams/stream.test.ts
+++ b/src/core/coordinators/streams/stream.test.ts
@@ -99,7 +99,7 @@ function setupControllerSpies(streamHeadValue = 1_000_000_000): ControllerSpies 
 
   const getOrFetchStreamSliceSpy = vi
     .spyOn(StreamPostsController, 'getOrFetchStreamSlice')
-    .mockResolvedValue({ nextPageIds: [], timestamp: 0 });
+    .mockResolvedValue({ nextPageIds: [], nextCursor: 0 });
 
   return { getStreamHeadSpy, getOrFetchStreamSliceSpy };
 }
@@ -331,7 +331,7 @@ describe('StreamCoordinator', () => {
       vi.spyOn(StreamPostsController, 'getStreamHead').mockResolvedValue(1_000_000_000);
       vi.spyOn(StreamPostsController, 'getOrFetchStreamSlice').mockResolvedValue({
         nextPageIds: [],
-        timestamp: 0,
+        nextCursor: 0,
       });
 
       const homeStoreState = mockHomeStore({

--- a/src/core/models/stream/post/postStream.types.test.ts
+++ b/src/core/models/stream/post/postStream.types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Pubky } from '@/models/models.types';
 import {
+  advanceCursor,
   buildAuthorCollectionsStreamId,
   buildCollectionItemsStreamId,
   buildDiscoverCollectionsStreamId,
@@ -109,5 +110,37 @@ describe('isAuthorStreamSkippingMuteFilter', () => {
     expect(isAuthorStreamSkippingMuteFilter('timeline:all:all')).toBe(false);
     expect(isAuthorStreamSkippingMuteFilter(buildDiscoverCollectionsStreamId())).toBe(false);
     expect(isAuthorStreamSkippingMuteFilter(buildCollectionItemsStreamId(TEST_PUBKY, TEST_POST_ID))).toBe(false);
+  });
+});
+
+describe('advanceCursor', () => {
+  const discover = buildDiscoverCollectionsStreamId(); // total_engagement:all:collection (skip)
+  const hot = 'total_engagement:all:all'; // engagement (skip)
+  const items = buildCollectionItemsStreamId(TEST_PUBKY, TEST_POST_ID); // collection:… (skip)
+  const timeline = 'timeline:all:all'; // score-cursor stream
+
+  it('advances skip streams by the RAW page size, ignoring how many survive filtering', () => {
+    // A page of 10 raw ids advances the offset by 10 even if all 10 are filtered out.
+    expect(advanceCursor(hot, 0, { ids: Array.from({ length: 10 }, (_, i) => `p${i}`), lastScore: null })).toBe(10);
+    expect(advanceCursor(discover, 40, { ids: ['a', 'b', 'c'], lastScore: null })).toBe(43);
+    expect(advanceCursor(items, 5, { ids: [], lastScore: null })).toBe(5);
+  });
+
+  it('never uses lastScore for skip streams (Nexus returns null for them)', () => {
+    // Even if a score leaks in, skip streams advance purely by raw count.
+    expect(advanceCursor(hot, 0, { ids: ['a', 'b'], lastScore: 999 })).toBe(2);
+  });
+
+  it('advances score streams to the last raw postscore', () => {
+    expect(advanceCursor(timeline, 100, { ids: ['a', 'b'], lastScore: 1717171717 })).toBe(1717171717);
+  });
+
+  it('holds position for score streams when no score is present (empty/last page)', () => {
+    expect(advanceCursor(timeline, 1717171717, { ids: [], lastScore: null })).toBe(1717171717);
+    expect(advanceCursor(timeline, 1717171717, { ids: [], lastScore: undefined })).toBe(1717171717);
+  });
+
+  it('keeps a falsy-but-valid score of 0 (guards `??` vs `||`)', () => {
+    expect(advanceCursor(timeline, 100, { ids: ['a'], lastScore: 0 })).toBe(0);
   });
 });

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -151,6 +151,11 @@ export function buildDiscoverCollectionsStreamId(): DiscoverCollectionsStreamId 
   return `${StreamSorting.ENGAGEMENT}:${StreamSource.ALL}:${StreamKind.COLLECTION}`;
 }
 
+/** The global "Discover Collections" stream (engagement-sorted, all sources, collection kind). */
+export function isDiscoverCollectionsStream(streamId: string): boolean {
+  return streamId === buildDiscoverCollectionsStreamId();
+}
+
 export function buildCollectionItemsStreamId(authorPubky: Pubky, postId: string): CollectionItemsStreamCompositeId {
   return `${StreamSource.COLLECTION}:${authorPubky}:${postId}`;
 }
@@ -199,6 +204,23 @@ export type PostStreamId =
 export function isSkipPaginatedStream(streamId: string): boolean {
   const head = streamId.split(':')[0];
   return head === StreamSorting.ENGAGEMENT || isCollectionItemsStream(streamId);
+}
+
+/**
+ * Advance a stream's pagination cursor by RAW backend data only, never by the post-filter
+ * visible count - so a fully-filtered page still moves forward and never re-requests posts.
+ * Skip streams: advance the `skip` offset by the raw page size. Score streams: resume from
+ * the last raw `last_post_score` (hold position when it's absent, e.g. an empty page).
+ */
+export function advanceCursor(
+  streamId: string,
+  prevCursor: number,
+  rawPage: { ids: string[]; lastScore: number | null | undefined },
+): number {
+  if (isSkipPaginatedStream(streamId)) {
+    return prevCursor + rawPage.ids.length;
+  }
+  return rawPage.lastScore ?? prevCursor;
 }
 
 /**

--- a/src/core/services/nexus/nexus.types.ts
+++ b/src/core/services/nexus/nexus.types.ts
@@ -241,8 +241,9 @@ export type NexusPost = {
 /** Paginated post stream response with cursor for pagination */
 export type NexusPostsKeyStream = {
   post_keys: string[];
-  /** Score of the last post, used as cursor for next page */
-  last_post_score: number;
+  /** Score of the last post, used as cursor for next page. Null for skip-paginated streams
+   * (engagement, single-collection), which page by offset instead. */
+  last_post_score: number | null;
 };
 
 /** Post with attachment metadata */

--- a/src/hooks/useNestedReplies/useNestedReplies.test.tsx
+++ b/src/hooks/useNestedReplies/useNestedReplies.test.tsx
@@ -73,12 +73,12 @@ describe('useNestedReplies', () => {
       .spyOn(StreamPostsController, 'getOrFetchStreamSlice')
       .mockResolvedValueOnce({
         nextPageIds: Array.from({ length: 10 }, (_, index) => `author:nested-${index + 3}`),
-        timestamp: 11,
+        nextCursor: 11,
         reachedEnd: false,
       })
       .mockResolvedValueOnce({
         nextPageIds: ['author:nested-13'],
-        timestamp: 12,
+        nextCursor: 12,
         reachedEnd: true,
       });
 
@@ -106,7 +106,7 @@ describe('useNestedReplies', () => {
 
     const getOrFetchSpy = vi.spyOn(StreamPostsController, 'getOrFetchStreamSlice').mockResolvedValue({
       nextPageIds: Array.from({ length: 10 }, (_, index) => `author:nested-${index + 3}`),
-      timestamp: 0,
+      nextCursor: 0,
       reachedEnd: false,
     });
 

--- a/src/hooks/useReplyStream/useReplyStream.test.tsx
+++ b/src/hooks/useReplyStream/useReplyStream.test.tsx
@@ -74,12 +74,12 @@ describe('useReplyStream', () => {
       .spyOn(StreamPostsController, 'getOrFetchStreamSlice')
       .mockResolvedValueOnce({
         nextPageIds: Array.from({ length: 10 }, (_, i) => `author:reply-${i + 3}`),
-        timestamp: 11,
+        nextCursor: 11,
         reachedEnd: false,
       })
       .mockResolvedValueOnce({
         nextPageIds: ['author:reply-last'],
-        timestamp: 12,
+        nextCursor: 12,
         reachedEnd: true,
       });
 
@@ -108,7 +108,7 @@ describe('useReplyStream', () => {
 
     const getOrFetchSpy = vi.spyOn(StreamPostsController, 'getOrFetchStreamSlice').mockResolvedValue({
       nextPageIds: ['author:reply-4'],
-      timestamp: 1,
+      nextCursor: 1,
       reachedEnd: true,
     });
 
@@ -139,7 +139,7 @@ describe('useReplyStream', () => {
 
     const getOrFetchSpy = vi.spyOn(StreamPostsController, 'getOrFetchStreamSlice').mockResolvedValue({
       nextPageIds: [],
-      timestamp: 1,
+      nextCursor: 1,
       reachedEnd: true,
     });
 
@@ -175,7 +175,7 @@ describe('useReplyStream', () => {
       callCount++;
       return {
         nextPageIds: Array.from({ length: 10 }, (_, i) => `author:reply-${callCount * 10 + i}`),
-        timestamp: callCount * 10,
+        nextCursor: callCount * 10,
         reachedEnd: false,
       };
     });

--- a/src/hooks/useReplyStream/useReplyStream.tsx
+++ b/src/hooks/useReplyStream/useReplyStream.tsx
@@ -178,9 +178,9 @@ export function useReplyStream(
           break;
         }
 
-        // Advance cursor using the timestamp from this page
-        if (result.timestamp && result.timestamp !== cursor) {
-          cursor = result.timestamp;
+        // Advance cursor using the resume cursor from this page
+        if (result.nextCursor && result.nextCursor !== cursor) {
+          cursor = result.nextCursor;
         } else {
           reachedEnd = true;
           break; // No cursor advancement — stop to avoid infinite loop

--- a/src/hooks/useStreamPagination/useStreamPagination.test.tsx
+++ b/src/hooks/useStreamPagination/useStreamPagination.test.tsx
@@ -35,7 +35,7 @@ describe('useStreamPagination', () => {
     vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(0);
     vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
       nextPageIds: mockPostIds,
-      timestamp: Date.now(),
+      nextCursor: Date.now(),
     });
     // Mock PostDetailsModel to return posts with timestamps that preserve input order
     // (newer posts first = higher timestamps)
@@ -49,6 +49,45 @@ describe('useStreamPagination', () => {
     // Mock sortPostIdsByTimestamp to preserve input order by default
     // (simulates already-sorted posts)
     vi.mocked(sortPostIdsByTimestamp).mockImplementation(async (ids: string[]) => ids);
+  });
+
+  describe('Cursor advances on empty-after-filter pages', () => {
+    it('advances streamTail from nextCursor on an empty page so the next loadMore resumes past it', async () => {
+      const streamId = 'timeline:all:all' as PostStreamId;
+      vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(0);
+      // Initial load: a full page, cursor 20.
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValueOnce({
+        nextPageIds: ['p1', 'p2'],
+        nextCursor: 20,
+      });
+      const { result } = renderHook(() => useStreamPagination({ streamId }));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // loadMore #1: a fully-filtered (empty) page that isn't the end; cursor advances to 40.
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValueOnce({
+        nextPageIds: [],
+        reachedEnd: false,
+        nextCursor: 40,
+      });
+      await act(async () => {
+        await result.current.loadMore();
+      });
+      expect(result.current.hasMore).toBe(true); // empty-but-not-ended keeps loading
+
+      // loadMore #2 must resume from the advanced cursor (40), not the stale 20.
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
+      vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValueOnce({
+        nextPageIds: ['p3'],
+        nextCursor: 41,
+      });
+      await act(async () => {
+        await result.current.loadMore();
+      });
+      expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
+        expect.objectContaining({ streamId, streamTail: 40 }),
+      );
+    });
   });
 
   describe('Initialization', () => {
@@ -117,7 +156,7 @@ describe('useStreamPagination', () => {
     it('should set hasMore to false when no posts are returned', async () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: [],
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: true, // Actual end of stream
       });
 
@@ -138,7 +177,7 @@ describe('useStreamPagination', () => {
     it('should keep hasMore true when empty results but not reached end', async () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: [],
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: false, // Filters removed all posts, but more exist
       });
 
@@ -160,7 +199,7 @@ describe('useStreamPagination', () => {
       const limit = 30;
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: Array(25).fill('post'),
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: true, // Less than limit (30) means end of stream
       });
 
@@ -218,7 +257,7 @@ describe('useStreamPagination', () => {
     it('should not load more when hasMore is false', async () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['post1', 'post2'],
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: true, // Less than limit (10) means end of stream
       });
 
@@ -358,7 +397,7 @@ describe('useStreamPagination', () => {
 
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['post1', 'post2', 'post3'],
-        timestamp: undefined, // Engagement streams don't use timestamp
+        nextCursor: undefined, // Engagement streams don't use timestamp
       });
 
       const { result } = renderHook(() =>
@@ -382,15 +421,16 @@ describe('useStreamPagination', () => {
 
   describe('Skip-paginated streams (collection items)', () => {
     // collection:<author>:<postId> pages by offset (`skip`); Nexus returns no timestamp/score
-    // cursor, so the cursor is the count of already-loaded items. Regression guard for the
-    // infinite-scroll flicker where a stuck null timestamp cursor re-served page 1 forever.
+    // cursor, so the resume cursor is a raw offset advanced by the controller and threaded
+    // back via `nextCursor`. Regression guard for the infinite-scroll flicker where a stuck
+    // cursor re-served page 1 forever, and for deriving the offset from the visible count.
     const collectionStreamId = 'collection:author-1:post-1' as PostStreamId;
 
     it('starts the initial load at offset 0, ignoring any cached timestamp cursor', async () => {
       vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(9999);
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c1', 'c2', 'c3'],
-        timestamp: undefined, // skip-paginated streams carry no timestamp cursor
+        nextCursor: 3,
       });
 
       const { result } = renderHook(() => useStreamPagination({ streamId: collectionStreamId }));
@@ -408,11 +448,11 @@ describe('useStreamPagination', () => {
       );
     });
 
-    it('paginates by the number of already-loaded items on loadMore (offset cursor)', async () => {
+    it('paginates by the offset cursor returned from the previous page on loadMore', async () => {
       vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(0);
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c1', 'c2', 'c3'],
-        timestamp: undefined,
+        nextCursor: 3,
       });
 
       const { result } = renderHook(() => useStreamPagination({ streamId: collectionStreamId }));
@@ -425,7 +465,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c4', 'c5'],
-        timestamp: undefined,
+        nextCursor: 5,
       });
 
       await act(async () => {
@@ -435,7 +475,7 @@ describe('useStreamPagination', () => {
       expect(StreamPostsController.getOrFetchStreamSlice).toHaveBeenCalledWith(
         expect.objectContaining({
           streamId: collectionStreamId,
-          streamTail: 3, // count of already-loaded items, not a timestamp
+          streamTail: 3, // resume offset threaded from the previous page
         }),
       );
     });
@@ -444,7 +484,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(0);
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c1', 'c2', 'c3'],
-        timestamp: undefined,
+        nextCursor: 3,
       });
 
       const { result } = renderHook(() => useStreamPagination({ streamId: collectionStreamId }));
@@ -462,7 +502,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c4', 'c5'],
-        timestamp: undefined,
+        nextCursor: 5,
       });
 
       await act(async () => {
@@ -482,7 +522,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getCachedLastPostTimestamp).mockResolvedValue(0);
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c1', 'c2'],
-        timestamp: undefined,
+        nextCursor: 2,
       });
 
       const { result } = renderHook(() => useStreamPagination({ streamId: collectionStreamId }));
@@ -500,7 +540,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c1', 'c2'],
-        timestamp: undefined,
+        nextCursor: 2,
       });
 
       await act(async () => {
@@ -519,7 +559,7 @@ describe('useStreamPagination', () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockClear();
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: ['c3'],
-        timestamp: undefined,
+        nextCursor: 3,
       });
 
       await act(async () => {
@@ -576,7 +616,7 @@ describe('useStreamPagination', () => {
       const limit = 30;
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: Array(limit).fill('post'),
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
       });
 
       const { result } = renderHook(() =>
@@ -607,7 +647,7 @@ describe('useStreamPagination', () => {
     it('should handle empty results with reachedEnd true', async () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: [],
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: true,
       });
 
@@ -628,7 +668,7 @@ describe('useStreamPagination', () => {
     it('should handle empty results with reachedEnd false', async () => {
       vi.mocked(StreamPostsController.getOrFetchStreamSlice).mockResolvedValue({
         nextPageIds: [],
-        timestamp: Date.now(),
+        nextCursor: Date.now(),
         reachedEnd: false,
       });
 
@@ -689,7 +729,7 @@ describe('useStreamPagination', () => {
     it('invokes onError on loadMore failures too', async () => {
       // First (initial) call succeeds, second (loadMore) call throws.
       vi.mocked(StreamPostsController.getOrFetchStreamSlice)
-        .mockResolvedValueOnce({ nextPageIds: mockPostIds, timestamp: Date.now() })
+        .mockResolvedValueOnce({ nextPageIds: mockPostIds, nextCursor: Date.now() })
         .mockRejectedValueOnce(new Error('boom'));
       const onError = vi.fn();
 

--- a/src/hooks/useStreamPagination/useStreamPagination.ts
+++ b/src/hooks/useStreamPagination/useStreamPagination.ts
@@ -64,12 +64,9 @@ export function useStreamPagination({
       setLoadingState(isInitialLoad, true);
       setError(null);
 
-      // Offset-paginated streams (engagement + single-collection items) carry the count of
-      // already-loaded posts as their cursor; Nexus returns no timestamp/score cursor for them.
-      const isSkipStream = isSkipPaginatedStream(streamId);
-
       try {
         let result: TReadPostStreamChunkResponse;
+        // Always resume from `streamTail`; never recompute the cursor from the visible count.
 
         if (isInitialLoad) {
           // Prepare stream for initial load: clear stale cache, merge unread posts, clear unread stream
@@ -81,38 +78,29 @@ export function useStreamPagination({
           result = await StreamPostsController.getOrFetchStreamSlice({
             streamId,
             lastPostId: undefined,
-            // Skip-paginated streams start at offset 0; timestamp streams seed from the cached tail.
-            streamTail: isSkipStream ? 0 : cachedLastPostTimestamp,
+            // Skip streams always start at offset 0; score streams seed from the cached tail.
+            streamTail: isSkipPaginatedStream(streamId) ? 0 : cachedLastPostTimestamp,
             limit,
           });
         } else {
-          const cursorValue = isSkipStream ? postIdsRef.current.length : streamTail;
-
           result = await StreamPostsController.getOrFetchStreamSlice({
             streamId,
             lastPostId,
-            streamTail: cursorValue,
+            streamTail,
             limit,
           });
         }
 
-        // Handle empty results
+        // Advance from the response, even on a fully-filtered (empty) page.
+        if (result.nextCursor != null) {
+          setStreamTail(result.nextCursor);
+        }
+
+        // hasMore reflects the stream end, not the filtered count: a mute/filter-emptied page
+        // keeps hasMore so the advanced cursor is re-requested. This can't spin, the cursor
+        // always advances by raw count, and an empty raw page forces reachedEnd.
         if (result.nextPageIds.length === 0) {
-          // Update cursor even on empty results so subsequent loads can progress
-          if (result.timestamp !== undefined) {
-            setStreamTail(result.timestamp);
-          }
-
-          // Respect reachedEnd flag - only set hasMore to false if we actually
-          // reached the end of stream, not just because filters removed all posts
-          if (result.reachedEnd) {
-            Logger.debug('[useStreamPagination] Empty result, reached end of stream');
-            setHasMore(false);
-          } else {
-            Logger.debug('[useStreamPagination] Empty result after filtering, more posts may exist');
-            setHasMore(true);
-          }
-
+          setHasMore(!result.reachedEnd);
           setLoadingState(isInitialLoad, false);
           return;
         }
@@ -121,20 +109,10 @@ export function useStreamPagination({
         const existingIds = new Set(postIdsRef.current);
         const newUniquePostIds = result.nextPageIds.filter((id) => !existingIds.has(id));
 
-        // Update pagination cursors even if all posts are duplicates
-        // (we need to move forward in the stream)
+        // Update last-returned id even if all posts are duplicates (we need to move forward)
         const lastId = result.nextPageIds[result.nextPageIds.length - 1];
         setLastPostId(lastId);
-
-        if (result.timestamp !== undefined) {
-          setStreamTail(result.timestamp);
-        }
-
-        // Check hasMore based on reachedEnd flag from the response
-        // This correctly handles cases where we hit MAX_FETCH_ITERATIONS due to mute filtering
-        // vs actually reaching the end of the stream
-        const hasMorePosts = result.reachedEnd !== true;
-        setHasMore(hasMorePosts);
+        setHasMore(result.reachedEnd !== true);
 
         // If all posts were duplicates, don't update the UI but keep hasMore state
         if (newUniquePostIds.length === 0) {

--- a/src/hooks/useThreadReplies/useThreadReplies.test.tsx
+++ b/src/hooks/useThreadReplies/useThreadReplies.test.tsx
@@ -57,12 +57,12 @@ describe('useThreadReplies', () => {
       .spyOn(StreamPostsController, 'getOrFetchStreamSlice')
       .mockResolvedValueOnce({
         nextPageIds: Array.from({ length: 10 }, (_, index) => `author:reply-${index + 3}`),
-        timestamp: 11,
+        nextCursor: 11,
         reachedEnd: false,
       })
       .mockResolvedValueOnce({
         nextPageIds: ['author:reply-4'],
-        timestamp: 12,
+        nextCursor: 12,
         reachedEnd: true,
       });
 
@@ -90,7 +90,7 @@ describe('useThreadReplies', () => {
 
     const getOrFetchSpy = vi.spyOn(StreamPostsController, 'getOrFetchStreamSlice').mockResolvedValue({
       nextPageIds: Array.from({ length: 10 }, (_, index) => `author:reply-${index + 3}`),
-      timestamp: 0,
+      nextCursor: 0,
       reachedEnd: false,
     });
 


### PR DESCRIPTION
Fixes #2170.

Advance skip-paginated cursors by raw backend count instead of post-filter visible count, so client-side filtering can't stall pagination. Affects Popularity-sorted feeds (Trending posts, and any feed sorted by Popularity) and Discover Collections; unifies the two skip paths and auto-loads Discover.
