### PR TITLE
fix(ui): polish visual feed tile overlay styles

### DIFF
--- a/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.test.tsx
@@ -223,6 +223,8 @@ describe('PostActionsBar', () => {
       'border-white/10',
       'bg-black/40',
       'text-white',
+      'hover:border-white/30',
+      'hover:bg-black/70',
     );
     expect(screen.getAllByTestId('typography')[0]).toHaveClass('text-white/80');
   });

--- a/src/components/organisms/PostActionsBar/PostActionsBar.tsx
+++ b/src/components/organisms/PostActionsBar/PostActionsBar.tsx
@@ -18,7 +18,7 @@ const postActionsButtonVariants = cva('', {
   variants: {
     variant: {
       default: 'border-none shadow-xs',
-      visual: 'border-white/10 bg-black/40 text-white shadow-none hover:bg-black/55',
+      visual: 'border-white/10 bg-black/40 text-white shadow-none hover:border-white/30 hover:bg-black/70',
     },
   },
   defaultVariants: {

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
@@ -10,6 +10,7 @@ const {
   mockUseInfiniteScroll,
   mockUseVisualFeedTiles,
   mockUseIsTouchDevice,
+  mockClickableTagsList,
 } = vi.hoisted(() => ({
   mockNavigateToPost: vi.fn(),
   mockPostHeaderUserInfo: vi.fn(({ timeAgo }: { timeAgo?: string }) => (
@@ -18,6 +19,11 @@ const {
   mockUseInfiniteScroll: vi.fn(),
   mockUseVisualFeedTiles: vi.fn(),
   mockUseIsTouchDevice: vi.fn(() => false),
+  mockClickableTagsList: vi.fn(({ className }: { className?: string }) => (
+    <div data-testid="visual-overlay-tags" className={className}>
+      Tags
+    </div>
+  )),
 }));
 
 vi.mock('./useVisualFeedTiles', () => ({
@@ -157,7 +163,7 @@ vi.mock('@/molecules/Timeline/TimelineStateWrapper/TimelineStateWrapper', async 
 
 vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => {
   return {
-    ClickableTagsList: () => <div data-testid="visual-overlay-tags">Tags</div>,
+    ClickableTagsList: mockClickableTagsList,
   };
 });
 
@@ -565,6 +571,29 @@ describe('VisualTimelinePosts', () => {
     );
 
     expect(screen.getByTestId('visual-overlay-content-stack')).toHaveClass('flex', 'flex-col', 'gap-4');
+  });
+
+  it('does not force a selected-looking border on overlay tags', () => {
+    render(
+      <VisualTimelinePosts
+        postIds={['author:post1']}
+        loading={false}
+        loadingMore={false}
+        error={null}
+        hasMore={false}
+        loadMore={vi.fn()}
+      />,
+    );
+
+    const tags = screen.getByTestId('visual-overlay-tags');
+    expect(tags).toHaveClass('text-white');
+    expect(tags.className).not.toContain('[&_[role=button]]:border-white/20');
+    expect(mockClickableTagsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        className: expect.not.stringContaining('[&_[role=button]]:border-white/20'),
+      }),
+      undefined,
+    );
   });
 
   describe('Infinite scroll configuration', () => {

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx.snap
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`VisualTimelinePosts - Snapshots > matches snapshot for a populated visu
             class="pointer-events-none absolute inset-0 flex flex-col justify-between bg-[linear-gradient(180deg,rgba(5,5,10,0.58)_0%,rgba(5,5,10,0.72)_100%)] opacity-0 backdrop-blur-[3px] transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100 p-5"
           >
             <div
-              class="pointer-events-none drop-shadow-[0_2px_10px_rgba(5,5,10,0.9)] group-focus-within:pointer-events-auto group-hover:pointer-events-auto"
+              class="pointer-events-none group-focus-within:pointer-events-auto group-hover:pointer-events-auto"
             >
               <div
                 class="flex flex-col gap-4 max-h-56"
@@ -72,9 +72,10 @@ exports[`VisualTimelinePosts - Snapshots > matches snapshot for a populated visu
               </div>
             </div>
             <div
-              class="pointer-events-none w-full drop-shadow-[0_2px_10px_rgba(5,5,10,0.9)] group-focus-within:pointer-events-auto group-hover:pointer-events-auto mt-4 flex flex-wrap items-end justify-between gap-x-6 gap-y-4"
+              class="pointer-events-none w-full group-focus-within:pointer-events-auto group-hover:pointer-events-auto mt-4 flex flex-wrap items-end justify-between gap-x-6 gap-y-4"
             >
               <div
+                class="text-white min-w-0 flex-1"
                 data-testid="visual-overlay-tags"
               >
                 Tags

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.tsx
@@ -146,7 +146,7 @@ function VisualTimelineTileOverlay({ tile, size, onReplyClick, onRepostClick }: 
     >
       <Container
         overrideDefaults
-        className="pointer-events-none drop-shadow-[0_2px_10px_rgba(5,5,10,0.9)] group-focus-within:pointer-events-auto group-hover:pointer-events-auto"
+        className="pointer-events-none group-focus-within:pointer-events-auto group-hover:pointer-events-auto"
       >
         <Container
           overrideDefaults
@@ -175,7 +175,7 @@ function VisualTimelineTileOverlay({ tile, size, onReplyClick, onRepostClick }: 
               <PostText
                 content={truncatedContent}
                 className={cn(
-                  'text-white drop-shadow-[0_2px_10px_rgba(5,5,10,0.9)] [&_*]:text-white [&_blockquote]:border-white/30 [&_button]:text-white [&_button]:hover:text-white/80',
+                  'text-white [&_*]:text-white [&_blockquote]:border-white/30 [&_button]:text-white [&_button]:hover:text-white/80',
                   isCompact ? 'text-sm leading-5' : 'text-base leading-6',
                 )}
               />
@@ -189,7 +189,7 @@ function VisualTimelineTileOverlay({ tile, size, onReplyClick, onRepostClick }: 
         onClick={stopPropagation}
         onPointerDown={stopPropagation}
         className={cn(
-          'pointer-events-none w-full drop-shadow-[0_2px_10px_rgba(5,5,10,0.9)] group-focus-within:pointer-events-auto group-hover:pointer-events-auto',
+          'pointer-events-none w-full group-focus-within:pointer-events-auto group-hover:pointer-events-auto',
           isCompact ? 'mt-4 flex flex-col gap-4' : 'mt-4 flex flex-wrap items-end justify-between gap-x-6 gap-y-4',
         )}
       >
@@ -201,7 +201,7 @@ function VisualTimelineTileOverlay({ tile, size, onReplyClick, onRepostClick }: 
           showAddButton={!tagsExpanded}
           addMode={true}
           maxTags={isCompact ? 3 : 4}
-          className={cn('text-white [&_[role=button]]:border-white/20', isCompact ? 'max-w-full' : 'min-w-0 flex-1')}
+          className={cn('text-white', isCompact ? 'max-w-full' : 'min-w-0 flex-1')}
         />
 
         <PostActionsBar


### PR DESCRIPTION
## Summary
- fix #2166
- Remove drop shadows from visual feed tile overlays so body text, avatar, and username read cleaner on the blurred background
- Stop forcing a white border on all overlay tags so only viewer-supported tags look selected
- Strengthen visual action button hover styles so they remain visible while the tile is hovered

## Changes
- Strip `drop-shadow` from the overlay header, `PostText`, and bottom tags/actions wrappers in `VisualTimelinePosts`
- Remove `[&_[role=button]]:border-white/20` from overlay `ClickableTagsList` while keeping `text-white`
- Update `PostActionsBar` visual variant hover to `hover:bg-black/70` and `hover:border-white/30`
- Extend unit tests/snapshot coverage for the overlay tag className and visual button hover classes

https://github.com/user-attachments/assets/ea54e283-cc19-4903-a5e8-fd89812db223

## Test plan
- [ ] Hover a visual feed tile and confirm no drop shadows on body text, avatar, or username
- [ ] Confirm tags show selected chrome only when the current user has supported them
- [ ] Hover action buttons on a visual tile and confirm distinct hover feedback (stronger bg/border)
- [ ] Run `npx vitest run src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx src/components/organisms/PostActionsBar/PostActionsBar.test.tsx`

## Notes
- Tag selected-state data/logic was already correct; the prod “all tags selected” look came from overlay CSS forcing borders on every `[role=button]`