### PR TITLE
Fix post input action bar alignment and expandable section stacking

### DIFF
--- a/src/components/organisms/PostInput/PostInput.test.tsx.snap
+++ b/src/components/organisms/PostInput/PostInput.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`PostInput - Mobile Snapshots > matches snapshot on mobile viewport 1`] 
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -141,7 +141,7 @@ exports[`PostInput - Snapshots > matches snapshot for article mode 1`] = `
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -222,7 +222,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant 1`] = `
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -304,7 +304,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant with article 
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -406,7 +406,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when dragging
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -500,7 +500,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when submitti
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -598,7 +598,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with attachme
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -692,7 +692,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with content 
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -784,7 +784,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with custom p
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -878,7 +878,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant without conte
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -971,7 +971,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply variant without cont
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -1068,7 +1068,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply with thread connecto
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div
@@ -1170,7 +1170,7 @@ exports[`PostInput - Snapshots > matches snapshot for repost variant without con
         data-testid="container"
       >
         <div
-          class="justify-between gap-4 md:flex-row md:gap-0"
+          class="gap-4"
           data-testid="container"
         >
           <div

--- a/src/components/organisms/PostInputActionBar/PostInputActionBar.test.tsx
+++ b/src/components/organisms/PostInputActionBar/PostInputActionBar.test.tsx
@@ -226,6 +226,12 @@ describe('PostInputActionBar', () => {
     expect(screen.getByText('45/300')).toHaveClass('sm:block');
   });
 
+  it('uses full width root layout', () => {
+    const { container } = render(<PostInputActionBar hideArticleButton={false} />);
+
+    expect(container.firstChild).toHaveClass('w-full');
+  });
+
   it('uses default size for post button on mobile', () => {
     mockUseIsMobile.mockReturnValue(true);
     render(<PostInputActionBar hideArticleButton={false} />);

--- a/src/components/organisms/PostInputActionBar/PostInputActionBar.test.tsx.snap
+++ b/src/components/organisms/PostInputActionBar/PostInputActionBar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostInputActionBar - Mobile Snapshots > matches snapshot on mobile viewport 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -180,7 +180,7 @@ exports[`PostInputActionBar - Mobile Snapshots > matches snapshot on mobile view
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with all callbacks 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -354,7 +354,7 @@ exports[`PostInputActionBar - Snapshots > matches snapshot with all callbacks 1`
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -532,7 +532,7 @@ exports[`PostInputActionBar - Snapshots > matches snapshot with default props 1`
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with disabled post button 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -710,7 +710,7 @@ exports[`PostInputActionBar - Snapshots > matches snapshot with disabled post bu
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with hideArticleButton prop 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -851,7 +851,7 @@ exports[`PostInputActionBar - Snapshots > matches snapshot with hideArticleButto
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with isArticle prop 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -951,7 +951,7 @@ exports[`PostInputActionBar - Snapshots > matches snapshot with isArticle prop 1
 
 exports[`PostInputActionBar - Snapshots > matches snapshot with isEdit prop 1`] = `
 <div
-  class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
+  class="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center"
   data-override-defaults="true"
   data-testid="container"
 >

--- a/src/components/organisms/PostInputActionBar/PostInputActionBar.tsx
+++ b/src/components/organisms/PostInputActionBar/PostInputActionBar.tsx
@@ -48,7 +48,7 @@ export function PostInputActionBar({
   const postButtonText = isSubmitting ? 'Posting...' : postButtonLabel;
   const postButtonIconClassName = isSubmitting ? 'animate-spin' : undefined;
   return (
-    <Container className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center" overrideDefaults>
+    <Container className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center" overrideDefaults>
       <Container className="flex items-center gap-2" overrideDefaults>
         {!isArticle ? (
           <Button

--- a/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.test.tsx
+++ b/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.test.tsx
@@ -456,6 +456,15 @@ describe('PostInputExpandableSection', () => {
     expect(actionBar).toHaveAttribute('data-character-max', '300');
   });
 
+  it('stacks tags above the action bar at all breakpoints', () => {
+    render(<PostInputExpandableSection {...defaultProps} />);
+
+    const layout = screen.getByTestId('post-input-tags').parentElement;
+    expect(layout).toHaveClass('gap-4');
+    expect(layout).not.toHaveClass('md:flex-row');
+    expect(layout).not.toHaveClass('md:gap-0');
+  });
+
   it('does not pass characterLimit when not provided', () => {
     render(<PostInputExpandableSection {...defaultProps} />);
 

--- a/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.test.tsx.snap
+++ b/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot when disabled
       Test
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -69,7 +69,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot when expanded
       Test content with link https://example.com
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -147,7 +147,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot when expanded
       </div>
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -201,7 +201,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot when isArticl
     data-testid="container"
   >
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -248,7 +248,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot when submitti
       Test
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -301,7 +301,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot with EDIT sub
       Editing content
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -348,7 +348,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot with REPLY su
       Test content
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div
@@ -395,7 +395,7 @@ exports[`PostInputExpandableSection - Snapshots > matches snapshot with emoji pi
       Test content
     </div>
     <div
-      class="justify-between gap-4 md:flex-row md:gap-0"
+      class="gap-4"
       data-testid="container"
     >
       <div

--- a/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.tsx
+++ b/src/components/organisms/PostInputExpandableSection/PostInputExpandableSection.tsx
@@ -119,7 +119,7 @@ export function PostInputExpandableSection({
                   ))}
                 </Container>
               )}
-              <Container className="justify-between gap-4 md:flex-row md:gap-0">
+              <Container className="gap-4">
                 <PostInputTags tags={tags} onTagsChange={setTags} disabled={isUiDisabled || isEdit} />
 
                 <PostInputActionBar


### PR DESCRIPTION
## Summary
- fix #1982 
- Make `PostInputActionBar` span the full available width so the New Post actions align consistently.
- Keep the expandable section layout stacked at all breakpoints so tags remain above the action bar.
- Add regression coverage for the updated container classes and layout behavior.

https://github.com/user-attachments/assets/c97f5656-8cfb-4f61-8568-ff716915a6fa

## Testing
- Updated component tests and snapshots for `PostInputActionBar` and `PostInputExpandableSection`.