### PR TITLE
fix(posts): redirect collection posts from /post to /collections.

### DIFF
--- a/src/components/templates/Post/SinglePost/SinglePost.test.tsx
+++ b/src/components/templates/Post/SinglePost/SinglePost.test.tsx
@@ -18,6 +18,10 @@ const SHORT_POST_DETAILS = {
   is_blurred: false,
 } satisfies EnrichedPostDetails;
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
 vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
   usePostDetails: vi.fn(),
 }));

--- a/src/components/templates/Post/SinglePost/SinglePostPage.test.tsx
+++ b/src/components/templates/Post/SinglePost/SinglePostPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getCollectionRoute } from '@/app/routes';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { POST_ID_STAGING_FIXTURE, PUBKY_52_STAGING_FIXTURE, PUBKY_INVALID_TOO_LONG } from '@/test-utils/pubky';
@@ -17,6 +18,17 @@ const SHORT_POST_DETAILS = {
   is_moderated: false,
   is_blurred: false,
 } satisfies EnrichedPostDetails;
+
+const COLLECTION_POST_DETAILS = {
+  ...SHORT_POST_DETAILS,
+  kind: 'collection' as const,
+} satisfies EnrichedPostDetails;
+
+const mockRouterReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
 
 vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
   usePostDetails: vi.fn(),
@@ -54,6 +66,8 @@ describe('SinglePostPage', () => {
   it('does not render a layout shell', () => {
     const { container } = render(<SinglePostPage postId={VALID_COMPOSITE_POST_ID} />);
     expect(container.firstChild).not.toHaveAttribute('data-testid', 'content-layout');
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(screen.getByTestId('single-post-content')).toBeInTheDocument();
   });
 
   it('renders not found without fetching invalid composite ids', () => {
@@ -62,5 +76,20 @@ describe('SinglePostPage', () => {
 
     expect(screen.getByTestId('post-not-found-discovery')).toBeInTheDocument();
     expect(usePostDetails).toHaveBeenCalledWith(invalidComposite, { enabled: false });
+  });
+
+  it('redirects collections to the collection route and does not render post content', () => {
+    vi.mocked(usePostDetails).mockReturnValue({
+      postDetails: COLLECTION_POST_DETAILS,
+      isLoading: false,
+    });
+
+    render(<SinglePostPage postId={VALID_COMPOSITE_POST_ID} />);
+
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      getCollectionRoute(PUBKY_52_STAGING_FIXTURE, POST_ID_STAGING_FIXTURE),
+    );
+    expect(screen.getByTestId('single-post-content-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('single-post-content')).not.toBeInTheDocument();
   });
 });

--- a/src/components/templates/Post/SinglePost/SinglePostPage.tsx
+++ b/src/components/templates/Post/SinglePost/SinglePostPage.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getCollectionRoute } from '@/app/routes';
 import { usePostMissing } from '@/hooks/usePostMissing/usePostMissing';
+import { parseCompositeId } from '@/models/models.utils';
 import { PostNotFoundDiscoveryView } from '@/organisms/PostNotFoundDiscoveryView/PostNotFoundDiscoveryView';
 import { SinglePostContent } from '@/organisms/SinglePostContent/SinglePostContent';
 import { SinglePostContentSkeleton } from '@/organisms/SinglePostContent/SinglePostContent.skeleton';
@@ -9,19 +13,30 @@ import type { SinglePostProps } from './SinglePost.types';
 /**
  * Post page body: fetch post details and render content, skeleton, or not-found.
  *
+ * Collections opened via `/post/...` are redirected to `/collections/...` — the
+ * post page is not a valid surface for `kind=collection`.
+ *
  * Shell layout (navigation, search, sidebars) lives in {@link PostPageShell}, either
  * from `app/post/[userId]/[postId]/layout.tsx` or via {@link SinglePost} for the
  * intercepted modal route. The shell shares {@link usePostMissing}, so it swaps to
  * the discovery layout whenever this body shows the not-found view.
  */
 export function SinglePostPage({ postId }: SinglePostProps) {
+  const router = useRouter();
   const { postMissing, postDetails, isLoading } = usePostMissing(postId);
+  const isCollection = postDetails?.kind === 'collection';
+
+  useEffect(() => {
+    if (!isCollection) return;
+    const { pubky, id } = parseCompositeId(postId);
+    router.replace(getCollectionRoute(pubky, id));
+  }, [isCollection, postId, router]);
 
   if (postMissing) {
     return <PostNotFoundDiscoveryView postId={postId} />;
   }
 
-  if (isLoading || !postDetails) {
+  if (isLoading || !postDetails || isCollection) {
     return <SinglePostContentSkeleton />;
   }
 


### PR DESCRIPTION
Redirect from /post/* to /collection/* when kind is collection.


https://github.com/user-attachments/assets/8906515d-6808-47e4-b6ab-5902f22e559c



Resolves #2168