### PR TITLE
[Experiment ]fix(ui): show collection edit notifications with correct copy and link

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -852,6 +852,7 @@
       "mentionedYou": "ذكرك في منشور",
       "deletedPost": "حذف منشورا",
       "editedPost": "عدّل منشوراً تفاعلت معه",
+      "updatedCollection": "updated a Collection",
       "fallback": "إشعار جديد"
     },
     "settings": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -852,6 +852,7 @@
       "mentionedYou": "hat Sie in einem Beitrag erwaehnt",
       "deletedPost": "hat einen Beitrag gelöscht",
       "editedPost": "hat einen Beitrag bearbeitet, mit dem Sie interagiert haben",
+      "updatedCollection": "updated a Collection",
       "fallback": "Neue Benachrichtigung"
     },
     "settings": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -850,6 +850,7 @@
       "mentionedYou": "mentioned you in post",
       "deletedPost": "deleted a post",
       "editedPost": "edited a post you have interacted with",
+      "updatedCollection": "updated a Collection",
       "fallback": "New notification"
     },
     "settings": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -852,6 +852,7 @@
       "mentionedYou": "te mencionó en una publicación",
       "deletedPost": "eliminó una publicación",
       "editedPost": "editó una publicación con la que interactuaste",
+      "updatedCollection": "updated a Collection",
       "fallback": "Nueva notificación"
     },
     "settings": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -850,6 +850,7 @@
       "mentionedYou": "vous a mentionne dans une publication",
       "deletedPost": "a supprimé une publication",
       "editedPost": "a modifié une publication avec laquelle vous avez interagi",
+      "updatedCollection": "updated a Collection",
       "fallback": "Nouvelle notification"
     },
     "settings": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -850,6 +850,7 @@
       "mentionedYou": "ti ha menzionato in un post",
       "deletedPost": "ha eliminato un post",
       "editedPost": "ha modificato un post con cui hai interagito",
+      "updatedCollection": "updated a Collection",
       "fallback": "Nuova notifica"
     },
     "settings": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -850,6 +850,7 @@
       "mentionedYou": "投稿であなたをメンションしました",
       "deletedPost": "投稿を削除しました",
       "editedPost": "関わった投稿を編集しました",
+      "updatedCollection": "updated a Collection",
       "fallback": "新しい通知"
     },
     "settings": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -850,6 +850,7 @@
       "mentionedYou": "mencionou você em um post",
       "deletedPost": "excluiu um post",
       "editedPost": "editou um post com que você interagiu",
+      "updatedCollection": "updated a Collection",
       "fallback": "Nova notificação"
     },
     "settings": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -850,6 +850,7 @@
       "mentionedYou": "在帖子中提到了您",
       "deletedPost": "删除了一条帖子",
       "editedPost": "编辑了您互动过的帖子",
+      "updatedCollection": "updated a Collection",
       "fallback": "新通知"
     },
     "settings": {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -675,6 +675,69 @@ describe('NotificationItem', () => {
 
     expect(screen.getByText('User').closest('a')).not.toHaveClass('hover:underline');
   });
+
+  it('shows updated a Collection and links to collection page for PostEdited collection', async () => {
+    const collectionContent = JSON.stringify({
+      name: 'My Collection',
+      description: 'Some description',
+      items: ['user1:post1'],
+    });
+
+    mockGetOrFetch.mockResolvedValue({
+      kind: 'collection',
+      content: collectionContent,
+    });
+
+    const editedNotification = {
+      id: 'post_edited:123:author1',
+      type: NotificationType.PostEdited,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      edit_source: 'repost',
+      edited_by: 'author1',
+      edited_uri: 'pubky://author1/pub/pubky.app/posts/collection123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost456',
+    } as FlatNotification;
+
+    render(<NotificationItem notification={editedNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('updated a Collection')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('updated a Collection').closest('a')).toHaveAttribute(
+      'href',
+      '/collections/author1/collection123',
+    );
+  });
+
+  it('shows edited a post and links to post page for PostEdited short post', async () => {
+    mockGetOrFetch.mockResolvedValue({
+      kind: 'short',
+      content: 'Hello world',
+    });
+
+    const editedNotification = {
+      id: 'post_edited:123:author1',
+      type: NotificationType.PostEdited,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      edit_source: 'repost',
+      edited_by: 'author1',
+      edited_uri: 'pubky://author1/pub/pubky.app/posts/post123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost456',
+    } as FlatNotification;
+
+    render(<NotificationItem notification={editedNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(mockGetOrFetch).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('edited a post you have interacted with')).toBeInTheDocument();
+    expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
+      'href',
+      '/post/author1/post123',
+    );
+  });
 });
 
 describe('NotificationItem - Snapshots', () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -700,6 +700,9 @@ describe('NotificationItem', () => {
 
     render(<NotificationItem notification={editedNotification} isUnread={false} />);
 
+    // While kind is loading, action text must not link to the generic post page
+    expect(screen.getByText('edited a post you have interacted with').closest('a')).toBeNull();
+
     await vi.waitFor(() => {
       expect(screen.getByText('updated a Collection')).toBeInTheDocument();
     });
@@ -729,14 +732,34 @@ describe('NotificationItem', () => {
     render(<NotificationItem notification={editedNotification} isUnread={false} />);
 
     await vi.waitFor(() => {
-      expect(mockGetOrFetch).toHaveBeenCalled();
+      expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
+        'href',
+        '/post/author1/post123',
+      );
     });
+  });
 
-    expect(screen.getByText('edited a post you have interacted with')).toBeInTheDocument();
-    expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
-      'href',
-      '/post/author1/post123',
-    );
+  it('falls back to post link for PostEdited when post fetch fails', async () => {
+    mockGetOrFetch.mockRejectedValue(new Error('network error'));
+
+    const editedNotification = {
+      id: 'post_edited:123:author1',
+      type: NotificationType.PostEdited,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      edit_source: 'repost',
+      edited_by: 'author1',
+      edited_uri: 'pubky://author1/pub/pubky.app/posts/post123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost456',
+    } as FlatNotification;
+
+    render(<NotificationItem notification={editedNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
+        'href',
+        '/post/author1/post123',
+      );
+    });
   });
 });
 

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -810,7 +810,7 @@ describe('NotificationItem', () => {
 
     rerender(<NotificationItem notification={collectionEditedNotification} isUnread={false} />);
 
-    // Stale short kind must not keep a /post link for the new collection target
+    // Kind is keyed by composite ID, so the first paint after target change has no link
     expect(screen.getByText('edited a post you have interacted with').closest('a')).toBeNull();
 
     await vi.waitFor(() => {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -761,6 +761,65 @@ describe('NotificationItem', () => {
       );
     });
   });
+
+  it('resets post kind when PostEdited target changes so stale kind cannot leak', async () => {
+    mockGetOrFetch.mockResolvedValueOnce({
+      kind: 'short',
+      content: 'Hello world',
+    });
+
+    const shortEditedNotification = {
+      id: 'post_edited:123:author1',
+      type: NotificationType.PostEdited,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      edit_source: 'repost',
+      edited_by: 'author1',
+      edited_uri: 'pubky://author1/pub/pubky.app/posts/post123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost456',
+    } as FlatNotification;
+
+    const { rerender } = render(<NotificationItem notification={shortEditedNotification} isUnread={false} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
+        'href',
+        '/post/author1/post123',
+      );
+    });
+
+    const collectionContent = JSON.stringify({
+      name: 'My Collection',
+      description: 'Some description',
+      items: ['user1:post1'],
+    });
+
+    mockGetOrFetch.mockResolvedValueOnce({
+      kind: 'collection',
+      content: collectionContent,
+    });
+
+    const collectionEditedNotification = {
+      id: 'post_edited:456:author1',
+      type: NotificationType.PostEdited,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      edit_source: 'repost',
+      edited_by: 'author1',
+      edited_uri: 'pubky://author1/pub/pubky.app/posts/collection123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost789',
+    } as FlatNotification;
+
+    rerender(<NotificationItem notification={collectionEditedNotification} isUnread={false} />);
+
+    // Stale short kind must not keep a /post link for the new collection target
+    expect(screen.getByText('edited a post you have interacted with').closest('a')).toBeNull();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('updated a Collection').closest('a')).toHaveAttribute(
+        'href',
+        '/collections/author1/collection123',
+      );
+    });
+  });
 });
 
 describe('NotificationItem - Snapshots', () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -739,7 +739,7 @@ describe('NotificationItem', () => {
     });
   });
 
-  it('falls back to post link for PostEdited when post fetch fails', async () => {
+  it('keeps PostEdited unlinked when post fetch fails', async () => {
     mockGetOrFetch.mockRejectedValue(new Error('network error'));
 
     const editedNotification = {
@@ -755,11 +755,10 @@ describe('NotificationItem', () => {
     render(<NotificationItem notification={editedNotification} isUnread={false} />);
 
     await vi.waitFor(() => {
-      expect(screen.getByText('edited a post you have interacted with').closest('a')).toHaveAttribute(
-        'href',
-        '/post/author1/post123',
-      );
+      expect(mockGetOrFetch).toHaveBeenCalled();
     });
+
+    expect(screen.getByText('edited a post you have interacted with').closest('a')).toBeNull();
   });
 
   it('resets post kind when PostEdited target changes so stale kind cannot leak', async () => {

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -49,10 +49,16 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     return postUri ? pubkyUriToCompositeId(postUri) : null;
   }, [notification]);
 
-  // State for post content and kind (fetched via controller).
-  // postKind: undefined = still loading, string = known kind, null = fetch failed/unavailable
-  const [postContent, setPostContent] = useState<string | null>(null);
-  const [postKind, setPostKind] = useState<string | null | undefined>(undefined);
+  // Post fetch state keyed by composite ID so a reused row never paints with a stale kind
+  // before the effect resets. Kind: undefined = loading, string = known, null = failed.
+  const [fetchedPost, setFetchedPost] = useState<{
+    compositeId: string;
+    kind: string | null;
+    content: string | null;
+  } | null>(null);
+
+  const postKind = fetchedPost && fetchedPost.compositeId === postCompositeId ? fetchedPost.kind : undefined;
+  const postContent = fetchedPost && fetchedPost.compositeId === postCompositeId ? fetchedPost.content : null;
 
   // Use existing hook for user profile data
   const { profile } = useUserProfile(actorUserId || '');
@@ -65,50 +71,50 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     if (!viewerId) return;
 
     let isCancelled = false;
-    setPostKind(undefined);
-    setPostContent(null);
+    const targetCompositeId = postCompositeId;
 
     // PostController.getOrFetch handles the caching strategy:
     // 1. Check local DB first
     // 2. If missing, fetch from Nexus
     // 3. Write to local DB
-    PostController.getOrFetch({ compositeId: postCompositeId, viewerId })
+    PostController.getOrFetch({ compositeId: targetCompositeId, viewerId })
       .then(async (post) => {
         if (isCancelled) return;
 
         if (!post) {
-          setPostKind(null);
+          setFetchedPost({ compositeId: targetCompositeId, kind: null, content: null });
           return;
         }
 
-        setPostKind(post.kind);
-
-        if (!post.content) return;
-
-        if (isPostDeleted(post.content)) {
-          setPostContent(tPost('deleted'));
-        } else if (post.kind === 'long') {
-          setPostContent(parseArticleContent(post.content)?.title || post.content);
-        } else if (post.kind === 'collection') {
-          const parsed = parseCollectionContent(post.content);
-          if (parsed) {
-            setPostContent(parsed.name);
+        let content: string | null = null;
+        if (post.content) {
+          if (isPostDeleted(post.content)) {
+            content = tPost('deleted');
+          } else if (post.kind === 'long') {
+            content = parseArticleContent(post.content)?.title || post.content;
+          } else if (post.kind === 'collection') {
+            const parsed = parseCollectionContent(post.content);
+            if (parsed) {
+              content = parsed.name;
+            } else {
+              content = post.content;
+              toast({
+                variant: 'error',
+                description: tPostToast('collectionParseError'),
+              });
+            }
           } else {
-            setPostContent(post.content);
-            toast({
-              variant: 'error',
-              description: tPostToast('collectionParseError'),
-            });
+            content = await resolvePubkyToNames(post.content);
+            if (isCancelled) return;
           }
-        } else {
-          const content = await resolvePubkyToNames(post.content);
-          if (!isCancelled) setPostContent(content);
         }
+
+        setFetchedPost({ compositeId: targetCompositeId, kind: post.kind, content });
       })
       .catch((error) => {
         if (!isCancelled) {
-          setPostKind(null);
-          Logger.warn('Failed to fetch notification post:', { postCompositeId, error });
+          setFetchedPost({ compositeId: targetCompositeId, kind: null, content: null });
+          Logger.warn('Failed to fetch notification post:', { postCompositeId: targetCompositeId, error });
         }
       });
 

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -49,8 +49,9 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     return postUri ? pubkyUriToCompositeId(postUri) : null;
   }, [notification]);
 
-  // State for post content (fetched via controller)
+  // State for post content and kind (fetched via controller)
   const [postContent, setPostContent] = useState<string | null>(null);
+  const [postKind, setPostKind] = useState<string | null>(null);
 
   // Use existing hook for user profile data
   const { profile } = useUserProfile(actorUserId || '');
@@ -70,26 +71,30 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     // 3. Write to local DB
     PostController.getOrFetch({ compositeId: postCompositeId, viewerId })
       .then(async (post) => {
-        if (!isCancelled && post?.content) {
-          if (isPostDeleted(post.content)) {
-            setPostContent(tPost('deleted'));
-          } else if (post.kind === 'long') {
-            setPostContent(parseArticleContent(post.content)?.title || post.content);
-          } else if (post.kind === 'collection') {
-            const parsed = parseCollectionContent(post.content);
-            if (parsed) {
-              setPostContent(parsed.name);
-            } else {
-              setPostContent(post.content);
-              toast({
-                variant: 'error',
-                description: tPostToast('collectionParseError'),
-              });
-            }
+        if (isCancelled || !post) return;
+
+        setPostKind(post.kind);
+
+        if (!post.content) return;
+
+        if (isPostDeleted(post.content)) {
+          setPostContent(tPost('deleted'));
+        } else if (post.kind === 'long') {
+          setPostContent(parseArticleContent(post.content)?.title || post.content);
+        } else if (post.kind === 'collection') {
+          const parsed = parseCollectionContent(post.content);
+          if (parsed) {
+            setPostContent(parsed.name);
           } else {
-            const content = await resolvePubkyToNames(post.content);
-            if (!isCancelled) setPostContent(content);
+            setPostContent(post.content);
+            toast({
+              variant: 'error',
+              description: tPostToast('collectionParseError'),
+            });
           }
+        } else {
+          const content = await resolvePubkyToNames(post.content);
+          if (!isCancelled) setPostContent(content);
         }
       })
       .catch((error) => {
@@ -109,7 +114,7 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
   const avatarUrl = profile?.avatarUrl;
 
   // Get notification action text (without username, for separate rendering)
-  const actionKey = getNotificationActionKey(notification);
+  const actionKey = getNotificationActionKey(notification, postKind);
   const actionText = t(actionKey);
 
   // Get post preview text
@@ -120,7 +125,7 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
   const timestampLong = formatNotificationTime(notification.timestamp, true);
 
   // Calculate notification links (business logic separated in pure function)
-  const { notificationLink, userProfileLink } = getNotificationLink(notification);
+  const { notificationLink, userProfileLink } = getNotificationLink(notification, postKind);
 
   // Handle tag click - navigate to search with the tag
   const handleTagClick = (tagLabel: string) => (e: React.MouseEvent) => {

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -49,9 +49,10 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     return postUri ? pubkyUriToCompositeId(postUri) : null;
   }, [notification]);
 
-  // State for post content and kind (fetched via controller)
+  // State for post content and kind (fetched via controller).
+  // postKind: undefined = still loading, string = known kind, null = fetch failed/unavailable
   const [postContent, setPostContent] = useState<string | null>(null);
-  const [postKind, setPostKind] = useState<string | null>(null);
+  const [postKind, setPostKind] = useState<string | null | undefined>(undefined);
 
   // Use existing hook for user profile data
   const { profile } = useUserProfile(actorUserId || '');
@@ -71,7 +72,12 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     // 3. Write to local DB
     PostController.getOrFetch({ compositeId: postCompositeId, viewerId })
       .then(async (post) => {
-        if (isCancelled || !post) return;
+        if (isCancelled) return;
+
+        if (!post) {
+          setPostKind(null);
+          return;
+        }
 
         setPostKind(post.kind);
 
@@ -99,6 +105,7 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
       })
       .catch((error) => {
         if (!isCancelled) {
+          setPostKind(null);
           Logger.warn('Failed to fetch notification post:', { postCompositeId, error });
         }
       });

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -65,6 +65,8 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
     if (!viewerId) return;
 
     let isCancelled = false;
+    setPostKind(undefined);
+    setPostContent(null);
 
     // PostController.getOrFetch handles the caching strategy:
     // 1. Check local DB first

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -50,7 +50,8 @@ export function NotificationItem({ notification, isUnread }: NotificationItemPro
   }, [notification]);
 
   // Post fetch state keyed by composite ID so a reused row never paints with a stale kind
-  // before the effect resets. Kind: undefined = loading, string = known, null = failed.
+  // before the effect resets. Effective kind is undefined until this matches postCompositeId.
+  // Stored kind: string = known, null = fetch failed/unavailable (link stays deferred).
   const [fetchedPost, setFetchedPost] = useState<{
     compositeId: string;
     kind: string | null;

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { type FlatNotification, NotificationType, PostChangedSource } from '@/models/notification/notification.types';
+import { getNotificationActionKey, getNotificationLink } from './NotificationItem.utils';
+
+const postEditedNotification = {
+  id: 'post_edited:123:author1',
+  type: NotificationType.PostEdited,
+  timestamp: Date.now(),
+  edit_source: PostChangedSource.Repost,
+  edited_by: 'author1',
+  edited_uri: 'pubky://author1/pub/pubky.app/posts/item123',
+  linked_uri: 'pubky://viewer/pub/pubky.app/posts/repost456',
+} as FlatNotification;
+
+describe('getNotificationActionKey', () => {
+  it('returns updatedCollection for PostEdited when post kind is collection', () => {
+    expect(getNotificationActionKey(postEditedNotification, 'collection')).toBe('updatedCollection');
+  });
+
+  it('returns editedPost for PostEdited when post kind is not collection', () => {
+    expect(getNotificationActionKey(postEditedNotification, 'short')).toBe('editedPost');
+  });
+
+  it('returns editedPost for PostEdited when post kind is unknown', () => {
+    expect(getNotificationActionKey(postEditedNotification)).toBe('editedPost');
+    expect(getNotificationActionKey(postEditedNotification, null)).toBe('editedPost');
+  });
+});
+
+describe('getNotificationLink', () => {
+  it('links PostEdited collection notifications to the collection route', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification, 'collection');
+    expect(notificationLink).toBe('/collections/author1/item123');
+  });
+
+  it('links PostEdited non-collection notifications to the post route', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification, 'short');
+    expect(notificationLink).toBe('/post/author1/item123');
+  });
+
+  it('falls back to the post route when post kind is unknown', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification);
+    expect(notificationLink).toBe('/post/author1/item123');
+  });
+});

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
@@ -33,6 +33,11 @@ describe('getNotificationLink', () => {
     expect(notificationLink).toBeNull();
   });
 
+  it('defers PostEdited link when post kind fetch failed', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification, null);
+    expect(notificationLink).toBeNull();
+  });
+
   it('links PostEdited collection notifications to the collection route', () => {
     const { notificationLink } = getNotificationLink(postEditedNotification, 'collection');
     expect(notificationLink).toBe('/collections/author1/item123');
@@ -40,11 +45,6 @@ describe('getNotificationLink', () => {
 
   it('links PostEdited non-collection notifications to the post route', () => {
     const { notificationLink } = getNotificationLink(postEditedNotification, 'short');
-    expect(notificationLink).toBe('/post/author1/item123');
-  });
-
-  it('falls back to the post route when post kind fetch failed', () => {
-    const { notificationLink } = getNotificationLink(postEditedNotification, null);
     expect(notificationLink).toBe('/post/author1/item123');
   });
 });

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
@@ -28,6 +28,11 @@ describe('getNotificationActionKey', () => {
 });
 
 describe('getNotificationLink', () => {
+  it('defers PostEdited link while post kind is still loading', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification, undefined);
+    expect(notificationLink).toBeNull();
+  });
+
   it('links PostEdited collection notifications to the collection route', () => {
     const { notificationLink } = getNotificationLink(postEditedNotification, 'collection');
     expect(notificationLink).toBe('/collections/author1/item123');
@@ -38,8 +43,8 @@ describe('getNotificationLink', () => {
     expect(notificationLink).toBe('/post/author1/item123');
   });
 
-  it('falls back to the post route when post kind is unknown', () => {
-    const { notificationLink } = getNotificationLink(postEditedNotification);
+  it('falls back to the post route when post kind fetch failed', () => {
+    const { notificationLink } = getNotificationLink(postEditedNotification, null);
     expect(notificationLink).toBe('/post/author1/item123');
   });
 });

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.ts
@@ -1,4 +1,4 @@
-import { APP_ROUTES, POST_ROUTES, PROFILE_ROUTES } from '@/app/routes';
+import { APP_ROUTES, getCollectionRoute, POST_ROUTES, PROFILE_ROUTES } from '@/app/routes';
 import { Logger } from '@/libs/logger/logger';
 import { truncateString } from '@/libs/utils/utils';
 import { CompositeIdDomain } from '@/models/models.types';
@@ -30,7 +30,10 @@ const NOTIFICATION_ACTION_KEY: Record<NotificationType, string> = {
  * Get notification action translation key (without the username) based on type
  * Returns the i18n key to be used with useTranslations('notifications.actions')
  */
-export function getNotificationActionKey(notification: FlatNotification): string {
+export function getNotificationActionKey(notification: FlatNotification, postKind?: string | null): string {
+  if (notification.type === NotificationType.PostEdited && postKind === 'collection') {
+    return 'updatedCollection';
+  }
   return NOTIFICATION_ACTION_KEY[notification.type] ?? 'fallback';
 }
 
@@ -102,7 +105,7 @@ function uriToUrlPath(uri: string | undefined): string | null {
  * Get the appropriate post link for a notification based on its type
  * Uses TypeScript's discriminated union type narrowing for type safety
  */
-function getPostLink(notification: FlatNotification): string | null {
+function getPostLink(notification: FlatNotification, postKind?: string | null): string | null {
   let uri: string | undefined;
 
   switch (notification.type) {
@@ -146,7 +149,16 @@ function getPostLink(notification: FlatNotification): string | null {
 
   // Convert URI to URL path format
   const urlPath = uriToUrlPath(uri);
-  return urlPath ? `${POST_ROUTES.POST}/${urlPath}` : null;
+  if (!urlPath) return null;
+
+  if (notification.type === NotificationType.PostEdited && postKind === 'collection') {
+    const [authorPubky, postId] = urlPath.split('/');
+    if (authorPubky && postId) {
+      return getCollectionRoute(authorPubky, postId);
+    }
+  }
+
+  return `${POST_ROUTES.POST}/${urlPath}`;
 }
 
 /**
@@ -168,9 +180,10 @@ function shouldUsePrimaryUserLink(notification: FlatNotification): boolean {
  * Pure function that separates business logic from presentation layer.
  *
  * @param notification - The notification to process
+ * @param postKind - Optional post kind for kind-aware routing (e.g. collection edits)
  * @returns Object with notificationLink and userProfileLink
  */
-export function getNotificationLink(notification: FlatNotification) {
+export function getNotificationLink(notification: FlatNotification, postKind?: string | null) {
   // Get user ID to create profile link
   const userId = getUserIdFromNotification(notification);
   const userProfileLink = userId ? getUserProfileLink(userId) : null;
@@ -178,7 +191,7 @@ export function getNotificationLink(notification: FlatNotification) {
   // Determine the main notification link
   // For user-centric notifications (follow/unfollow/friend), use profile link
   // For post-centric notifications, use post link
-  const postLink = getPostLink(notification);
+  const postLink = getPostLink(notification, postKind);
   const usePrimaryUserLink = shouldUsePrimaryUserLink(notification);
   const notificationLink = usePrimaryUserLink ? userProfileLink : postLink;
 

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.ts
@@ -104,6 +104,9 @@ function uriToUrlPath(uri: string | undefined): string | null {
 /**
  * Get the appropriate post link for a notification based on its type
  * Uses TypeScript's discriminated union type narrowing for type safety
+ *
+ * @param postKind - `undefined` means kind is still loading (PostEdited defers the link);
+ *   `null` means resolved/unavailable (fall back to post route); a string is the known kind
  */
 function getPostLink(notification: FlatNotification, postKind?: string | null): string | null {
   let uri: string | undefined;
@@ -131,6 +134,8 @@ function getPostLink(notification: FlatNotification, postKind?: string | null): 
       break;
 
     case NotificationType.PostEdited:
+      // Defer until kind is known so collection edits never briefly point at /post
+      if (postKind === undefined) return null;
       uri = notification.edited_uri;
       break;
 
@@ -180,7 +185,9 @@ function shouldUsePrimaryUserLink(notification: FlatNotification): boolean {
  * Pure function that separates business logic from presentation layer.
  *
  * @param notification - The notification to process
- * @param postKind - Optional post kind for kind-aware routing (e.g. collection edits)
+ * @param postKind - Post kind for kind-aware routing. For PostEdited: `undefined` defers
+ *   the link while loading; `null` falls back to the post route; `'collection'` uses
+ *   the collection route.
  * @returns Object with notificationLink and userProfileLink
  */
 export function getNotificationLink(notification: FlatNotification, postKind?: string | null) {

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.ts
@@ -105,8 +105,8 @@ function uriToUrlPath(uri: string | undefined): string | null {
  * Get the appropriate post link for a notification based on its type
  * Uses TypeScript's discriminated union type narrowing for type safety
  *
- * @param postKind - `undefined` means kind is still loading (PostEdited defers the link);
- *   `null` means resolved/unavailable (fall back to post route); a string is the known kind
+ * @param postKind - `undefined`/`null` means kind is unknown (PostEdited defers the link);
+ *   a string is the known kind
  */
 function getPostLink(notification: FlatNotification, postKind?: string | null): string | null {
   let uri: string | undefined;
@@ -134,8 +134,8 @@ function getPostLink(notification: FlatNotification, postKind?: string | null): 
       break;
 
     case NotificationType.PostEdited:
-      // Defer until kind is known so collection edits never briefly point at /post
-      if (postKind === undefined) return null;
+      // Defer until kind is known so we never guess /post vs /collections
+      if (postKind == null) return null;
       uri = notification.edited_uri;
       break;
 
@@ -185,9 +185,9 @@ function shouldUsePrimaryUserLink(notification: FlatNotification): boolean {
  * Pure function that separates business logic from presentation layer.
  *
  * @param notification - The notification to process
- * @param postKind - Post kind for kind-aware routing. For PostEdited: `undefined` defers
- *   the link while loading; `null` falls back to the post route; `'collection'` uses
- *   the collection route.
+ * @param postKind - Post kind for kind-aware routing. For PostEdited: `undefined`/`null`
+ *   defer the link (loading or unknown); `'collection'` uses the collection route;
+ *   any other string uses the post route.
  * @returns Object with notificationLink and userProfileLink
  */
 export function getNotificationLink(notification: FlatNotification, postKind?: string | null) {


### PR DESCRIPTION
Use post kind so PostEdited collection notifications say "updated a Collection" and navigate to /collections instead of the generic post page.

Note: I am testing Cursor's `babysit` feature on this PR - forgive redundant comments.


https://github.com/user-attachments/assets/2a3f8566-9c75-4519-bcdf-9ba6aaad946e



Resolves #2125 