### PR TITLE
fix(runtime-config): allow empty PUBKY_RUNTIME_MODERATED_TAGS=[]

### DIFF
--- a/src/libs/runtime-config/runtime-config.schema.test.ts
+++ b/src/libs/runtime-config/runtime-config.schema.test.ts
@@ -129,6 +129,22 @@ describe('runtimeEnvInputSchema', () => {
     expect(parsed.defaultUrl).toBe('https://app.example.com');
   });
 
+  it('accepts an empty MODERATED_TAGS JSON array as no moderated tags', () => {
+    const parsed = runtimeEnvInputSchema.parse({ ...VALID_ENV_INPUT, moderatedTags: '[]' });
+
+    expect(parsed.moderatedTags).toEqual([]);
+  });
+
+  it('falls back to default moderatedTags when unset or blank', () => {
+    expect(runtimeEnvInputSchema.parse(VALID_ENV_INPUT).moderatedTags).toEqual(APP_RUNTIME_DEFAULTS.moderatedTags);
+    expect(runtimeEnvInputSchema.parse({ ...VALID_ENV_INPUT, moderatedTags: '' }).moderatedTags).toEqual(
+      APP_RUNTIME_DEFAULTS.moderatedTags,
+    );
+    expect(runtimeEnvInputSchema.parse({ ...VALID_ENV_INPUT, moderatedTags: '   ' }).moderatedTags).toEqual(
+      APP_RUNTIME_DEFAULTS.moderatedTags,
+    );
+  });
+
   it('throws on invalid optional boolean values', () => {
     expect(() => runtimeEnvInputSchema.parse({ ...VALID_ENV_INPUT, notificationPollOnStart: 'tru' })).toThrow();
     expect(() => runtimeEnvInputSchemaWithDefaults.parse({ streamPollOnStart: 'yes' })).toThrow();
@@ -147,6 +163,15 @@ describe('runtimeConfigValueSchema', () => {
     expect(parsed.sentryTracesSampleRate).toBe(SENTRY_RUNTIME_DEFAULTS.sentryTracesSampleRate);
     expect(parsed.notificationPollIntervalMs).toBe(APP_RUNTIME_DEFAULTS.notificationPollIntervalMs);
     expect(parsed.moderatedTags).toEqual(APP_RUNTIME_DEFAULTS.moderatedTags);
+  });
+
+  it('accepts an empty moderatedTags array (no moderated tags)', () => {
+    const parsed = runtimeConfigValueSchema.parse({
+      ...NETWORK_RUNTIME_DEFAULTS,
+      moderatedTags: [],
+    });
+
+    expect(parsed.moderatedTags).toEqual([]);
   });
 
   it('accepts an already-parsed config object with the Sentry tier present', () => {

--- a/src/libs/runtime-config/runtime-config.schema.ts
+++ b/src/libs/runtime-config/runtime-config.schema.ts
@@ -107,7 +107,9 @@ const optionalStringArrayFromString = (label: string) =>
         return z.NEVER;
       }
     })
-    .pipe(z.array(nonEmptyStringValue).min(1).optional());
+    // Empty arrays are intentional (e.g. MODERATED_TAGS=[] means no moderated tags).
+    // Unset / blank strings stay `undefined` so the value-schema default still applies.
+    .pipe(z.array(nonEmptyStringValue).optional());
 
 /**
  * Optional-tier env strings: a missing OR empty/whitespace value means "unset".
@@ -230,10 +232,7 @@ export const runtimeConfigValueSchema = networkConfigValueSchema.extend({
   ttlUserMaxBatchSize: positiveIntValue.default(APP_RUNTIME_DEFAULTS.ttlUserMaxBatchSize),
   ttlRetryDelayMs: positiveIntValue.default(APP_RUNTIME_DEFAULTS.ttlRetryDelayMs),
   moderationId: nonEmptyStringValue.default(APP_RUNTIME_DEFAULTS.moderationId),
-  moderatedTags: z
-    .array(nonEmptyStringValue)
-    .min(1)
-    .default([...APP_RUNTIME_DEFAULTS.moderatedTags]),
+  moderatedTags: z.array(nonEmptyStringValue).default([...APP_RUNTIME_DEFAULTS.moderatedTags]),
   exchangeRateApi: urlValue.default(APP_RUNTIME_DEFAULTS.exchangeRateApi),
   preludeSdkKey: nonEmptyStringValue.optional(),
   preludeSdkTimeoutMs: positiveIntValue.default(APP_RUNTIME_DEFAULTS.preludeSdkTimeoutMs),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix #2182
- Empty `PUBKY_RUNTIME_MODERATED_TAGS=[]` is a valid deployer intent (“no moderated tags”) but was rejected by `.min(1)` on both the env-string helper and the value schema
- Unset / blank still falls back to the default `['nudity']`

## Changes
- Drop `.min(1)` from `optionalStringArrayFromString` so a parsed `[]` is accepted
- Drop `.min(1)` from `runtimeConfigValueSchema.moderatedTags` so empty arrays validate in the browser-injected config path too
- Add unit tests for `[]`, unset/blank default fallback, and already-parsed empty arrays

## Test plan
- [x] `npm run test -- src/libs/runtime-config/runtime-config.schema.test.ts src/libs/runtime-config/runtime-config.test.ts` (40 passed)
- [ ] Confirm a deploy with `PUBKY_RUNTIME_MODERATED_TAGS=[]` starts without env validation errors
- [ ] Confirm unset `PUBKY_RUNTIME_MODERATED_TAGS` still resolves to `['nudity']`

## Notes
- No behavior change for non-empty lists; only empty arrays become valid

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-206ff0cc-933c-4c7f-acf7-c92ce7e853a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-206ff0cc-933c-4c7f-acf7-c92ce7e853a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

