### PR TITLE
fix(ui): improve collection description legibility

### DIFF
--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
         </div>
       </div>
       <p
-        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-muted-foreground"
+        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-secondary-foreground"
         data-testid="typography"
       >
         A bit of Bitcoin purity amidst all of the madness.
@@ -350,7 +350,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
         </div>
       </div>
       <p
-        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-muted-foreground"
+        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-secondary-foreground"
         data-testid="typography"
       >
         A bit of Bitcoin purity amidst all of the madness.
@@ -587,7 +587,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
         </div>
       </div>
       <p
-        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-muted-foreground"
+        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-secondary-foreground"
         data-testid="typography"
       >
         A bit of Bitcoin purity amidst all of the madness.

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -313,7 +313,7 @@ function CollectionCardContent({
             {description && (
               <Typography
                 overrideDefaults
-                className="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-muted-foreground"
+                className="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-secondary-foreground"
               >
                 {description}
               </Typography>

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the non-owner Fol
       </div>
     </div>
     <p
-      class="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-muted-foreground lg:text-2xl"
+      class="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-secondary-foreground lg:text-2xl"
       data-testid="typography"
     >
       A bit of Bitcoin purity amidst all of the madness.
@@ -332,7 +332,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
       </div>
     </div>
     <p
-      class="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-muted-foreground lg:text-2xl"
+      class="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-secondary-foreground lg:text-2xl"
       data-testid="typography"
     >
       A bit of Bitcoin purity amidst all of the madness.

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
@@ -216,7 +216,7 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
         {description && (
           <Typography
             overrideDefaults
-            className="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-muted-foreground lg:text-2xl"
+            className="max-w-3xl text-xl leading-8 font-light wrap-anywhere text-secondary-foreground lg:text-2xl"
           >
             {description}
           </Typography>


### PR DESCRIPTION
## Summary

- Use `text-secondary-foreground` for collection preview card descriptions
- Use the same color for collection page header descriptions
- Update the affected component snapshots

## Testing

- 76 collection component tests passed
- TypeScript typecheck passed