### PR TITLE
fix(ui): refine collection card rendering, actions, layout

### DIFF
--- a/src/components/organisms/ClickableTagsList/ClickableTagsList.test.tsx
+++ b/src/components/organisms/ClickableTagsList/ClickableTagsList.test.tsx
@@ -219,6 +219,28 @@ describe('ClickableTagsList', () => {
       expect(getPostTagButton('web3', 10)).toBeInTheDocument();
     });
 
+    it('limits visible tags without constraining the add-tag input', () => {
+      render(
+        <ClickableTagsList
+          taggedId="post-123"
+          taggedKind={TagKind.POST}
+          tags={mockTags}
+          maxVisibleTags={1}
+          showAddButton
+          addMode
+        />,
+      );
+
+      expect(getPostTagButton('bitcoin', 5)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'ethereum tag (3 posts)' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'web3 tag (10 posts)' })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('post-tag-add-button'));
+
+      expect(screen.getByTestId('tag-input')).toBeInTheDocument();
+      expect(mockTagInput).toHaveBeenLastCalledWith(expect.objectContaining({ maxTags: undefined }), undefined);
+    });
+
     it('returns null when no tags and no input/button', () => {
       const { container } = render(<ClickableTagsList taggedId="post-123" taggedKind={TagKind.POST} tags={[]} />);
 

--- a/src/components/organisms/ClickableTagsList/ClickableTagsList.tsx
+++ b/src/components/organisms/ClickableTagsList/ClickableTagsList.tsx
@@ -45,6 +45,7 @@ export function ClickableTagsList({
   taggedKind,
   tags: providedTags,
   maxTags,
+  maxVisibleTags,
   maxTagLength = CLICKABLE_TAGS_DEFAULT_MAX_LENGTH,
   maxTotalChars = CLICKABLE_TAGS_DEFAULT_MAX_TOTAL_CHARS,
   showCount = true,
@@ -128,7 +129,7 @@ export function ClickableTagsList({
   const displayLabels = getDisplayTags(tagLabels, {
     maxTagLength,
     maxTotalChars,
-    maxCount: maxTags,
+    maxCount: maxVisibleTags ?? maxTags,
   });
   const visibleTags = enrichedTags.filter((tag) => displayLabels.includes(tag.label));
 

--- a/src/components/organisms/ClickableTagsList/ClickableTagsList.types.ts
+++ b/src/components/organisms/ClickableTagsList/ClickableTagsList.types.ts
@@ -10,8 +10,10 @@ export interface ClickableTagsListProps {
   taggedKind: TagKind;
   /** Optional: pre-loaded tags (if not provided, will fetch from IndexedDB) */
   tags?: NexusTag[];
-  /** Maximum number of tags to display */
+  /** Maximum tag count shared by the display list and add-tag input. */
   maxTags?: number;
+  /** Optional display-only cap that does not constrain the add-tag input. */
+  maxVisibleTags?: number;
   /** Maximum character length per tag */
   maxTagLength?: number;
   /** Maximum total characters across all tags */

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
@@ -1,12 +1,14 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
-import { TagKind } from '@/application/tag/tag.types';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
+import type { Pubky } from '@/models/models.types';
+import type { TagWithAvatars } from '@/molecules/TaggedItem/TaggedItem.types';
 import { PostMainLayoutProvider } from '@/organisms/PostMain/PostMainLayoutContext';
+import type { NexusTag } from '@/services/nexus/nexus.types';
 import { asOpaque } from '@/test-utils/type-assertions';
 import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
 import { CollectionCard } from './CollectionCard';
@@ -17,6 +19,10 @@ import { CollectionCard } from './CollectionCard';
 
 const mockUseAuthStore = vi.fn();
 const mockLocalCollections: Record<string, string | undefined> = {};
+const mockSetShowSignInDialog = vi.fn();
+const mockHandleTagToggle = vi.fn();
+const mockHandleTagAdd = vi.fn().mockResolvedValue({ success: true });
+const mockIsViewerTagger = vi.fn((tag: TagWithAvatars) => tag.relationship ?? false);
 
 vi.mock('next-intl', () => ({
   useTranslations: (namespace?: string) => (key: string, values?: { count?: number }) =>
@@ -48,7 +54,54 @@ vi.mock('@/hooks/useBookmark/useBookmark', () => ({
 
 const mockRequireAuth = vi.fn(<T,>(action: () => T) => action());
 vi.mock('@/hooks/useRequireAuth/useRequireAuth', () => ({
-  useRequireAuth: () => ({ requireAuth: mockRequireAuth }),
+  useRequireAuth: () => ({ isAuthenticated: true, requireAuth: mockRequireAuth }),
+}));
+
+vi.mock('@/hooks/useEntityTags/useEntityTags', () => ({
+  useEntityTags: vi.fn((_entityId, _taggedKind, options) => ({
+    tags: options?.providedTags ?? mockCollectionTags,
+    count: options?.providedTags?.length ?? mockCollectionTags.length,
+    isLoading: false,
+    isViewerTagger: mockIsViewerTagger,
+    handleTagToggle: mockHandleTagToggle,
+    handleTagAdd: mockHandleTagAdd,
+  })),
+}));
+
+vi.mock('@/hooks/useEnrichedTags/useEnrichedTags', () => ({
+  useEnrichedTags: vi.fn((tags: NexusTag[]) => ({
+    enrichedTags: tags.map((tag) => ({
+      ...tag,
+      taggers: tag.taggers.map((taggerId, index) => ({
+        id: taggerId as Pubky,
+        name: `User ${index + 1}`,
+        avatarUrl: `https://example.com/${taggerId}.png`,
+      })),
+    })),
+    isLoading: false,
+  })),
+}));
+
+vi.mock('@/hooks/useIsTouchDevice/useIsTouchDevice', () => ({
+  useIsTouchDevice: () => false,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/hooks/usePostTaggers/usePostTaggers', () => ({
+  usePostTaggers: () => ({
+    taggersByLabel: new Map(),
+    taggerStates: new Map(),
+    fetchAllTaggers: vi.fn(),
+  }),
+}));
+
+vi.mock('@/molecules/UserInfoPopover/UserInfoPopover', () => ({
+  UserInfoPopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="user-info-popover">{children}</div>
+  ),
 }));
 
 const mockDeletePost = vi.fn().mockResolvedValue(undefined);
@@ -127,31 +180,6 @@ vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
   ),
 }));
 
-vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => ({
-  ClickableTagsList: ({
-    taggedId,
-    taggedKind,
-    showAddButton,
-    readOnly,
-    maxVisibleTags,
-  }: {
-    taggedId: string;
-    taggedKind: TagKind;
-    showAddButton: boolean;
-    readOnly?: boolean;
-    maxVisibleTags?: number;
-  }) => (
-    <div
-      data-testid="clickable-tags-list"
-      data-tagged-id={taggedId}
-      data-tagged-kind={String(taggedKind)}
-      data-show-add-button={String(showAddButton)}
-      data-read-only={String(readOnly ?? false)}
-      data-max-visible-tags={maxVisibleTags}
-    />
-  ),
-}));
-
 // ---------------------------------------------------------------------------
 // Fixtures + helpers
 // ---------------------------------------------------------------------------
@@ -159,6 +187,12 @@ vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => ({
 const AUTHOR_PUBKY = 'o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy';
 const POST_ID = '0034BBBDFK83G';
 const COMPOSITE_ID = `${AUTHOR_PUBKY}:${POST_ID}`;
+const mockCollectionTags: NexusTag[] = [
+  { label: 'bitcoin', taggers_count: 5, taggers: ['user1', 'user2'], relationship: true },
+  { label: 'ethereum', taggers_count: 3, taggers: ['user3'], relationship: false },
+  { label: 'web3', taggers_count: 10, taggers: [], relationship: false },
+  { label: 'nostr', taggers_count: 1, taggers: ['user4'], relationship: false },
+];
 
 const COLLECTION_CONTENT = JSON.stringify({
   name: 'Based Bitcoin',
@@ -177,9 +211,18 @@ const mockUsePostDetails = vi.mocked(usePostDetails);
 const mockUseUserProfile = vi.mocked(useUserProfile);
 const mockUseBookmark = vi.mocked(useBookmark);
 
+function getTagsList(container: HTMLElement = document.body) {
+  return container.querySelector('[data-cy="clickable-tags-list"]');
+}
+
+function getAddTagButton(container: HTMLElement = document.body) {
+  return container.querySelector('[data-cy="post-tag-add-button"]');
+}
+
 function setAuthStore(currentUserPubky: string | null) {
-  mockUseAuthStore.mockImplementation((selector: (state: { currentUserPubky: string | null }) => unknown) =>
-    selector({ currentUserPubky }),
+  mockUseAuthStore.mockImplementation(
+    (selector: (state: { currentUserPubky: string | null; setShowSignInDialog: () => void }) => unknown) =>
+      selector({ currentUserPubky, setShowSignInDialog: mockSetShowSignInDialog }),
   );
 }
 
@@ -233,6 +276,7 @@ function setBookmark({ isBookmarked = false, isToggling = false } = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(useIsMobile).mockReturnValue(false);
+  mockIsViewerTagger.mockImplementation((tag: TagWithAvatars) => tag.relationship ?? false);
   for (const key of Object.keys(mockLocalCollections)) delete mockLocalCollections[key];
   setAuthStore(null);
   setPostDetails(COLLECTION_CONTENT);
@@ -266,13 +310,12 @@ describe('CollectionCard', () => {
   });
 
   it('restores the add-tag control for landing cards while keeping the tag-count button hidden', () => {
-    render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
 
-    const tags = screen.getByTestId('clickable-tags-list');
-    expect(tags).toHaveAttribute('data-tagged-id', COMPOSITE_ID);
-    expect(tags).toHaveAttribute('data-tagged-kind', String(TagKind.POST));
-    expect(tags).toHaveAttribute('data-show-add-button', 'true');
-    expect(tags).not.toHaveAttribute('data-max-visible-tags');
+    expect(getTagsList(container)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'bitcoin tag (5 posts)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ethereum tag (3 posts)' })).toBeInTheDocument();
+    expect(getAddTagButton(container)).toBeInTheDocument();
     expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
   });
 
@@ -332,7 +375,10 @@ describe('CollectionCard', () => {
       expect(link).toHaveAttribute('data-layout', 'default');
       expect(screen.getByText('Based Bitcoin')).toHaveClass('text-xl', 'leading-7');
       expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-size', 'sm');
-      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-max-visible-tags', '3');
+      expect(screen.getByRole('button', { name: 'bitcoin tag (5 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ethereum tag (3 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'web3 tag (10 posts)' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'nostr tag (1 posts)' })).not.toBeInTheDocument();
     });
 
     it('uses full width when tags layout is inline on desktop', () => {
@@ -620,9 +666,12 @@ describe('CollectionCard', () => {
 
       render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} presentation="embed" />);
 
-      expect(screen.getByTestId('clickable-tags-list')).toBeInTheDocument();
-      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-show-add-button', 'false');
-      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-max-visible-tags', '3');
+      expect(getTagsList()).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'bitcoin tag (5 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ethereum tag (3 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'web3 tag (10 posts)' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'nostr tag (1 posts)' })).not.toBeInTheDocument();
+      expect(getAddTagButton()).not.toBeInTheDocument();
       expect(screen.getByLabelText('collections.card.follow')).toBeInTheDocument();
       expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
     });
@@ -632,9 +681,12 @@ describe('CollectionCard', () => {
 
       render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} presentation="embed" />);
 
-      expect(screen.getByTestId('clickable-tags-list')).toBeInTheDocument();
-      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-show-add-button', 'false');
-      expect(screen.getByTestId('clickable-tags-list')).not.toHaveAttribute('data-max-visible-tags');
+      expect(getTagsList()).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'bitcoin tag (5 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ethereum tag (3 posts)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'web3 tag (10 posts)' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'nostr tag (1 posts)' })).not.toBeInTheDocument();
+      expect(getAddTagButton()).not.toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
       expect(document.querySelector('[data-cy="collection-card-actions"]')).not.toBeInTheDocument();
@@ -688,9 +740,9 @@ describe('CollectionCard', () => {
         <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} presentation="embed" interactiveActions={false} />,
       );
 
-      const tagsList = screen.getByTestId('clickable-tags-list');
-      expect(tagsList).toHaveAttribute('data-show-add-button', 'false');
-      expect(tagsList).toHaveAttribute('data-read-only', 'true');
+      expect(getTagsList()).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'bitcoin tag (5 posts)' })).toBeInTheDocument();
+      expect(getAddTagButton()).not.toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
       expect(document.querySelector('[data-cy="collection-card-actions"]')).not.toBeInTheDocument();

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx
@@ -1,14 +1,14 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnrichedPostDetails } from '@/application/moderation/moderation.types';
 import { TagKind } from '@/application/tag/tag.types';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
-import { usePostCounts } from '@/hooks/usePostCounts/usePostCounts';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
 import { PostMainLayoutProvider } from '@/organisms/PostMain/PostMainLayoutContext';
 import { asOpaque } from '@/test-utils/type-assertions';
+import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
 import { CollectionCard } from './CollectionCard';
 
 // ---------------------------------------------------------------------------
@@ -44,10 +44,6 @@ vi.mock('@/hooks/useUserProfile/useUserProfile', () => ({
 
 vi.mock('@/hooks/useBookmark/useBookmark', () => ({
   useBookmark: vi.fn(),
-}));
-
-vi.mock('@/hooks/usePostCounts/usePostCounts', () => ({
-  usePostCounts: vi.fn(),
 }));
 
 const mockRequireAuth = vi.fn(<T,>(action: () => T) => action());
@@ -137,11 +133,13 @@ vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => ({
     taggedKind,
     showAddButton,
     readOnly,
+    maxVisibleTags,
   }: {
     taggedId: string;
     taggedKind: TagKind;
     showAddButton: boolean;
     readOnly?: boolean;
+    maxVisibleTags?: number;
   }) => (
     <div
       data-testid="clickable-tags-list"
@@ -149,31 +147,7 @@ vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => ({
       data-tagged-kind={String(taggedKind)}
       data-show-add-button={String(showAddButton)}
       data-read-only={String(readOnly ?? false)}
-    />
-  ),
-}));
-
-vi.mock('@/organisms/PostTagsPanel/PostTagsPanel', () => ({
-  PostTagsPanel: ({
-    postId,
-    widthMode,
-    autoFocusInput,
-    enableLoadingSkeleton,
-    className,
-  }: {
-    postId: string;
-    widthMode: string;
-    autoFocusInput: boolean;
-    enableLoadingSkeleton: boolean;
-    className?: string;
-  }) => (
-    <div
-      data-testid="post-tags-panel"
-      data-auto-focus-input={String(autoFocusInput)}
-      data-enable-loading-skeleton={String(enableLoadingSkeleton)}
-      data-post-id={postId}
-      data-width-mode={widthMode}
-      className={className}
+      data-max-visible-tags={maxVisibleTags}
     />
   ),
 }));
@@ -202,7 +176,6 @@ const COLLECTION_CONTENT_NO_COVER = JSON.stringify({
 const mockUsePostDetails = vi.mocked(usePostDetails);
 const mockUseUserProfile = vi.mocked(useUserProfile);
 const mockUseBookmark = vi.mocked(useBookmark);
-const mockUsePostCounts = vi.mocked(usePostCounts);
 
 function setAuthStore(currentUserPubky: string | null) {
   mockUseAuthStore.mockImplementation((selector: (state: { currentUserPubky: string | null }) => unknown) =>
@@ -257,19 +230,6 @@ function setBookmark({ isBookmarked = false, isToggling = false } = {}) {
   return toggle;
 }
 
-function setPostCounts(uniqueTags = 3) {
-  mockUsePostCounts.mockReturnValue({
-    postCounts: {
-      id: COMPOSITE_ID,
-      tags: 4,
-      unique_tags: uniqueTags,
-      reposts: 0,
-      replies: 0,
-    },
-    isLoading: false,
-  });
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(useIsMobile).mockReturnValue(false);
@@ -278,7 +238,6 @@ beforeEach(() => {
   setPostDetails(COLLECTION_CONTENT);
   setOwnerProfile('Bitcoin Wizard', 'https://example.com/avatar.png');
   setBookmark();
-  setPostCounts();
 });
 
 // ---------------------------------------------------------------------------
@@ -306,13 +265,15 @@ describe('CollectionCard', () => {
     expect(link).toHaveAttribute('data-cy', 'collection-card');
   });
 
-  it('wires ClickableTagsList to the composite id with POST kind and the add button enabled', () => {
+  it('restores the add-tag control for landing cards while keeping the tag-count button hidden', () => {
     render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
 
     const tags = screen.getByTestId('clickable-tags-list');
     expect(tags).toHaveAttribute('data-tagged-id', COMPOSITE_ID);
     expect(tags).toHaveAttribute('data-tagged-kind', String(TagKind.POST));
     expect(tags).toHaveAttribute('data-show-add-button', 'true');
+    expect(tags).not.toHaveAttribute('data-max-visible-tags');
+    expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
   });
 
   it('pins the tags and action row to the bottom of the card with mt-auto', () => {
@@ -320,9 +281,25 @@ describe('CollectionCard', () => {
 
     const actionRow = container.querySelector('[data-cy="collection-card-bottom-row"]');
 
-    expect(actionRow).toHaveClass('mt-auto', 'flex-row', 'items-end', 'justify-between');
+    expect(actionRow).toHaveClass(
+      'mt-auto',
+      'flex-col',
+      'items-start',
+      'gap-3',
+      'md:flex-row',
+      'md:items-end',
+      'md:justify-between',
+      'md:gap-4',
+    );
     expect(container.querySelector('[data-cy="post-tags-expandable-row-actions"]')).not.toBeInTheDocument();
-    expect(container.querySelector('[data-cy="collection-card-tag-actions"]')).toHaveClass('self-end');
+    expect(container.querySelector('[data-cy="collection-card-actions"]')).toHaveClass(
+      'w-full',
+      'justify-start',
+      'self-start',
+      'md:w-auto',
+      'md:justify-end',
+      'md:self-end',
+    );
   });
 
   describe('wide timeline layout', () => {
@@ -355,6 +332,7 @@ describe('CollectionCard', () => {
       expect(link).toHaveAttribute('data-layout', 'default');
       expect(screen.getByText('Based Bitcoin')).toHaveClass('text-xl', 'leading-7');
       expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-size', 'sm');
+      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-max-visible-tags', '3');
     });
 
     it('uses full width when tags layout is inline on desktop', () => {
@@ -446,16 +424,6 @@ describe('CollectionCard', () => {
       expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
     });
 
-    it('renders the tag CTA before the Follow button', () => {
-      setAuthStore('some-other-user');
-
-      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
-
-      const tagButton = screen.getByLabelText('post.actions.tagPost');
-      const followButton = screen.getByLabelText('collections.card.follow');
-      expect(tagButton.compareDocumentPosition(followButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    });
-
     it('renders an Unfollow button when the post is already bookmarked', () => {
       setAuthStore('some-other-user');
       setBookmark({ isBookmarked: true });
@@ -509,100 +477,41 @@ describe('CollectionCard', () => {
   });
 
   describe('CTA — owner', () => {
-    it('renders the Delete placeholder button when the viewer owns the collection', () => {
+    it('hides Delete outside an opted-in My Collections card', () => {
       setAuthStore(AUTHOR_PUBKY);
 
       render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+
+      expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-cy="collection-card-actions"]')).not.toBeInTheDocument();
+    });
+
+    it('renders Delete when the owner card opts in from My Collections', () => {
+      setAuthStore(AUTHOR_PUBKY);
+
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
 
       expect(screen.getByLabelText('collections.card.delete')).toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('collections.card.unfollow')).not.toBeInTheDocument();
     });
 
-    it('renders the tag CTA before the Delete button', () => {
+    it('shows the Delete label below md while keeping the desktop action icon-only', () => {
       setAuthStore(AUTHOR_PUBKY);
 
-      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
-
-      const tagButton = screen.getByLabelText('post.actions.tagPost');
-      const deleteButton = screen.getByLabelText('collections.card.delete');
-      expect(tagButton.compareDocumentPosition(deleteButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    });
-
-    it('toggles the editable tags panel from the tag CTA and suppresses card navigation', () => {
-      setAuthStore(AUTHOR_PUBKY);
-      const onParentClick = vi.fn();
-
-      render(
-        <div onClick={onParentClick}>
-          <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />
-        </div>,
-      );
-
-      const tagButton = screen.getByLabelText('post.actions.tagPost');
-      fireEvent.click(tagButton);
-
-      expect(screen.queryByTestId('clickable-tags-list')).not.toBeInTheDocument();
-      const panel = screen.getByTestId('post-tags-panel');
-      expect(panel).toHaveAttribute('data-post-id', COMPOSITE_ID);
-      expect(panel).toHaveAttribute('data-width-mode', 'full');
-      expect(panel).toHaveAttribute('data-auto-focus-input', 'true');
-      expect(panel).toHaveAttribute('data-enable-loading-skeleton', 'false');
-      expect(document.querySelector('[data-cy="post-tags-expandable-row"]')).toHaveClass('items-end');
-      expect(document.querySelector('[data-cy="post-tags-expandable-row-actions"]')).not.toBeInTheDocument();
-      expect(document.querySelector('[data-cy="collection-card-tag-actions"]')).toHaveClass('self-end');
-      expect(onParentClick).not.toHaveBeenCalled();
-    });
-
-    it('lets clicks in expanded tag panel gaps bubble to the card link', () => {
-      setAuthStore(AUTHOR_PUBKY);
-      const onParentClick = vi.fn();
-
-      render(
-        <div onClick={onParentClick}>
-          <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />
-        </div>,
-      );
-
-      fireEvent.click(screen.getByLabelText('post.actions.tagPost'));
-
-      const tagsColumn = document.querySelector('[data-cy="post-tags-expandable-row"]')?.firstElementChild;
-      expect(tagsColumn).toBeTruthy();
-      fireEvent.click(tagsColumn!);
-
-      expect(onParentClick).toHaveBeenCalledTimes(1);
-    });
-
-    it('suppresses navigation when clicking inside the expanded tag panel', () => {
-      setAuthStore(AUTHOR_PUBKY);
-      const onParentClick = vi.fn();
-
-      render(
-        <div onClick={onParentClick}>
-          <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />
-        </div>,
-      );
-
-      fireEvent.click(screen.getByLabelText('post.actions.tagPost'));
-      fireEvent.click(screen.getByTestId('post-tags-panel'));
-
-      expect(onParentClick).not.toHaveBeenCalled();
-    });
-
-    it('renders Delete as an icon-only button (aria-label, no visible label text)', () => {
-      setAuthStore(AUTHOR_PUBKY);
-
-      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
 
       const deleteButton = screen.getByLabelText('collections.card.delete');
-      expect(deleteButton).not.toHaveTextContent('collections.card.delete');
+      const deleteLabel = screen.getByText('collections.card.delete', { selector: 'span' });
+      expect(deleteButton).toContainElement(deleteLabel);
+      expect(deleteLabel).toHaveClass('md:hidden');
     });
 
     it('does not toggle the bookmark when the owner clicks Delete (placeholder only)', () => {
       setAuthStore(AUTHOR_PUBKY);
       const toggle = setBookmark({ isBookmarked: false });
 
-      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+      render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
 
       fireEvent.click(screen.getByLabelText('collections.card.delete'));
 
@@ -613,7 +522,7 @@ describe('CollectionCard', () => {
       it('opens the confirmation dialog with collection-specific copy on Delete click', () => {
         setAuthStore(AUTHOR_PUBKY);
         setBookmark({ isBookmarked: false });
-        render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+        render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
 
         fireEvent.click(screen.getByLabelText('collections.card.delete'));
 
@@ -628,7 +537,7 @@ describe('CollectionCard', () => {
         setAuthStore(AUTHOR_PUBKY);
         setBookmark({ isBookmarked: false });
         mockDeletePost.mockClear();
-        render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+        render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
 
         fireEvent.click(screen.getByLabelText('collections.card.delete'));
         fireEvent.click(screen.getByTestId('dialog-confirm-delete-btn'));
@@ -704,25 +613,31 @@ describe('CollectionCard', () => {
       expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-name', 'Bitcoin Wizard');
     });
 
-    it('shows tags, Follow, and the tag-toggle CTA for non-owners', () => {
+    it('shows tags and Follow without tag-management controls for non-owners', () => {
+      vi.mocked(useIsMobile).mockReturnValue(true);
       setAuthStore('some-other-user');
       setBookmark({ isBookmarked: false });
 
       render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} presentation="embed" />);
 
       expect(screen.getByTestId('clickable-tags-list')).toBeInTheDocument();
+      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-show-add-button', 'false');
+      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-max-visible-tags', '3');
       expect(screen.getByLabelText('collections.card.follow')).toBeInTheDocument();
-      expect(screen.getByLabelText('post.actions.tagPost')).toBeInTheDocument();
+      expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
     });
 
-    it('shows tags, Delete, and the tag-toggle CTA for the owner', () => {
+    it('shows tags without Delete or tag-management controls for the owner', () => {
       setAuthStore(AUTHOR_PUBKY);
 
       render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} presentation="embed" />);
 
       expect(screen.getByTestId('clickable-tags-list')).toBeInTheDocument();
-      expect(screen.getByLabelText('collections.card.delete')).toBeInTheDocument();
-      expect(screen.getByLabelText('post.actions.tagPost')).toBeInTheDocument();
+      expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-show-add-button', 'false');
+      expect(screen.getByTestId('clickable-tags-list')).not.toHaveAttribute('data-max-visible-tags');
+      expect(screen.queryByLabelText('collections.card.delete')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-cy="collection-card-actions"]')).not.toBeInTheDocument();
     });
 
     it('clips the cover at the link boundary in preview embeds', () => {
@@ -746,7 +661,7 @@ describe('CollectionCard', () => {
       expect(card).not.toHaveClass('rounded-none');
     });
 
-    it('elevates action CTAs on embeds without a cover', () => {
+    it('elevates the Follow CTA on embeds without a cover', () => {
       setAuthStore('some-other-user');
       setBookmark({ isBookmarked: false });
       setPostDetails(
@@ -763,7 +678,6 @@ describe('CollectionCard', () => {
       expect(countBadge).toHaveClass('bg-card');
 
       expect(screen.getByLabelText('collections.card.follow')).toHaveClass('bg-card', 'text-foreground');
-      expect(screen.getByLabelText('post.actions.tagPost', { exact: false })).toHaveClass('bg-card', 'text-foreground');
     });
 
     it('hides CTAs and renders read-only tags when interactiveActions is false', () => {
@@ -779,7 +693,7 @@ describe('CollectionCard', () => {
       expect(tagsList).toHaveAttribute('data-read-only', 'true');
       expect(screen.queryByLabelText('collections.card.follow')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('post.actions.tagPost')).not.toBeInTheDocument();
-      expect(document.querySelector('[data-cy="collection-card-tag-actions"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-cy="collection-card-actions"]')).not.toBeInTheDocument();
     });
   });
 });
@@ -796,7 +710,7 @@ describe('CollectionCard - Snapshots', () => {
   it('matches the snapshot for the owner Delete state', () => {
     setAuthStore(AUTHOR_PUBKY);
 
-    const { container } = render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
+    const { container } = render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} showDeleteAction />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -817,6 +731,25 @@ describe('CollectionCard - Snapshots', () => {
         <CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />
       </PostMainLayoutProvider>,
     );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('CollectionCard - Mobile Snapshots', () => {
+  beforeEach(() => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    setMobileViewport();
+  });
+
+  afterEach(() => {
+    resetViewport();
+  });
+
+  it('matches the mobile snapshot with up to three visible tags and stacked actions', () => {
+    setAuthStore('viewer-pubky');
+    setBookmark({ isBookmarked: false });
+
+    const { container } = render(<CollectionCard authorPubky={AUTHOR_PUBKY} postId={POST_ID} />);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -1,5 +1,196 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`CollectionCard - Mobile Snapshots > matches the mobile snapshot with up to three visible tags and stacked actions 1`] = `
+<a
+  aria-label="Based Bitcoin"
+  class="group relative block h-full w-full"
+  data-cy="collection-card"
+  data-interactive-actions="true"
+  data-layout="default"
+  data-presentation="landing"
+  href="/collections/o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy/0034BBBDFK83G"
+>
+  <div
+    class="flex flex-col text-card-foreground shadow-sm relative isolate h-full gap-0 overflow-hidden py-0 rounded-md border-transparent bg-card/40"
+    data-slot="card"
+    data-testid="card"
+  >
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 -z-10 bg-cover bg-center bg-no-repeat"
+      data-testid="container"
+      style="background-image: linear-gradient(to right, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.35)), url(\\"https://example.com/cover.png\\");"
+    />
+    <div
+      class="flex h-full flex-col gap-3 p-6"
+      data-slot="card-content"
+    >
+      <div
+        class="flex w-full flex-wrap items-center gap-3 sm:flex-nowrap"
+        data-testid="container"
+      >
+        <div
+          class="flex min-w-0 flex-1 items-center gap-2"
+          data-testid="container"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-library size-6 shrink-0 text-foreground"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m16 6 4 14"
+            />
+            <path
+              d="M12 6v14"
+            />
+            <path
+              d="M8 8v12"
+            />
+            <path
+              d="M4 4v16"
+            />
+          </svg>
+          <span
+            class="min-w-0 truncate font-bold text-foreground text-xl leading-7"
+            data-testid="typography"
+          >
+            Based Bitcoin
+          </span>
+          <div
+            aria-label="2 posts"
+            class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
+            data-testid="container"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-sticky-note size-3 shrink-0"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+              />
+              <path
+                d="M15 3v5a1 1 0 0 0 1 1h5"
+              />
+            </svg>
+            <span
+              class="text-xs leading-4 font-medium tracking-widest uppercase"
+              data-testid="typography"
+            >
+              2
+              <span
+                class="hidden sm:inline"
+                data-testid="typography"
+              >
+                 posts
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end"
+          data-testid="container"
+        >
+          <div
+            data-alt="Bitcoin Wizard"
+            data-avatar-url="https://example.com/avatar.png"
+            data-fallback-seed="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
+            data-name="Bitcoin Wizard"
+            data-size="sm"
+            data-testid="avatar-with-fallback"
+          >
+            Bitcoin Wizard
+          </div>
+        </div>
+      </div>
+      <p
+        class="line-clamp-2 w-full min-w-0 text-base leading-6 font-medium wrap-anywhere text-secondary-foreground"
+        data-testid="typography"
+      >
+        A bit of Bitcoin purity amidst all of the madness.
+      </p>
+      <div
+        class="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
+        data-cy="collection-card-bottom-row"
+        data-testid="container"
+      >
+        <div
+          class="flex w-full flex-wrap justify-between gap-3 sm:flex-nowrap items-center min-w-0 flex-1"
+          data-cy="post-tags-expandable-row"
+          data-testid="container"
+        >
+          <div
+            class="min-w-0 flex-1"
+            data-testid="container"
+          >
+            <div
+              data-max-visible-tags="3"
+              data-read-only="false"
+              data-show-add-button="true"
+              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
+              data-tagged-kind="post"
+              data-testid="clickable-tags-list"
+            />
+          </div>
+        </div>
+        <div
+          class="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
+          data-cy="collection-card-actions"
+          data-testid="container"
+        >
+          <button
+            aria-label="collections.card.follow"
+            class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 px-3 has-[>svg]:px-3.5 gap-2 text-xs"
+            data-size="sm"
+            data-slot="button"
+            data-variant="secondary"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-plus size-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 12h14"
+              />
+              <path
+                d="M12 5v14"
+              />
+            </svg>
+            collections.card.follow
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</a>
+`;
+
 exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Follow state 1`] = `
 <a
   aria-label="Based Bitcoin"
@@ -127,7 +318,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
         A bit of Bitcoin purity amidst all of the madness.
       </p>
       <div
-        class="mt-auto flex w-full flex-row items-end justify-between gap-3"
+        class="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
         data-cy="collection-card-bottom-row"
         data-testid="container"
       >
@@ -150,49 +341,10 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
           </div>
         </div>
         <div
-          class="flex shrink-0 items-center gap-2 self-end"
-          data-cy="collection-card-tag-actions"
+          class="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
+          data-cy="collection-card-actions"
           data-testid="container"
         >
-          <button
-            aria-expanded="false"
-            aria-label="post.actions.tagPost"
-            class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 border-none shadow-xs"
-            data-cy="post-tag-btn"
-            data-size="sm"
-            data-slot="button"
-            data-variant="secondary"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-tag"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
-              />
-              <circle
-                cx="7.5"
-                cy="7.5"
-                fill="currentColor"
-                r=".5"
-              />
-            </svg>
-            <span
-              class="text-xs leading-4 font-bold text-muted-foreground"
-              data-testid="typography"
-            >
-              3
-            </span>
-          </button>
           <button
             aria-label="collections.card.follow"
             class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 px-3 has-[>svg]:px-3.5 gap-2 text-xs"
@@ -356,7 +508,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
         A bit of Bitcoin purity amidst all of the madness.
       </p>
       <div
-        class="mt-auto flex w-full flex-row items-end justify-between gap-3"
+        class="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
         data-cy="collection-card-bottom-row"
         data-testid="container"
       >
@@ -379,49 +531,10 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
           </div>
         </div>
         <div
-          class="flex shrink-0 items-center gap-2 self-end"
-          data-cy="collection-card-tag-actions"
+          class="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
+          data-cy="collection-card-actions"
           data-testid="container"
         >
-          <button
-            aria-expanded="false"
-            aria-label="post.actions.tagPost"
-            class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 border-none shadow-xs"
-            data-cy="post-tag-btn"
-            data-size="sm"
-            data-slot="button"
-            data-variant="secondary"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-tag"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
-              />
-              <circle
-                cx="7.5"
-                cy="7.5"
-                fill="currentColor"
-                r=".5"
-              />
-            </svg>
-            <span
-              class="text-xs leading-4 font-bold text-muted-foreground"
-              data-testid="typography"
-            >
-              3
-            </span>
-          </button>
           <button
             aria-label="collections.card.delete"
             class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 px-3 has-[>svg]:px-3.5 gap-2 text-xs"
@@ -458,6 +571,11 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
                 d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
               />
             </svg>
+            <span
+              class="md:hidden"
+            >
+              collections.card.delete
+            </span>
           </button>
         </div>
       </div>
@@ -593,7 +711,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
         A bit of Bitcoin purity amidst all of the madness.
       </p>
       <div
-        class="mt-auto flex w-full flex-row items-end justify-between gap-3"
+        class="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
         data-cy="collection-card-bottom-row"
         data-testid="container"
       >
@@ -616,49 +734,10 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
           </div>
         </div>
         <div
-          class="flex shrink-0 items-center gap-2 self-end"
-          data-cy="collection-card-tag-actions"
+          class="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
+          data-cy="collection-card-actions"
           data-testid="container"
         >
-          <button
-            aria-expanded="false"
-            aria-label="post.actions.tagPost"
-            class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 border-none shadow-xs"
-            data-cy="post-tag-btn"
-            data-size="sm"
-            data-slot="button"
-            data-variant="secondary"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-tag"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
-              />
-              <circle
-                cx="7.5"
-                cy="7.5"
-                fill="currentColor"
-                r=".5"
-              />
-            </svg>
-            <span
-              class="text-xs leading-4 font-bold text-muted-foreground"
-              data-testid="typography"
-            >
-              3
-            </span>
-          </button>
           <button
             aria-label="collections.card.follow"
             class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 px-3 has-[>svg]:px-3.5 gap-2 text-xs"
@@ -810,7 +889,7 @@ exports[`CollectionCard - Snapshots > matches the snapshot when no cover image a
         </div>
       </div>
       <div
-        class="mt-auto flex w-full flex-row items-end justify-between gap-3"
+        class="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
         data-cy="collection-card-bottom-row"
         data-testid="container"
       >
@@ -833,49 +912,10 @@ exports[`CollectionCard - Snapshots > matches the snapshot when no cover image a
           </div>
         </div>
         <div
-          class="flex shrink-0 items-center gap-2 self-end"
-          data-cy="collection-card-tag-actions"
+          class="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
+          data-cy="collection-card-actions"
           data-testid="container"
         >
-          <button
-            aria-expanded="false"
-            aria-label="post.actions.tagPost"
-            class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 border-none shadow-xs"
-            data-cy="post-tag-btn"
-            data-size="sm"
-            data-slot="button"
-            data-variant="secondary"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-tag"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
-              />
-              <circle
-                cx="7.5"
-                cy="7.5"
-                fill="currentColor"
-                r=".5"
-              />
-            </svg>
-            <span
-              class="text-xs leading-4 font-bold text-muted-foreground"
-              data-testid="typography"
-            >
-              3
-            </span>
-          </button>
           <button
             aria-label="collections.card.follow"
             class="inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 px-3 has-[>svg]:px-3.5 gap-2 text-xs"

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -141,13 +141,174 @@ exports[`CollectionCard - Mobile Snapshots > matches the mobile snapshot with up
             data-testid="container"
           >
             <div
-              data-max-visible-tags="3"
-              data-read-only="false"
-              data-show-add-button="true"
-              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
-              data-tagged-kind="post"
-              data-testid="clickable-tags-list"
-            />
+              class="flex flex-col gap-1"
+              data-testid="container"
+            >
+              <div
+                class="flex flex-wrap items-center gap-2"
+                data-cy="clickable-tags-list"
+                data-testid="container"
+              >
+                <button
+                  aria-label="bitcoin tag (5 posts)"
+                  aria-pressed="true"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-cy="post-tag"
+                  data-state="on"
+                  data-tag-label="bitcoin"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 153, 0) 0%, rgb(255, 153, 0) 100%); box-shadow: inset 0 0 0 1px #FF9900;"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="bitcoin"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      bitcoin
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      5
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF9900;"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md border border-solid"
+                    style="border-color: rgb(255, 153, 0);"
+                  />
+                </button>
+                <button
+                  aria-label="ethereum tag (3 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-cy="post-tag"
+                  data-state="off"
+                  data-tag-label="ethereum"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 9, 0) 0%, rgb(255, 9, 0) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="ethereum"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      ethereum
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      3
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF0900;"
+                  />
+                </button>
+                <button
+                  aria-label="web3 tag (10 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-cy="post-tag"
+                  data-state="off"
+                  data-tag-label="web3"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(95, 0, 255) 0%, rgb(95, 0, 255) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="web3"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      web3
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      10
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #5f00FF;"
+                  />
+                </button>
+                <div
+                  class="relative h-8 overflow-hidden rounded-md border border-dashed border-input shadow-sm"
+                  style="width: 34px; transform-origin: 0% 50% 0;"
+                >
+                  <div
+                    class="h-full w-full absolute inset-0 inline-flex items-center justify-center"
+                    style="opacity: 1;"
+                  >
+                    <button
+                      aria-label="Add new tag"
+                      class="inline-flex items-center justify-center whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border hover:text-accent-foreground gap-1.5 px-3 has-[>svg]:px-3.5 relative size-8 min-w-8! rounded-md bg-transparent p-0! transition-opacity hover:bg-transparent hover:opacity-80 gap-0! px-0! has-[>svg]:px-0! border-transparent shadow-none hover:border-transparent hover:shadow-none"
+                      data-cy="post-tag-add-button"
+                      data-size="sm"
+                      data-slot="button"
+                      data-variant="outline"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-plus pointer-events-none absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 opacity-[0.32]"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
@@ -332,12 +493,192 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
             data-testid="container"
           >
             <div
-              data-read-only="false"
-              data-show-add-button="true"
-              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
-              data-tagged-kind="post"
-              data-testid="clickable-tags-list"
-            />
+              class="flex flex-col gap-1"
+              data-testid="container"
+            >
+              <div
+                class="flex flex-wrap items-center gap-2"
+                data-cy="clickable-tags-list"
+                data-testid="container"
+              >
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="bitcoin tag (5 posts)"
+                  aria-pressed="true"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="bitcoin"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 153, 0) 0%, rgb(255, 153, 0) 100%); box-shadow: inset 0 0 0 1px #FF9900;"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="bitcoin"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      bitcoin
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      5
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF9900;"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md border border-solid"
+                    style="border-color: rgb(255, 153, 0);"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="ethereum tag (3 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="ethereum"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 9, 0) 0%, rgb(255, 9, 0) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="ethereum"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      ethereum
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      3
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF0900;"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="web3 tag (10 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="web3"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(95, 0, 255) 0%, rgb(95, 0, 255) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="web3"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      web3
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      10
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #5f00FF;"
+                  />
+                </button>
+                <div
+                  class="relative h-8 overflow-hidden rounded-md border border-dashed border-input shadow-sm"
+                  style="width: 34px; transform-origin: 0% 50% 0;"
+                >
+                  <div
+                    class="h-full w-full absolute inset-0 inline-flex items-center justify-center"
+                    style="opacity: 1;"
+                  >
+                    <button
+                      aria-label="Add new tag"
+                      class="inline-flex items-center justify-center whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border hover:text-accent-foreground gap-1.5 px-3 has-[>svg]:px-3.5 relative size-8 min-w-8! rounded-md bg-transparent p-0! transition-opacity hover:bg-transparent hover:opacity-80 gap-0! px-0! has-[>svg]:px-0! border-transparent shadow-none hover:border-transparent hover:shadow-none"
+                      data-cy="post-tag-add-button"
+                      data-size="sm"
+                      data-slot="button"
+                      data-variant="outline"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-plus pointer-events-none absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 opacity-[0.32]"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
@@ -522,12 +863,192 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
             data-testid="container"
           >
             <div
-              data-read-only="false"
-              data-show-add-button="true"
-              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
-              data-tagged-kind="post"
-              data-testid="clickable-tags-list"
-            />
+              class="flex flex-col gap-1"
+              data-testid="container"
+            >
+              <div
+                class="flex flex-wrap items-center gap-2"
+                data-cy="clickable-tags-list"
+                data-testid="container"
+              >
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="bitcoin tag (5 posts)"
+                  aria-pressed="true"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="bitcoin"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 153, 0) 0%, rgb(255, 153, 0) 100%); box-shadow: inset 0 0 0 1px #FF9900;"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="bitcoin"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      bitcoin
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      5
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF9900;"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md border border-solid"
+                    style="border-color: rgb(255, 153, 0);"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="ethereum tag (3 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="ethereum"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 9, 0) 0%, rgb(255, 9, 0) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="ethereum"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      ethereum
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      3
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF0900;"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="web3 tag (10 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="web3"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(95, 0, 255) 0%, rgb(95, 0, 255) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="web3"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      web3
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      10
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #5f00FF;"
+                  />
+                </button>
+                <div
+                  class="relative h-8 overflow-hidden rounded-md border border-dashed border-input shadow-sm"
+                  style="width: 34px; transform-origin: 0% 50% 0;"
+                >
+                  <div
+                    class="h-full w-full absolute inset-0 inline-flex items-center justify-center"
+                    style="opacity: 1;"
+                  >
+                    <button
+                      aria-label="Add new tag"
+                      class="inline-flex items-center justify-center whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border hover:text-accent-foreground gap-1.5 px-3 has-[>svg]:px-3.5 relative size-8 min-w-8! rounded-md bg-transparent p-0! transition-opacity hover:bg-transparent hover:opacity-80 gap-0! px-0! has-[>svg]:px-0! border-transparent shadow-none hover:border-transparent hover:shadow-none"
+                      data-cy="post-tag-add-button"
+                      data-size="sm"
+                      data-slot="button"
+                      data-variant="outline"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-plus pointer-events-none absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 opacity-[0.32]"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
@@ -725,12 +1246,192 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
             data-testid="container"
           >
             <div
-              data-read-only="false"
-              data-show-add-button="true"
-              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
-              data-tagged-kind="post"
-              data-testid="clickable-tags-list"
-            />
+              class="flex flex-col gap-1"
+              data-testid="container"
+            >
+              <div
+                class="flex flex-wrap items-center gap-2"
+                data-cy="clickable-tags-list"
+                data-testid="container"
+              >
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="bitcoin tag (5 posts)"
+                  aria-pressed="true"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="bitcoin"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 153, 0) 0%, rgb(255, 153, 0) 100%); box-shadow: inset 0 0 0 1px #FF9900;"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="bitcoin"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      bitcoin
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      5
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF9900;"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md border border-solid"
+                    style="border-color: rgb(255, 153, 0);"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="ethereum tag (3 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="ethereum"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 9, 0) 0%, rgb(255, 9, 0) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="ethereum"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      ethereum
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      3
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF0900;"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="web3 tag (10 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="web3"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(95, 0, 255) 0%, rgb(95, 0, 255) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="web3"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      web3
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      10
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #5f00FF;"
+                  />
+                </button>
+                <div
+                  class="relative h-8 overflow-hidden rounded-md border border-dashed border-input shadow-sm"
+                  style="width: 34px; transform-origin: 0% 50% 0;"
+                >
+                  <div
+                    class="h-full w-full absolute inset-0 inline-flex items-center justify-center"
+                    style="opacity: 1;"
+                  >
+                    <button
+                      aria-label="Add new tag"
+                      class="inline-flex items-center justify-center whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border hover:text-accent-foreground gap-1.5 px-3 has-[>svg]:px-3.5 relative size-8 min-w-8! rounded-md bg-transparent p-0! transition-opacity hover:bg-transparent hover:opacity-80 gap-0! px-0! has-[>svg]:px-0! border-transparent shadow-none hover:border-transparent hover:shadow-none"
+                      data-cy="post-tag-add-button"
+                      data-size="sm"
+                      data-slot="button"
+                      data-variant="outline"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-plus pointer-events-none absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 opacity-[0.32]"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
@@ -903,12 +1604,192 @@ exports[`CollectionCard - Snapshots > matches the snapshot when no cover image a
             data-testid="container"
           >
             <div
-              data-read-only="false"
-              data-show-add-button="true"
-              data-tagged-id="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy:0034BBBDFK83G"
-              data-tagged-kind="post"
-              data-testid="clickable-tags-list"
-            />
+              class="flex flex-col gap-1"
+              data-testid="container"
+            >
+              <div
+                class="flex flex-wrap items-center gap-2"
+                data-cy="clickable-tags-list"
+                data-testid="container"
+              >
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="bitcoin tag (5 posts)"
+                  aria-pressed="true"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="bitcoin"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 153, 0) 0%, rgb(255, 153, 0) 100%); box-shadow: inset 0 0 0 1px #FF9900;"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="bitcoin"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      bitcoin
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      5
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF9900;"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md border border-solid"
+                    style="border-color: rgb(255, 153, 0);"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="ethereum tag (3 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="ethereum"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(255, 9, 0) 0%, rgb(255, 9, 0) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="ethereum"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      ethereum
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      3
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #FF0900;"
+                  />
+                </button>
+                <button
+                  aria-controls="radix-normalized"
+                  aria-expanded="false"
+                  aria-haspopup="dialog"
+                  aria-label="web3 tag (10 posts)"
+                  aria-pressed="false"
+                  class="cursor-pointer inline-flex items-center justify-center bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-w-9 group/tag relative h-8 max-w-full gap-1 rounded-md px-3 backdrop-blur-lg border-0 text-sm leading-5 font-bold text-white subpixel-antialiased transition-all duration-200 hover:bg-transparent hover:text-white data-[state=on]:border data-[state=on]:border-solid data-[state=on]:bg-transparent data-[state=on]:text-white"
+                  data-as-child="true"
+                  data-cy="post-tag"
+                  data-slot="popover-trigger"
+                  data-state="closed"
+                  data-tag-label="web3"
+                  data-testid="popover-trigger"
+                  style="background-image: linear-gradient(90deg, rgba(5, 5, 10, 0.7) 0%, rgba(5, 5, 10, 0.7) 100%), linear-gradient(90deg, rgb(95, 0, 255) 0%, rgb(95, 0, 255) 100%);"
+                  type="button"
+                >
+                  <div
+                    class="flex h-8 w-fit max-w-full min-w-0 cursor-pointer items-center justify-between rounded-md transition-all duration-200 px-0"
+                    data-cy="tag"
+                    data-testid="tag"
+                    style="background-color: transparent; border: medium; box-shadow: none;"
+                    title="web3"
+                  >
+                    <p
+                      class="text-sm text-foreground truncate font-bold"
+                      data-cy="tag-name"
+                      data-testid="tag-name"
+                    >
+                      web3
+                    </p>
+                    <p
+                      class="text-sm ml-1.5 shrink-0 font-medium text-foreground/50"
+                      data-cy="post-tag-count"
+                      data-testid="tag-count"
+                    >
+                      10
+                    </p>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-0 rounded-md opacity-0 transition-opacity group-hover/tag:opacity-100"
+                    style="box-shadow: inset 0px 0px 8px 0px #5f00FF;"
+                  />
+                </button>
+                <div
+                  class="relative h-8 overflow-hidden rounded-md border border-dashed border-input shadow-sm"
+                  style="width: 34px; transform-origin: 0% 50% 0;"
+                >
+                  <div
+                    class="h-full w-full absolute inset-0 inline-flex items-center justify-center"
+                    style="opacity: 1;"
+                  >
+                    <button
+                      aria-label="Add new tag"
+                      class="inline-flex items-center justify-center whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer border hover:text-accent-foreground gap-1.5 px-3 has-[>svg]:px-3.5 relative size-8 min-w-8! rounded-md bg-transparent p-0! transition-opacity hover:bg-transparent hover:opacity-80 gap-0! px-0! has-[>svg]:px-0! border-transparent shadow-none hover:border-transparent hover:shadow-none"
+                      data-cy="post-tag-add-button"
+                      data-size="sm"
+                      data-slot="button"
+                      data-variant="outline"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-plus pointer-events-none absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 opacity-[0.32]"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -13,6 +13,7 @@ import { Typography } from '@/atoms/Typography/Typography';
 import { useBookmark } from '@/hooks/useBookmark/useBookmark';
 import { useDeletePost } from '@/hooks/useDeletePost/useDeletePost';
 import { useEffectiveTagsLayout } from '@/hooks/useEffectiveTagsLayout/useEffectiveTagsLayout';
+import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
 import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
@@ -28,7 +29,6 @@ import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFal
 import { CollectionCardSkeleton } from '@/organisms/Collections/CollectionCard/CollectionCard.skeleton';
 import { CollectionCardBlurred } from '@/organisms/Collections/CollectionCard/CollectionCardBlurred';
 import { PostTagsExpandableRow } from '@/organisms/PostTagsExpandableRow/PostTagsExpandableRow';
-import { PostTagToggleButton } from '@/organisms/PostTagsExpandableRow/PostTagToggleButton';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 
@@ -50,16 +50,18 @@ interface CollectionCardProps {
   /**
    * Controls layout, visible actions, and embed chrome.
    *
-   * - `landing` — full card in catalog sections (default)
+   * - `landing` — full card in catalog sections and collection feeds (default)
    * - `embed` — nested preview (repost, share dialog, inline in post body)
    */
   presentation?: CollectionCardPresentation;
   /**
-   * When `false`, tags render read-only and the tag-toggle / Follow / Delete CTAs
-   * are hidden. Use for collection embeds inside share/repost dialogs; feed embeds
-   * keep the default (`true`).
+   * When `false`, tags render read-only and the Follow / Delete CTA is hidden.
+   * Use for collection embeds inside share/repost dialogs; feed embeds keep the
+   * default (`true`).
    */
   interactiveActions?: boolean;
+  /** Show the owner Delete action. Opt in only from the My Collections overview. */
+  showDeleteAction?: boolean;
 }
 
 /**
@@ -69,7 +71,7 @@ interface CollectionCardProps {
  * landing sections (`presentation="landing"`) and nested embed surfaces
  * (`presentation="embed"` — repost, share dialog, inline post body).
  * Use `interactiveActions={false}` on dialog embeds so tags stay visible but
- * non-interactive and CTAs are hidden; feed embeds keep full interactions.
+ * non-interactive and the Follow / Delete CTA is hidden.
  * Self-contained: derives title / description / cover / item count / owner profile / tags / ownership
  * locally from `(authorPubky, postId)`, so callers stay thin.
  *
@@ -88,8 +90,10 @@ export function CollectionCard({
   initialIsBookmarked,
   presentation = 'landing',
   interactiveActions = true,
+  showDeleteAction = false,
 }: CollectionCardProps) {
   const compositeId = buildCompositeId({ pubky: authorPubky, id: postId });
+  const isMobile = useIsMobile();
   const isWideLayout = useEffectiveTagsLayout() === 'side';
   const { postDetails, isLoading } = usePostDetails(compositeId);
 
@@ -125,8 +129,10 @@ export function CollectionCard({
       className={className}
       initialIsBookmarked={initialIsBookmarked}
       presentation={presentation}
+      isMobile={isMobile}
       isWideLayout={isWideLayout}
       interactiveActions={interactiveActions}
+      showDeleteAction={showDeleteAction}
     />
   );
 }
@@ -139,8 +145,10 @@ interface CollectionCardContentProps {
   className?: string;
   initialIsBookmarked?: boolean;
   presentation: CollectionCardPresentation;
+  isMobile: boolean;
   isWideLayout: boolean;
   interactiveActions: boolean;
+  showDeleteAction: boolean;
 }
 
 function CollectionCardContent({
@@ -151,10 +159,13 @@ function CollectionCardContent({
   className,
   initialIsBookmarked,
   presentation,
+  isMobile,
   isWideLayout,
   interactiveActions,
+  showDeleteAction,
 }: CollectionCardContentProps) {
   const isEmbed = presentation === 'embed';
+  const showTagAddButton = interactiveActions && !isEmbed;
   const t = useTranslations('collections.card');
   const tCardToast = useTranslations('collections.card.toast');
 
@@ -162,6 +173,9 @@ function CollectionCardContent({
 
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const isOwn = currentUserPubky === authorPubky;
+  const canDelete = interactiveActions && isOwn && showDeleteAction;
+  const canFollow = interactiveActions && !isOwn;
+  const showCardActions = canDelete || canFollow;
   const { requireAuth } = useRequireAuth();
 
   const collection = parseCollectionContent(postDetails.content);
@@ -226,16 +240,10 @@ function CollectionCardContent({
     },
   });
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const [tagsExpanded, setTagsExpanded] = useState(false);
 
   const handleDelete = (event: MouseEvent) => {
     suppressCardNavigation(event);
     setDeleteConfirmOpen(true);
-  };
-
-  const handleTagToggle = (event: MouseEvent<HTMLButtonElement>) => {
-    suppressCardNavigation(event);
-    setTagsExpanded((prev) => !prev);
   };
 
   const handleDeleteConfirm = () => {
@@ -320,47 +328,35 @@ function CollectionCardContent({
             )}
 
             {/*
-              Bottom row: tags (left) | tag-toggle + Follow/Delete (right).
+              Bottom row: tags (left) | Follow/Delete (right).
 
               `interactiveActions={false}` (share/repost dialog previews): tags
-              stay visible but read-only; CTAs hidden — matches non-collection
-              repost previews. Feed embeds default to interactive actions.
+              stay visible but read-only; Follow/Delete hidden — matches
+              non-collection repost previews.
             */}
             <Container
               overrideDefaults
               data-cy="collection-card-bottom-row"
-              className="mt-auto flex w-full flex-row items-end justify-between gap-3"
+              className="mt-auto flex w-full flex-col items-start gap-3 md:flex-row md:items-end md:justify-between md:gap-4"
             >
               <PostTagsExpandableRow
                 postId={compositeId}
                 preventDefaultOnClick
-                expanded={tagsExpanded}
-                onExpandedChange={setTagsExpanded}
                 showTagToggle={false}
-                showAddButton={interactiveActions}
+                showAddButton={showTagAddButton}
                 tagsReadOnly={!interactiveActions}
-                // Full mode keeps the expanded tag UI from being squeezed on
-                // mobile collection cards. It also preserves PostTagsPanel's
-                // existing "See all" behavior when there are more than 3 tags.
-                panelWidthMode="full"
+                maxVisibleTags={isMobile ? 3 : undefined}
                 className="min-w-0 flex-1"
               />
-              {interactiveActions && (
+              {showCardActions && (
                 <Container
                   overrideDefaults
-                  data-cy="collection-card-tag-actions"
-                  className="flex shrink-0 items-center gap-2 self-end"
+                  data-cy="collection-card-actions"
+                  className="flex w-full shrink-0 items-center justify-start gap-2 self-start md:w-auto md:justify-end md:self-end"
                   onClick={suppressCardNavigation}
                   onAuxClick={suppressCardNavigation}
                 >
-                  <PostTagToggleButton
-                    postId={compositeId}
-                    expanded={tagsExpanded}
-                    onToggle={handleTagToggle}
-                    disabled={isOwn && isDeleting}
-                    onMutedSurface={embeddedOnMuted}
-                  />
-                  {isOwn ? (
+                  {canDelete ? (
                     <Button
                       variant="secondary"
                       size="sm"
@@ -370,8 +366,9 @@ function CollectionCardContent({
                       className={embeddedMutedActionClass}
                     >
                       <Trash2 className="size-4" />
+                      <span className="md:hidden">{t('delete')}</span>
                     </Button>
-                  ) : (
+                  ) : canFollow ? (
                     <Button
                       variant="secondary"
                       size="sm"
@@ -383,7 +380,7 @@ function CollectionCardContent({
                       {isBookmarked ? <Minus className="size-4" /> : <Plus className="size-4" />}
                       {isBookmarked ? t('unfollow') : t('follow')}
                     </Button>
-                  )}
+                  ) : null}
                 </Container>
               )}
             </Container>

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
@@ -168,16 +168,19 @@ vi.mock('@/organisms/ClickableTagsList/ClickableTagsList', () => ({
     taggedId,
     taggedKind,
     showAddButton,
+    maxVisibleTags,
   }: {
     taggedId: string;
     taggedKind: TagKind;
     showAddButton: boolean;
+    maxVisibleTags?: number;
   }) => (
     <div
       data-testid="clickable-tags-list"
       data-tagged-id={taggedId}
       data-tagged-kind={String(taggedKind)}
       data-show-add-button={String(showAddButton)}
+      data-max-visible-tags={maxVisibleTags}
     />
   ),
 }));
@@ -369,6 +372,7 @@ describe('CollectionHero', () => {
     expect(tags).toHaveAttribute('data-tagged-id', COMPOSITE_ID);
     expect(tags).toHaveAttribute('data-tagged-kind', String(TagKind.POST));
     expect(tags).toHaveAttribute('data-show-add-button', 'true');
+    expect(tags).not.toHaveAttribute('data-max-visible-tags');
     expect(screen.getByLabelText('post.actions.tagPost')).toBeInTheDocument();
   });
 

--- a/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx
@@ -102,8 +102,21 @@ vi.mock('@/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard',
 }));
 
 vi.mock('@/organisms/Collections/CollectionCard/CollectionCard', () => ({
-  CollectionCard: ({ authorPubky, postId }: { authorPubky: string; postId: string }) => (
-    <div data-testid="collection-card" data-author-pubky={authorPubky} data-post-id={postId} />
+  CollectionCard: ({
+    authorPubky,
+    postId,
+    showDeleteAction,
+  }: {
+    authorPubky: string;
+    postId: string;
+    showDeleteAction?: boolean;
+  }) => (
+    <div
+      data-testid="collection-card"
+      data-author-pubky={authorPubky}
+      data-post-id={postId}
+      data-show-delete-action={String(showDeleteAction ?? false)}
+    />
   ),
 }));
 
@@ -237,8 +250,10 @@ describe('MyCollections', () => {
     expect(cards).toHaveLength(2);
     expect(cards[0]).toHaveAttribute('data-author-pubky', AUTHOR_A);
     expect(cards[0]).toHaveAttribute('data-post-id', 'p1');
+    expect(cards[0]).toHaveAttribute('data-show-delete-action', 'true');
     expect(cards[1]).toHaveAttribute('data-author-pubky', AUTHOR_A);
     expect(cards[1]).toHaveAttribute('data-post-id', 'p2');
+    expect(cards[1]).toHaveAttribute('data-show-delete-action', 'true');
     expect(screen.getByTestId('collection-bookmark-card')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'collections.new.cta' })).toHaveAttribute(
       'data-cy',

--- a/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx.snap
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.test.tsx.snap
@@ -80,11 +80,13 @@ exports[`MyCollections > MyCollections - Snapshots > matches the snapshot for th
     <div
       data-author-pubky="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
       data-post-id="p1"
+      data-show-delete-action="true"
       data-testid="collection-card"
     />
     <div
       data-author-pubky="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
       data-post-id="p2"
+      data-show-delete-action="true"
       data-testid="collection-card"
     />
     <button

--- a/src/components/organisms/Collections/MyCollections/MyCollections.tsx
+++ b/src/components/organisms/Collections/MyCollections/MyCollections.tsx
@@ -162,7 +162,7 @@ function MyCollectionsStream({ currentUserPubky }: MyCollectionsStreamProps) {
             ))
           : visibleIds.map((compositeId) => {
               const { pubky, id } = parseCompositeId(compositeId);
-              return <CollectionCard key={compositeId} authorPubky={pubky} postId={id} />;
+              return <CollectionCard key={compositeId} authorPubky={pubky} postId={id} showDeleteAction />;
             })}
         <NewCollectionCardCTA />
       </Container>

--- a/src/components/organisms/PostCardSkeleton/PostCardSkeleton.test.tsx.snap
+++ b/src/components/organisms/PostCardSkeleton/PostCardSkeleton.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`PostCardSkeleton - Snapshots > matches snapshot 1`] = `
       />
     </div>
     <div
-      class="mx-auto w-full flex flex-col items-start gap-2 md:flex-row md:items-start md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2!"
+      class="mx-auto w-full flex flex-col items-start gap-3 md:flex-row md:items-start md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3!"
       data-testid="container"
     >
       <div

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.skeleton.tsx
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.skeleton.tsx
@@ -17,8 +17,8 @@ export function PostInlineTagsActionsSkeleton() {
   return (
     <Container
       className={cn(
-        'flex-col items-start gap-2 md:flex-row md:items-start md:justify-between md:gap-4',
-        '@max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2!',
+        'flex-col items-start gap-3 md:flex-row md:items-start md:justify-between md:gap-4',
+        '@max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3!',
       )}
     >
       <Container overrideDefaults className="flex flex-wrap items-center gap-2">

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx
@@ -107,6 +107,7 @@ describe('PostInlineTagsActions', () => {
   it('renders the collapsed inline tags list by default', () => {
     render(<PostInlineTagsActions {...defaultProps} />);
 
+    expect(screen.getByTestId('container')).toHaveClass('gap-3', 'md:gap-4', '@max-xl/grid:gap-3!');
     expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-post-id', 'author:post-1');
     expect(screen.getByTestId('clickable-tags-list')).toHaveAttribute('data-show-add-button', 'true');
     expect(screen.queryByTestId('post-tags-panel')).not.toBeInTheDocument();

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx.snap
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostInlineTagsActions - Snapshots > matches snapshot with default props 1`] = `
 <div
-  class="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+  class="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
   data-testid="container"
 >
   <div

--- a/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.tsx
+++ b/src/components/organisms/PostInlineTagsActions/PostInlineTagsActions.tsx
@@ -30,10 +30,10 @@ export function PostInlineTagsActions({
     <Container
       onClick={(event) => event.stopPropagation()}
       className={cn(
-        'flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4',
+        'flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4',
         // Grid-scoped (decision D4): inside a narrow grid cell keep tags + actions
         // stacked. `!` beats the still-active viewport `md:` row classes; inert off-grid.
-        '@max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2!',
+        '@max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3!',
         tagsExpanded ? 'md:items-end' : 'md:items-start',
         className,
       )}

--- a/src/components/organisms/PostMain/PostMain.test.tsx.snap
+++ b/src/components/organisms/PostMain/PostMain.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`PostMain - Mobile Snapshots > matches snapshot on mobile viewport 1`] =
         post-123
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div
@@ -95,7 +95,7 @@ exports[`PostMain - Snapshots > matches snapshot for quote repost by current use
         me:quote-repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div
@@ -158,7 +158,7 @@ exports[`PostMain - Snapshots > matches snapshot for repost by another user 1`] 
         other-user:repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div
@@ -220,7 +220,7 @@ exports[`PostMain - Snapshots > matches snapshot for simple repost by current us
         me:simple-repost-1
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div
@@ -389,7 +389,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply false 1`] = `
         post-no-reply-456
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div
@@ -465,7 +465,7 @@ exports[`PostMain - Snapshots > matches snapshot with isReply true 1`] = `
         post-reply-123
       </div>
       <div
-        data-class-name="flex-col items-start gap-2 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-2! md:items-start"
+        data-class-name="flex-col items-start gap-3 md:flex-row md:justify-between md:gap-4 @max-xl/grid:mt-auto @max-xl/grid:flex-col! @max-xl/grid:items-start! @max-xl/grid:gap-3! md:items-start"
         data-testid="container"
       >
         <div

--- a/src/components/organisms/PostTagsExpandableRow/PostTagsExpandableRow.test.tsx
+++ b/src/components/organisms/PostTagsExpandableRow/PostTagsExpandableRow.test.tsx
@@ -145,6 +145,14 @@ describe('PostTagsExpandableRow', () => {
     expect(screen.queryByTestId('post-tags-panel')).not.toBeInTheDocument();
   });
 
+  it('forwards the visible tag limit to the collapsed tag list', () => {
+    render(<PostTagsExpandableRow postId={POST_ID} maxVisibleTags={1} />);
+
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+    expect(screen.queryByText('ethereum')).not.toBeInTheDocument();
+    expect(screen.queryByText('web3')).not.toBeInTheDocument();
+  });
+
   it('toggles from clickable tags to the editable tags panel', () => {
     render(<PostTagsExpandableRow postId={POST_ID} />);
 

--- a/src/components/organisms/PostTagsExpandableRow/PostTagsExpandableRow.tsx
+++ b/src/components/organisms/PostTagsExpandableRow/PostTagsExpandableRow.tsx
@@ -6,6 +6,7 @@ import { Container } from '@/atoms/Container/Container';
 import { POST_TAGS_MAX_LENGTH, POST_TAGS_MAX_TOTAL_CHARS } from '@/config/tags';
 import { cn } from '@/libs/utils/utils';
 import { ClickableTagsList } from '@/organisms/ClickableTagsList/ClickableTagsList';
+import type { ClickableTagsListProps } from '@/organisms/ClickableTagsList/ClickableTagsList.types';
 import { PostTagsPanel } from '@/organisms/PostTagsPanel/PostTagsPanel';
 import type { PostTagsPanelProps } from '@/organisms/PostTagsPanel/PostTagsPanel.types';
 import { PostTagToggleButton } from './PostTagToggleButton';
@@ -24,6 +25,8 @@ interface PostTagsExpandableRowProps {
   showAddButton?: boolean;
   /** Forwarded to `ClickableTagsList` — tags display without toggle/add. */
   tagsReadOnly?: boolean;
+  /** Forwarded to `ClickableTagsList` — limits visible tags without constraining tag creation. */
+  maxVisibleTags?: ClickableTagsListProps['maxVisibleTags'];
   panelWidthMode?: PostTagsPanelProps['widthMode'];
 }
 
@@ -39,6 +42,7 @@ export function PostTagsExpandableRow({
   showTagToggle = true,
   showAddButton = true,
   tagsReadOnly = false,
+  maxVisibleTags,
   panelWidthMode = 'fit',
 }: PostTagsExpandableRowProps) {
   const [internalExpanded, setInternalExpanded] = useState(false);
@@ -88,6 +92,7 @@ export function PostTagsExpandableRow({
             taggedKind={TagKind.POST}
             maxTagLength={POST_TAGS_MAX_LENGTH}
             maxTotalChars={POST_TAGS_MAX_TOTAL_CHARS}
+            maxVisibleTags={maxVisibleTags}
             showCount={true}
             showInput={false}
             showAddButton={showAddButton}

--- a/src/components/organisms/Timeline/Posts/FeedItem/TimelineFeedItem.test.tsx
+++ b/src/components/organisms/Timeline/Posts/FeedItem/TimelineFeedItem.test.tsx
@@ -42,8 +42,21 @@ vi.mock('@/organisms/Timeline/PostReplies/PostReplies', () => {
 
 vi.mock('@/organisms/Collections/CollectionCard/CollectionCard', () => {
   return {
-    CollectionCard: ({ authorPubky, postId }: { authorPubky: string; postId: string }) => (
-      <div data-testid="collection-card" data-author-pubky={authorPubky} data-post-id={postId} />
+    CollectionCard: ({
+      authorPubky,
+      postId,
+      showDeleteAction,
+    }: {
+      authorPubky: string;
+      postId: string;
+      showDeleteAction?: boolean;
+    }) => (
+      <div
+        data-testid="collection-card"
+        data-author-pubky={authorPubky}
+        data-post-id={postId}
+        data-show-delete-action={String(showDeleteAction ?? false)}
+      />
     ),
   };
 });
@@ -117,6 +130,7 @@ describe('TimelineFeedItem', () => {
     expect(collectionCard).toBeInTheDocument();
     expect(collectionCard).toHaveAttribute('data-author-pubky', 'author-pubky');
     expect(collectionCard).toHaveAttribute('data-post-id', 'collection-id');
+    expect(collectionCard).toHaveAttribute('data-show-delete-action', 'false');
     expect(screen.queryByTestId('post-author-pubky:collection-id')).not.toBeInTheDocument();
     expect(screen.queryByTestId('replies-author-pubky:collection-id')).not.toBeInTheDocument();
   });

--- a/src/components/organisms/Timeline/Posts/FeedItem/TimelineFeedItem.test.tsx.snap
+++ b/src/components/organisms/Timeline/Posts/FeedItem/TimelineFeedItem.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`TimelineFeedItem - Snapshots > matches snapshot for a collection timeli
   <div
     data-author-pubky="author-pubky"
     data-post-id="collection-id"
+    data-show-delete-action="false"
     data-testid="collection-card"
   />
 </div>


### PR DESCRIPTION
Fixes incorrect collection card rendering on mobile, removes interactivity in embedded previews, fixes spacing, other layout tweaks.

## Summary

- Keep the add-tag button on collection overview cards and standalone cards in collection-filtered feeds.
- Hide the add-tag button on embedded collection previews, including previews inside posts and share dialogs.
- Remove the aggregate collection tag-count action from preview cards while preserving interactions on individual tag chips.
- Show collection Delete actions only in My Collections, never in feeds or embedded previews.
- Show the Delete icon and label on mobile while keeping the desktop action icon-only.
- Display up to three collection tags on mobile without changing tag-addition limits or desktop display behavior.
- Move collection-card actions below tags on mobile with 12px vertical spacing.
- Apply the same 12px mobile spacing between tags and actions to ordinary post cards and their skeletons.
- Add and update focused component tests and snapshots for the responsive and context-specific behavior.

## Collection preview behavior

- **My Collections:** add-tag and owner Delete actions are available.
- **Collections overview:** add-tag is available.
- **Collections-only feed:** add-tag is available; Delete is never shown.
- **Embedded previews:** no add-tag, aggregate tag-count, or Delete action.
- Individual tag chips retain their existing behavior in every context.

## Verification

- 255 focused component tests passed across 12 test files.
- TypeScript typecheck passed.
- ESLint passed.
- Prettier check passed.
- `git diff --check` passed.
- Desktop and mobile browser smoke testing passed for the updated card contexts and responsive layouts.

