### PR TITLE
fix(ui): align collection counts with avatars

### DIFF
--- a/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.test.tsx.snap
@@ -47,6 +47,11 @@ exports[`CollectionBookmarkCard - Snapshots > matches the snapshot for a signed-
           >
             Bookmarks
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="123 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -85,11 +90,6 @@ exports[`CollectionBookmarkCard - Snapshots > matches the snapshot for a signed-
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Alice"
             data-avatar-url="https://example.com/avatar.png"
@@ -162,7 +162,7 @@ exports[`CollectionBookmarkCard - Snapshots > matches the snapshot for the signe
           </span>
         </div>
         <div
-          class="flex shrink-0 items-center justify-end"
+          class="flex shrink-0 items-center justify-end gap-2"
           data-testid="container"
         >
           <div

--- a/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.tsx
+++ b/src/components/organisms/Collections/CollectionBookmarkCard/CollectionBookmarkCard.tsx
@@ -58,10 +58,10 @@ export function CollectionBookmarkCard({ className }: CollectionBookmarkCardProp
               >
                 {title}
               </Typography>
-              {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />}
             </Container>
 
-            <Container overrideDefaults className="flex shrink-0 items-center justify-end">
+            <Container overrideDefaults className="flex shrink-0 items-center justify-end gap-2">
+              {bookmarkCount !== undefined && <CollectionCountBadge count={bookmarkCount} />}
               <AvatarWithFallback
                 avatarUrl={avatarUrl}
                 name={avatarName}

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.test.tsx.snap
@@ -65,6 +65,11 @@ exports[`CollectionCard - Mobile Snapshots > matches the mobile snapshot with up
           >
             Based Bitcoin
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="2 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -103,11 +108,6 @@ exports[`CollectionCard - Mobile Snapshots > matches the mobile snapshot with up
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Bitcoin Wizard"
             data-avatar-url="https://example.com/avatar.png"
@@ -417,6 +417,11 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
           >
             Based Bitcoin
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="2 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -455,11 +460,6 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the non-owner Fol
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Bitcoin Wizard"
             data-avatar-url="https://example.com/avatar.png"
@@ -787,6 +787,11 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
           >
             Based Bitcoin
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="2 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -825,11 +830,6 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the owner Delete 
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Bitcoin Wizard"
             data-avatar-url="https://example.com/avatar.png"
@@ -1170,6 +1170,11 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
           >
             Based Bitcoin
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="2 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -1208,11 +1213,6 @@ exports[`CollectionCard - Snapshots > matches the snapshot for the wide timeline
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Bitcoin Wizard"
             data-avatar-url="https://example.com/avatar.png"
@@ -1534,6 +1534,11 @@ exports[`CollectionCard - Snapshots > matches the snapshot when no cover image a
           >
             Quiet collection
           </span>
+        </div>
+        <div
+          class="flex shrink-0 items-center justify-end gap-2"
+          data-testid="container"
+        >
           <div
             aria-label="0 posts"
             class="flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 py-1 text-muted-foreground bg-background"
@@ -1572,11 +1577,6 @@ exports[`CollectionCard - Snapshots > matches the snapshot when no cover image a
               </span>
             </span>
           </div>
-        </div>
-        <div
-          class="flex shrink-0 items-center justify-end"
-          data-testid="container"
-        >
           <div
             data-alt="Bitcoin Wizard"
             data-avatar-url="https://example.com/avatar.png"

--- a/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
+++ b/src/components/organisms/Collections/CollectionCard/CollectionCard.tsx
@@ -289,7 +289,7 @@ function CollectionCardContent({
           )}
 
           <CardContent className={cn('flex h-full flex-col gap-3', isWideLayout ? 'p-12' : 'p-6')}>
-            {/* Header row: icon + title + item-count (left, grows) | avatar (right) */}
+            {/* Header row: icon + title (left, grows) | item-count + avatar (right) */}
             <Container overrideDefaults className="flex w-full flex-wrap items-center gap-3 sm:flex-nowrap">
               <Container overrideDefaults className="flex min-w-0 flex-1 items-center gap-2">
                 <Library className="size-6 shrink-0 text-foreground" />
@@ -303,10 +303,10 @@ function CollectionCardContent({
                 >
                   {title}
                 </Typography>
-                <CollectionCountBadge count={itemCount} tone={embeddedOnMuted ? 'on-muted' : 'on-card'} />
               </Container>
 
-              <Container overrideDefaults className="flex shrink-0 items-center justify-end">
+              <Container overrideDefaults className="flex shrink-0 items-center justify-end gap-2">
+                <CollectionCountBadge count={itemCount} tone={embeddedOnMuted ? 'on-muted' : 'on-card'} />
                 <AvatarWithFallback
                   avatarUrl={ownerAvatarUrl}
                   name={ownerName}


### PR DESCRIPTION
## Summary

- Move collection post counts directly to the left of owner avatars
- Apply the same layout to the pinned Bookmarks card
- Update affected component snapshots

## Validation

- 49 focused component tests passed
- ESLint passed
- `git diff --check` passed

<img width="830" height="383" alt="image" src="https://github.com/user-attachments/assets/42bae101-e814-4365-a16a-10895b42bc34" />
