### PR TITLE
fix(ui): refine collection header spacing

### DIFF
--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx
@@ -353,6 +353,7 @@ describe('CollectionHero', () => {
     expect(avatar).toHaveAttribute('data-name', 'Bitcoin Wizard');
     expect(avatar).toHaveAttribute('data-avatar-url', 'https://example.com/avatar.png');
     expect(avatar).toHaveAttribute('data-fallback-seed', AUTHOR_PUBKY);
+    expect(avatar).toHaveAttribute('data-size', 'sm');
   });
 
   it('links the owner avatar and name to the author profile', () => {

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the non-owner Fol
       data-testid="container"
     >
       <div
-        class="flex items-center min-w-0 flex-1 gap-2 lg:flex-none"
+        class="flex items-center min-w-0 flex-1 gap-3 lg:flex-none"
         data-testid="container"
       >
         <a
@@ -40,7 +40,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the non-owner Fol
             data-avatar-url="https://example.com/avatar.png"
             data-fallback-seed="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
             data-name="Bitcoin Wizard"
-            data-size="md"
+            data-size="sm"
             data-testid="avatar-with-fallback"
           >
             Bitcoin Wizard
@@ -121,7 +121,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the non-owner Fol
       </div>
     </div>
     <div
-      class="flex flex-wrap items-center gap-3"
+      class="flex flex-wrap items-center gap-2"
       data-testid="container"
     >
       <button
@@ -262,7 +262,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
       data-testid="container"
     >
       <div
-        class="flex items-center min-w-0 flex-1 gap-2 lg:flex-none"
+        class="flex items-center min-w-0 flex-1 gap-3 lg:flex-none"
         data-testid="container"
       >
         <a
@@ -274,7 +274,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
             data-avatar-url="https://example.com/avatar.png"
             data-fallback-seed="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
             data-name="Bitcoin Wizard"
-            data-size="md"
+            data-size="sm"
             data-testid="avatar-with-fallback"
           >
             Bitcoin Wizard
@@ -355,7 +355,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot for the owner state 1
       </div>
     </div>
     <div
-      class="flex flex-wrap items-center gap-3"
+      class="flex flex-wrap items-center gap-2"
       data-testid="container"
     >
       <button
@@ -545,7 +545,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot when no cover image a
       data-testid="container"
     >
       <div
-        class="flex items-center min-w-0 flex-1 gap-2 lg:flex-none"
+        class="flex items-center min-w-0 flex-1 gap-3 lg:flex-none"
         data-testid="container"
       >
         <a
@@ -557,7 +557,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot when no cover image a
             data-avatar-url="https://example.com/avatar.png"
             data-fallback-seed="o1gg96ewuojmopcjbz8895478wdtxtzzber7aezq6ror5a91j7dy"
             data-name="Bitcoin Wizard"
-            data-size="md"
+            data-size="sm"
             data-testid="avatar-with-fallback"
           >
             Bitcoin Wizard
@@ -632,7 +632,7 @@ exports[`CollectionHero - Snapshots > matches the snapshot when no cover image a
       </div>
     </div>
     <div
-      class="flex flex-wrap items-center gap-3"
+      class="flex flex-wrap items-center gap-2"
       data-testid="container"
     >
       <button

--- a/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
+++ b/src/components/organisms/Collections/CollectionHero/CollectionHero.tsx
@@ -205,8 +205,8 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
             fallbackSeed={authorPubky}
             avatarUrl={ownerAvatarUrl}
             isResolved={isOwnerResolved}
-            size="md"
-            className="min-w-0 flex-1 gap-2 lg:flex-none"
+            size="sm"
+            className="min-w-0 flex-1 gap-3 lg:flex-none"
             profileHref={ownerProfileHref}
           />
           <CollectionCountBadge count={itemCount} />
@@ -231,7 +231,7 @@ function CollectionHeroContent({ authorPubky, compositeId, postDetails, classNam
         />
 
         {/* Actions */}
-        <Container overrideDefaults className="flex flex-wrap items-center gap-3">
+        <Container overrideDefaults className="flex flex-wrap items-center gap-2">
           {isOwn ? (
             <>
               <DialogAddContent


### PR DESCRIPTION
## Summary

- Reduce the collection page owner avatar to 24px
- Set the avatar-to-owner-name spacing to 12px
- Set the action-button spacing to 8px
- Update the focused component assertion and snapshots

## Validation

- 33 CollectionHero tests passed
- ESLint passed
- `git diff --check` passed

## Visual of applied changes
<img width="1223" height="384" alt="image" src="https://github.com/user-attachments/assets/5337c856-0129-440d-94cf-419d7fc50d51" />
