### PR TITLE
fix(ui): use brand color for saved to collection indicator for posts

### DIFF
--- a/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx
@@ -159,6 +159,7 @@ describe('PostSavePicker', () => {
     const { container } = renderPicker();
 
     expect(getTriggerIcon(container)).toHaveAttribute('data-state', 'saved');
+    expect(container.querySelector('.lucide-square-library')).toHaveClass('text-brand');
   });
 
   it('keeps the collection icon while the desktop save menu is open', async () => {

--- a/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`PostSavePicker > matches desktop picker snapshot when open 1`] = `
         </svg>
         <svg
           aria-hidden="true"
-          class="lucide lucide-square-library absolute inset-0 transition-[opacity,transform] duration-150 ease-out scale-100 opacity-100"
+          class="lucide lucide-square-library absolute inset-0 transition-[opacity,transform] duration-150 ease-out scale-100 opacity-100 text-brand"
           fill="none"
           height="24"
           stroke="currentColor"

--- a/src/components/organisms/PostSavePicker/PostSavePicker.tsx
+++ b/src/components/organisms/PostSavePicker/PostSavePicker.tsx
@@ -82,7 +82,7 @@ function SaveTriggerIcon({ state }: { state: SaveTriggerIconState }) {
       className="relative size-4"
     >
       <Library aria-hidden="true" className={iconClassName('default')} />
-      <SquareLibrary aria-hidden="true" className={iconClassName('saved')} />
+      <SquareLibrary aria-hidden="true" className={cn(iconClassName('saved'), 'text-brand')} />
     </Typography>
   );
 }


### PR DESCRIPTION
## Summary

- use the brand color for the saved to collection indicator for posts
- preserve the existing default icon color
- add a focused assertion and update the component snapshot

## Testing

- 18 PostSavePicker tests passed
- ESLint passed
- Prettier passed
- git diff --check passed

## Visual

<img width="824" height="537" alt="image" src="https://github.com/user-attachments/assets/dcc1433b-72ed-433f-8fc0-bc813e4a2c86" />
