### PR TITLE
[DESIGN EXPERIMENT] Visual Reach Selector

### DIFF
--- a/cypress/e2e/feed.cy.ts
+++ b/cypress/e2e/feed.cy.ts
@@ -297,7 +297,8 @@ describe('feed and filters', () => {
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile1.username));
     cy.get('[data-cy="filter-reach-radiogroup"]').find('[aria-label="Following"]').click();
     waitForFeedToLoad();
-    cy.get('[data-cy="filter-sort-radiogroup"]').find('[aria-label="Popularity"]').click();
+    cy.get('[data-cy="filter-sort-radiogroup"]').click();
+    cy.get('[role="option"][aria-label="Popularity"]').click();
     waitForFeedToLoad();
 
     // * check the posts are in the correct order

--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -392,6 +392,7 @@ describe('posts', () => {
     cy.location('pathname').should('contain', '/post/');
 
     // switch to wide layout
+    cy.get('[data-cy="filter-layout-dropdown"]').filter(':visible').click();
     cy.get('[data-cy="wide-layout-toggle"]').filter(':visible').click();
 
     // add three tags to post

--- a/cypress/support/collections.ts
+++ b/cypress/support/collections.ts
@@ -182,7 +182,8 @@ export const deleteCollectionFromHero = () => {
 
 // apply a content filter (e.g. 'All', 'Collections') from the home feed sidebar
 export const applyContentFilter = (label: string) => {
-  cy.get('[data-testid="filter-content-radiogroup"]').find(`[aria-label="${label}"]`).click();
+  cy.get('[data-testid="filter-content-dropdown"]').click();
+  cy.get(`[role="option"][aria-label="${label}"]`).click();
   waitForFeedToLoad();
 };
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1158,10 +1158,30 @@
   },
   "filters": {
     "reach": {
-      "title": "النطاق",
+      "title": "منشورات من",
       "all": "الكل",
+      "network": "الشبكة",
+      "myNetwork": "شبكتي",
       "following": "المتابَعون",
-      "friends": "الاصدقاء"
+      "friends": "الاصدقاء",
+      "me": "انا",
+      "profileTag": "وسم الملف الشخصي",
+      "profileTagLimitReached": "{max} وسوم كحد أقصى",
+      "taggedBy": "بواسطة {reach}",
+      "taggedByLabel": "اختر من قام بوسم هذه الملفات الشخصية",
+      "profileTagSummary": {
+        "reach": {
+          "all": "منشورات من أي شخص وسمه {curator} كـ {tags}",
+          "friends": "منشورات من الأصدقاء الذين وسمهم {curator} كـ {tags}",
+          "following": "منشورات من الأشخاص الذين أتابعهم ووسمهم {curator} كـ {tags}",
+          "network": "منشورات من أشخاص في شبكتي وسمهم {curator} كـ {tags}"
+        },
+        "curator": {
+          "me": "أنا",
+          "following": "الأشخاص الذين أتابعهم",
+          "network": "شبكتي"
+        }
+      }
     },
     "sort": {
       "title": "الترتيب",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1164,10 +1164,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Reichweite",
+      "title": "Beiträge von",
       "all": "Alle",
+      "network": "Netzwerk",
+      "myNetwork": "Mein Netzwerk",
       "following": "Folge ich",
-      "friends": "Freunde"
+      "friends": "Freunde",
+      "me": "Ich",
+      "profileTag": "Profil-Tag",
+      "profileTagLimitReached": "max. {max} Tags",
+      "taggedBy": "von {reach}",
+      "taggedByLabel": "Auswählen, wer diese Profile markiert hat",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Beiträge von allen, die von {curator} als {tags} markiert wurden",
+          "friends": "Beiträge von Freunden, die von {curator} als {tags} markiert wurden",
+          "following": "Beiträge von Personen, denen ich folge und die von {curator} als {tags} markiert wurden",
+          "network": "Beiträge von Personen in meinem Netzwerk, die von {curator} als {tags} markiert wurden"
+        },
+        "curator": {
+          "me": "mir",
+          "following": "Personen, denen ich folge",
+          "network": "meinem Netzwerk"
+        }
+      }
     },
     "sort": {
       "title": "Sortieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1162,10 +1162,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Reach",
+      "title": "Posts from",
       "all": "All",
+      "network": "Network",
+      "myNetwork": "My Network",
       "following": "Following",
-      "friends": "Friends"
+      "friends": "Friends",
+      "me": "Me",
+      "profileTag": "profile tag",
+      "profileTagLimitReached": "{max} tags max",
+      "taggedBy": "by {reach}",
+      "taggedByLabel": "Choose who tagged these profiles",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Posts from anyone tagged as {tags} by {curator}",
+          "friends": "Posts from friends tagged as {tags} by {curator}",
+          "following": "Posts from people I follow tagged as {tags} by {curator}",
+          "network": "Posts from people in my network tagged as {tags} by {curator}"
+        },
+        "curator": {
+          "me": "me",
+          "following": "people I follow",
+          "network": "my network"
+        }
+      }
     },
     "sort": {
       "title": "Sort",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1164,10 +1164,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Alcance",
+      "title": "Publicaciones de",
       "all": "Todos",
+      "network": "Red",
+      "myNetwork": "Mi red",
       "following": "Siguiendo",
-      "friends": "Amigos"
+      "friends": "Amigos",
+      "me": "Yo",
+      "profileTag": "etiqueta de perfil",
+      "profileTagLimitReached": "máximo {max} etiquetas",
+      "taggedBy": "por {reach}",
+      "taggedByLabel": "Elige quién etiquetó estos perfiles",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Publicaciones de cualquiera etiquetado como {tags} por {curator}",
+          "friends": "Publicaciones de amigos etiquetados como {tags} por {curator}",
+          "following": "Publicaciones de personas que sigo etiquetadas como {tags} por {curator}",
+          "network": "Publicaciones de personas de mi red etiquetadas como {tags} por {curator}"
+        },
+        "curator": {
+          "me": "mí",
+          "following": "personas que sigo",
+          "network": "mi red"
+        }
+      }
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1162,10 +1162,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Portee",
+      "title": "Publications de",
       "all": "Tous",
+      "network": "Réseau",
+      "myNetwork": "Mon réseau",
       "following": "Abonnements",
-      "friends": "Amis"
+      "friends": "Amis",
+      "me": "Moi",
+      "profileTag": "tag de profil",
+      "profileTagLimitReached": "{max} tags maximum",
+      "taggedBy": "par {reach}",
+      "taggedByLabel": "Choisissez qui a tagué ces profils",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Publications de toute personne taguée comme {tags} par {curator}",
+          "friends": "Publications d’amis tagués comme {tags} par {curator}",
+          "following": "Publications de personnes que je suis taguées comme {tags} par {curator}",
+          "network": "Publications de personnes de mon réseau taguées comme {tags} par {curator}"
+        },
+        "curator": {
+          "me": "moi",
+          "following": "les personnes que je suis",
+          "network": "mon réseau"
+        }
+      }
     },
     "sort": {
       "title": "Trier",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1162,10 +1162,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Portata",
+      "title": "Post di",
       "all": "Tutti",
+      "network": "Rete",
+      "myNetwork": "La mia rete",
       "following": "Seguiti",
-      "friends": "Amici"
+      "friends": "Amici",
+      "me": "Io",
+      "profileTag": "tag profilo",
+      "profileTagLimitReached": "massimo {max} tag",
+      "taggedBy": "da {reach}",
+      "taggedByLabel": "Scegli chi ha taggato questi profili",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Post di chiunque sia stato taggato come {tags} da {curator}",
+          "friends": "Post di amici taggati come {tags} da {curator}",
+          "following": "Post di persone che seguo taggate come {tags} da {curator}",
+          "network": "Post di persone nella mia rete taggate come {tags} da {curator}"
+        },
+        "curator": {
+          "me": "me",
+          "following": "persone che seguo",
+          "network": "la mia rete"
+        }
+      }
     },
     "sort": {
       "title": "Ordina",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1162,10 +1162,30 @@
   },
   "filters": {
     "reach": {
-      "title": "範囲",
+      "title": "投稿元",
       "all": "すべて",
+      "network": "ネットワーク",
+      "myNetwork": "自分のネットワーク",
       "following": "フォロー中",
-      "friends": "友達"
+      "friends": "友達",
+      "me": "自分",
+      "profileTag": "プロフィールタグ",
+      "profileTagLimitReached": "最大{max}個のタグ",
+      "taggedBy": "{reach}による",
+      "taggedByLabel": "これらのプロフィールをタグ付けした範囲を選択",
+      "profileTagSummary": {
+        "reach": {
+          "all": "{curator}が {tags} とタグ付けした人の投稿",
+          "friends": "{curator}が {tags} とタグ付けした友達の投稿",
+          "following": "{curator}が {tags} とタグ付けしたフォロー中の人の投稿",
+          "network": "{curator}が {tags} とタグ付けした自分のネットワーク内の人の投稿"
+        },
+        "curator": {
+          "me": "私",
+          "following": "フォロー中の人",
+          "network": "自分のネットワーク"
+        }
+      }
     },
     "sort": {
       "title": "並べ替え",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1162,10 +1162,30 @@
   },
   "filters": {
     "reach": {
-      "title": "Alcance",
+      "title": "Posts de",
       "all": "Todos",
+      "network": "Rede",
+      "myNetwork": "Minha rede",
       "following": "Seguindo",
-      "friends": "Amigos"
+      "friends": "Amigos",
+      "me": "Eu",
+      "profileTag": "tag de perfil",
+      "profileTagLimitReached": "máximo de {max} tags",
+      "taggedBy": "por {reach}",
+      "taggedByLabel": "Escolha quem marcou estes perfis",
+      "profileTagSummary": {
+        "reach": {
+          "all": "Posts de qualquer pessoa marcada como {tags} por {curator}",
+          "friends": "Posts de amigos marcados como {tags} por {curator}",
+          "following": "Posts de pessoas que sigo marcadas como {tags} por {curator}",
+          "network": "Posts de pessoas da minha rede marcadas como {tags} por {curator}"
+        },
+        "curator": {
+          "me": "mim",
+          "following": "pessoas que sigo",
+          "network": "minha rede"
+        }
+      }
     },
     "sort": {
       "title": "Ordenar",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1156,10 +1156,30 @@
   },
   "filters": {
     "reach": {
-      "title": "范围",
+      "title": "帖子来源",
       "all": "全部",
+      "network": "网络",
+      "myNetwork": "我的网络",
       "following": "关注",
-      "friends": "好友"
+      "friends": "好友",
+      "me": "我",
+      "profileTag": "个人资料标签",
+      "profileTagLimitReached": "最多 {max} 个标签",
+      "taggedBy": "由{reach}标记",
+      "taggedByLabel": "选择谁标记了这些个人资料",
+      "profileTagSummary": {
+        "reach": {
+          "all": "{curator}标记为 {tags} 的任何人的帖子",
+          "friends": "{curator}标记为 {tags} 的好友帖子",
+          "following": "{curator}标记为 {tags} 的我关注的人的帖子",
+          "network": "{curator}标记为 {tags} 的我网络中的人的帖子"
+        },
+        "curator": {
+          "me": "我",
+          "following": "我关注的人",
+          "network": "我的网络"
+        }
+      }
     },
     "sort": {
       "title": "排序",

--- a/src/components/molecules/Filters/FilterContent/FilterContent.test.tsx
+++ b/src/components/molecules/Filters/FilterContent/FilterContent.test.tsx
@@ -1,31 +1,45 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { VISUAL_DISABLED_CONTENT } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedVisual.helpers';
-import { CONTENT, type ContentType } from '@/stores/home/home.types';
+import { CONTENT } from '@/stores/home/home.types';
 import { FilterContent } from './FilterContent';
 
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+});
+
+async function selectContentOption(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox', { name: 'Content' }));
+  await user.click(screen.getByRole('option', { name: label }));
+}
+
 describe('FilterContent', () => {
-  it('renders with default selected tab', () => {
+  it('renders the current option in a dropdown trigger', () => {
     render(<FilterContent />);
 
     expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Content' })).toHaveTextContent('All');
   });
 
-  it('calls onTabChange when tab is clicked', () => {
+  it('calls onTabChange when an option is selected', async () => {
     const onTabChange = vi.fn();
     render(<FilterContent onTabChange={onTabChange} />);
 
-    fireEvent.click(screen.getByText('Images'));
-    expect(onTabChange).toHaveBeenCalledWith('images');
+    await selectContentOption('Images');
+
+    expect(onTabChange).toHaveBeenCalledWith(CONTENT.IMAGES);
   });
 
-  it('handles all tab types correctly', () => {
+  it('supports all content options', async () => {
     const onTabChange = vi.fn();
     render(<FilterContent onTabChange={onTabChange} />);
 
-    // Map of tab values to their display labels
-    const tabsToTest: Array<{ value: ContentType; label: string }> = [
-      { value: CONTENT.ALL, label: 'All' },
+    const options = [
       { value: CONTENT.SHORT, label: 'Posts' },
       { value: CONTENT.LONG, label: 'Articles' },
       { value: CONTENT.COLLECTIONS, label: 'Collections' },
@@ -33,78 +47,78 @@ describe('FilterContent', () => {
       { value: CONTENT.VIDEOS, label: 'Videos' },
       { value: CONTENT.LINKS, label: 'Links' },
       { value: CONTENT.FILES, label: 'Files' },
+      { value: CONTENT.ALL, label: 'All' },
     ];
 
-    tabsToTest.forEach(({ value, label }) => {
-      fireEvent.click(screen.getByText(label));
-      expect(onTabChange).toHaveBeenCalledWith(value);
+    for (const { label } of options) {
+      await selectContentOption(label);
+    }
+
+    options.forEach(({ value }, index) => {
+      expect(onTabChange).toHaveBeenNthCalledWith(index + 1, value);
     });
+  }, 10_000);
+
+  it('updates the trigger when the controlled selection changes', () => {
+    const { rerender } = render(<FilterContent selectedTab={CONTENT.ALL} />);
+
+    expect(screen.getByRole('combobox', { name: 'Content' })).toHaveTextContent('All');
+
+    rerender(<FilterContent selectedTab={CONTENT.LONG} />);
+
+    expect(screen.getByRole('combobox', { name: 'Content' })).toHaveTextContent('Articles');
   });
 
-  it('handles tab switching correctly', () => {
-    const onTabChange = vi.fn();
-    render(<FilterContent selectedTab={CONTENT.ALL} onTabChange={onTabChange} />);
-
-    // Click on articles tab
-    fireEvent.click(screen.getByText('Articles'));
-    expect(onTabChange).toHaveBeenCalledWith(CONTENT.LONG); // 'long' is the value
-    expect(onTabChange).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles multiple tab clicks', () => {
+  it('handles multiple option selections', async () => {
     const onTabChange = vi.fn();
     render(<FilterContent onTabChange={onTabChange} />);
 
-    fireEvent.click(screen.getByText('Images'));
-    fireEvent.click(screen.getByText('Videos'));
-    fireEvent.click(screen.getByText('Files'));
+    await selectContentOption('Images');
+    await selectContentOption('Videos');
+    await selectContentOption('Files');
 
-    expect(onTabChange).toHaveBeenCalledTimes(3);
-    expect(onTabChange).toHaveBeenNthCalledWith(1, 'images');
-    expect(onTabChange).toHaveBeenNthCalledWith(2, 'videos');
-    expect(onTabChange).toHaveBeenNthCalledWith(3, 'files');
+    expect(onTabChange).toHaveBeenNthCalledWith(1, CONTENT.IMAGES);
+    expect(onTabChange).toHaveBeenNthCalledWith(2, CONTENT.VIDEOS);
+    expect(onTabChange).toHaveBeenNthCalledWith(3, CONTENT.FILES);
   });
 
-  it('renders all items as disabled when disabled prop is true', () => {
-    render(<FilterContent disabled />);
-
-    const labels = ['All', 'Posts', 'Articles', 'Collections', 'Images', 'Videos', 'Links', 'Files'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  it('does not call onTabChange when disabled', () => {
+  it('disables the dropdown when the filter is disabled', async () => {
     const onTabChange = vi.fn();
+    const user = userEvent.setup();
     render(<FilterContent disabled onTabChange={onTabChange} />);
 
-    fireEvent.click(screen.getByText('Images'));
-    fireEvent.click(screen.getByText('Videos'));
-    fireEvent.click(screen.getByText('Files'));
+    const trigger = screen.getByRole('combobox', { name: 'Content' });
+    expect(trigger).toBeDisabled();
 
+    await user.click(trigger);
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
     expect(onTabChange).not.toHaveBeenCalled();
   });
 
-  it('items are not disabled by default', () => {
+  it('renders enabled options by default', async () => {
+    const user = userEvent.setup();
     render(<FilterContent />);
 
-    const labels = ['All', 'Posts', 'Articles', 'Collections', 'Images', 'Videos', 'Links', 'Files'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).not.toHaveAttribute('aria-disabled', 'true');
-    });
+    await user.click(screen.getByRole('combobox', { name: 'Content' }));
+
+    for (const label of ['All', 'Posts', 'Articles', 'Collections', 'Images', 'Videos', 'Links', 'Files']) {
+      expect(screen.getByRole('option', { name: label })).not.toHaveAttribute('aria-disabled', 'true');
+    }
   });
 
-  it('disables only the requested tabs', () => {
+  it('disables only the requested options', async () => {
+    const user = userEvent.setup();
     render(<FilterContent disabledTabs={VISUAL_DISABLED_CONTENT} />);
 
-    expect(screen.getByLabelText('Posts')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Articles')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Collections')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Links')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Files')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('All')).not.toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Images')).not.toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getByLabelText('Videos')).not.toHaveAttribute('aria-disabled', 'true');
+    await user.click(screen.getByRole('combobox', { name: 'Content' }));
+
+    for (const label of ['Posts', 'Articles', 'Collections', 'Links', 'Files']) {
+      expect(screen.getByRole('option', { name: label })).toHaveAttribute('aria-disabled', 'true');
+    }
+    for (const label of ['All', 'Images', 'Videos']) {
+      expect(screen.getByRole('option', { name: label })).not.toHaveAttribute('aria-disabled', 'true');
+    }
   });
 });
 

--- a/src/components/molecules/Filters/FilterContent/FilterContent.test.tsx.snap
+++ b/src/components/molecules/Filters/FilterContent/FilterContent.test.tsx.snap
@@ -19,357 +19,78 @@ exports[`FilterContent - Snapshots > matches snapshot with All content selected 
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-layers size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+            />
+            <path
+              d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+            />
+            <path
+              d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+            />
+          </svg>
+        </span>
+        <span>
           All
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -392,357 +113,85 @@ exports[`FilterContent - Snapshots > matches snapshot with Articles content sele
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-newspaper size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 18h-5"
+            />
+            <path
+              d="M18 14h-8"
+            />
+            <path
+              d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+            />
+            <rect
+              height="4"
+              rx="1"
+              width="8"
+              x="10"
+              y="6"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Articles"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Articles
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -765,357 +214,81 @@ exports[`FilterContent - Snapshots > matches snapshot with Collections content s
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-library size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m16 6 4 14"
+            />
+            <path
+              d="M12 6v14"
+            />
+            <path
+              d="M8 8v12"
+            />
+            <path
+              d="M4 4v16"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Collections"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Collections
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -1138,357 +311,78 @@ exports[`FilterContent - Snapshots > matches snapshot with Files content selecte
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-download size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 15V3"
+            />
+            <path
+              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+            />
+            <path
+              d="m7 10 5 5 5-5"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Files"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Files
         </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -1511,357 +405,85 @@ exports[`FilterContent - Snapshots > matches snapshot with Images content select
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-image size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              ry="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <circle
+              cx="9"
+              cy="9"
+              r="2"
+            />
+            <path
+              d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Images"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Images
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -1884,357 +506,75 @@ exports[`FilterContent - Snapshots > matches snapshot with Links content selecte
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-link size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+            />
+            <path
+              d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Links"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Links
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -2257,357 +597,75 @@ exports[`FilterContent - Snapshots > matches snapshot with Posts content selecte
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-sticky-note size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+            />
+            <path
+              d="M15 3v5a1 1 0 0 0 1 1h5"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Posts"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Posts
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -2630,357 +688,77 @@ exports[`FilterContent - Snapshots > matches snapshot with Videos content select
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          All
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-play size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Videos"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Videos
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -3003,357 +781,78 @@ exports[`FilterContent - Snapshots > matches snapshot with default props 1`] = `
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-layers size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+            />
+            <path
+              d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+            />
+            <path
+              d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+            />
+          </svg>
+        </span>
+        <span>
           All
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -3376,364 +875,79 @@ exports[`FilterContent - Snapshots > matches snapshot with disabled state 1`] = 
       Content
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-content-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-content-dropdown"
+    data-disabled=""
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-content-dropdown"
+    dir="ltr"
+    disabled=""
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-disabled="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-layers h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-          />
-          <path
-            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-          />
-          <path
-            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-layers size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+            />
+            <path
+              d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+            />
+            <path
+              d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+            />
+          </svg>
+        </span>
+        <span>
           All
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Posts"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sticky-note h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
-          />
-          <path
-            d="M15 3v5a1 1 0 0 0 1 1h5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Posts
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Articles"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-newspaper h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15 18h-5"
-          />
-          <path
-            d="M18 14h-8"
-          />
-          <path
-            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
-          />
-          <rect
-            height="4"
-            rx="1"
-            width="8"
-            x="10"
-            y="6"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Articles
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Collections"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-library h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="m16 6 4 14"
-          />
-          <path
-            d="M12 6v14"
-          />
-          <path
-            d="M8 8v12"
-          />
-          <path
-            d="M4 4v16"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Collections
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Images"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-image h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            ry="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <circle
-            cx="9"
-            cy="9"
-            r="2"
-          />
-          <path
-            d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Images
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Videos"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-circle-play h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Videos
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Links"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-link h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          />
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Links
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Files"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-download h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 15V3"
-          />
-          <path
-            d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
-          />
-          <path
-            d="m7 10 5 5 5-5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Files
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;

--- a/src/components/molecules/Filters/FilterContent/FilterContent.tsx
+++ b/src/components/molecules/Filters/FilterContent/FilterContent.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import * as React from 'react';
 import { CirclePlay, Download, Image, Layers, Library, Link, Newspaper, StickyNote } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { CONTENT, type ContentType } from '@/stores/home/home.types';
-import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
+import { FilterDropdown } from '../FilterDropdown/FilterDropdown';
 import { BaseFilterProps } from '../Filters.types';
 
 interface FilterContentProps extends BaseFilterProps<ContentType> {
@@ -18,73 +17,68 @@ export function FilterContent({
   disabledTabs = [],
 }: FilterContentProps) {
   const t = useTranslations('filters.content');
-  const disabledSet = React.useMemo(() => new Set(disabledTabs), [disabledTabs]);
-  const isDisabled = React.useCallback(
-    (contentType: ContentType) => {
-      return disabled || disabledSet.has(contentType) ? true : undefined;
+  const disabledSet = new Set(disabledTabs);
+  const isDisabled = (contentType: ContentType) => disabled || disabledSet.has(contentType) || undefined;
+  const items = [
+    {
+      key: CONTENT.ALL,
+      label: t('all'),
+      icon: Layers,
+      disabled: isDisabled(CONTENT.ALL),
     },
-    [disabled, disabledSet],
-  );
-  const items = React.useMemo(
-    () => [
-      {
-        key: CONTENT.ALL,
-        label: t('all'),
-        icon: Layers,
-        disabled: isDisabled(CONTENT.ALL),
-      },
-      {
-        key: CONTENT.SHORT,
-        label: t('posts'),
-        icon: StickyNote,
-        disabled: isDisabled(CONTENT.SHORT),
-      },
-      {
-        key: CONTENT.LONG,
-        label: t('articles'),
-        icon: Newspaper,
-        disabled: isDisabled(CONTENT.LONG),
-      },
-      {
-        key: CONTENT.COLLECTIONS,
-        label: t('collections'),
-        icon: Library,
-        disabled: isDisabled(CONTENT.COLLECTIONS),
-      },
-      {
-        key: CONTENT.IMAGES,
-        label: t('images'),
-        icon: Image,
-        disabled: isDisabled(CONTENT.IMAGES),
-      },
-      {
-        key: CONTENT.VIDEOS,
-        label: t('videos'),
-        icon: CirclePlay,
-        disabled: isDisabled(CONTENT.VIDEOS),
-      },
-      {
-        key: CONTENT.LINKS,
-        label: t('links'),
-        icon: Link,
-        disabled: isDisabled(CONTENT.LINKS),
-      },
-      {
-        key: CONTENT.FILES,
-        label: t('files'),
-        icon: Download,
-        disabled: isDisabled(CONTENT.FILES),
-      },
-    ],
-    [t, isDisabled],
-  );
+    {
+      key: CONTENT.SHORT,
+      label: t('posts'),
+      icon: StickyNote,
+      disabled: isDisabled(CONTENT.SHORT),
+    },
+    {
+      key: CONTENT.LONG,
+      label: t('articles'),
+      icon: Newspaper,
+      disabled: isDisabled(CONTENT.LONG),
+    },
+    {
+      key: CONTENT.COLLECTIONS,
+      label: t('collections'),
+      icon: Library,
+      disabled: isDisabled(CONTENT.COLLECTIONS),
+    },
+    {
+      key: CONTENT.IMAGES,
+      label: t('images'),
+      icon: Image,
+      disabled: isDisabled(CONTENT.IMAGES),
+    },
+    {
+      key: CONTENT.VIDEOS,
+      label: t('videos'),
+      icon: CirclePlay,
+      disabled: isDisabled(CONTENT.VIDEOS),
+    },
+    {
+      key: CONTENT.LINKS,
+      label: t('links'),
+      icon: Link,
+      disabled: isDisabled(CONTENT.LINKS),
+    },
+    {
+      key: CONTENT.FILES,
+      label: t('files'),
+      icon: Download,
+      disabled: isDisabled(CONTENT.FILES),
+    },
+  ];
+
   return (
-    <FilterRadioGroup
+    <FilterDropdown
       title={t('title')}
       items={items}
       selectedValue={selectedTab}
       defaultValue={defaultSelectedTab}
       onChange={onTabChange}
+      dataCy="filter-content-dropdown"
+      testId="filter-content-dropdown"
     />
   );
 }

--- a/src/components/molecules/Filters/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/molecules/Filters/FilterDropdown/FilterDropdown.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import * as React from 'react';
+import { FilterHeader, FilterRoot } from '@/atoms/Filter/Filter';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/atoms/Select/Select';
+import { useControlledState } from '@/hooks/useControlledState/useControlledState';
+import type { FilterListItem } from '../Filters.types';
+
+interface FilterDropdownProps<T extends string> {
+  title?: string;
+  ariaLabel?: string;
+  items: FilterListItem<T>[];
+  selectedValue?: T;
+  defaultValue?: T;
+  onChange?: (value: T) => void;
+  dataCy?: string;
+  testId?: string;
+}
+
+export function FilterDropdown<T extends string>({
+  title,
+  ariaLabel,
+  items,
+  selectedValue: controlledValue,
+  defaultValue,
+  onChange,
+  dataCy,
+  testId,
+}: FilterDropdownProps<T>) {
+  const headerId = React.useId();
+  const { value: selectedValue, setValue: setSelectedValue } = useControlledState({
+    value: controlledValue,
+    defaultValue: defaultValue ?? items[0]?.key,
+    onChange,
+  });
+  const selectedItem = items.find((item) => item.key === selectedValue) ?? items[0];
+  const isDisabled = items.every((item) => item.disabled);
+
+  if (!selectedItem) {
+    return null;
+  }
+
+  const SelectedIcon = selectedItem.icon;
+
+  return (
+    <FilterRoot>
+      {title && <FilterHeader title={title} id={headerId} />}
+
+      <Select value={selectedValue} onValueChange={(value) => setSelectedValue(value as T)} disabled={isDisabled}>
+        <SelectTrigger
+          aria-label={title ? undefined : ariaLabel}
+          aria-labelledby={title ? headerId : undefined}
+          data-cy={dataCy}
+          data-testid={testId}
+          className="h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300 data-[state=open]:[&>svg:last-child]:rotate-180"
+        >
+          <SelectValue>
+            <span className="flex items-center gap-2">
+              <span className="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full">
+                <SelectedIcon className="size-5" />
+              </span>
+              <span>{selectedItem.label}</span>
+            </span>
+          </SelectValue>
+        </SelectTrigger>
+
+        <SelectContent position="item-aligned" className="min-w-48">
+          {items.map(({ key, label, icon: Icon, disabled, dataCy: itemDataCy }) => (
+            <SelectItem
+              key={key}
+              value={key}
+              disabled={disabled}
+              aria-label={label}
+              data-cy={itemDataCy}
+              className="py-2 transition-colors hover:text-secondary-foreground hover:**:text-secondary-foreground data-[highlighted]:text-secondary-foreground data-[highlighted]:**:text-secondary-foreground data-[state=checked]:font-bold"
+            >
+              <span className="flex items-center gap-2">
+                <span className="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full">
+                  <Icon className="size-5" />
+                </span>
+                <span>{label}</span>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </FilterRoot>
+  );
+}

--- a/src/components/molecules/Filters/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/molecules/Filters/FilterDropdown/FilterDropdown.tsx
@@ -72,7 +72,7 @@ export function FilterDropdown<T extends string>({
               disabled={disabled}
               aria-label={label}
               data-cy={itemDataCy}
-              className="py-2 transition-colors hover:text-secondary-foreground hover:**:text-secondary-foreground data-[highlighted]:text-secondary-foreground data-[highlighted]:**:text-secondary-foreground data-[state=checked]:font-bold"
+              className="py-2 font-medium transition-colors hover:text-secondary-foreground hover:**:text-secondary-foreground data-[highlighted]:text-secondary-foreground data-[highlighted]:**:text-secondary-foreground data-[state=checked]:font-bold"
             >
               <span className="flex items-center gap-2">
                 <span className="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full">

--- a/src/components/molecules/Filters/FilterLayout/FilterLayout.test.tsx
+++ b/src/components/molecules/Filters/FilterLayout/FilterLayout.test.tsx
@@ -1,88 +1,106 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { LAYOUT, type LayoutType } from '@/stores/home/home.types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { LAYOUT } from '@/stores/home/home.types';
 import { FilterLayout } from './FilterLayout';
 
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+});
+
+async function selectLayoutOption(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox', { name: 'Layout' }));
+  await user.click(screen.getByRole('option', { name: label }));
+}
+
 describe('FilterLayout', () => {
-  it('renders with default selected tab', () => {
+  it('renders the current option in a dropdown trigger', () => {
     render(<FilterLayout />);
 
     expect(screen.getByText('Layout')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Layout' })).toHaveTextContent('Columns');
   });
 
-  it('calls onTabChange when tab is clicked', () => {
-    const onTabChange = vi.fn();
-    render(<FilterLayout onTabChange={onTabChange} />);
-    fireEvent.click(screen.getByText('Wide'));
-    expect(onTabChange).toHaveBeenCalledWith('wide');
-  });
-
-  it('handles all tab types correctly', () => {
+  it('calls onTabChange when an option is selected', async () => {
     const onTabChange = vi.fn();
     render(<FilterLayout onTabChange={onTabChange} />);
 
-    ([LAYOUT.COLUMNS, LAYOUT.WIDE, LAYOUT.LIST] as LayoutType[]).forEach((tab) => {
-      const label = tab === LAYOUT.COLUMNS ? 'Columns' : tab === LAYOUT.WIDE ? 'Wide' : 'List';
-      fireEvent.click(screen.getByText(label));
-      expect(onTabChange).toHaveBeenCalledWith(tab);
-    });
+    await selectLayoutOption('Wide');
+
+    expect(onTabChange).toHaveBeenCalledWith(LAYOUT.WIDE);
   });
 
-  it('rerenders with different selected tabs', () => {
+  it('supports all layout options', async () => {
+    const onTabChange = vi.fn();
+    render(<FilterLayout onTabChange={onTabChange} />);
+
+    await selectLayoutOption('Wide');
+    await selectLayoutOption('List');
+    await selectLayoutOption('Columns');
+
+    expect(onTabChange).toHaveBeenNthCalledWith(1, LAYOUT.WIDE);
+    expect(onTabChange).toHaveBeenNthCalledWith(2, LAYOUT.LIST);
+    expect(onTabChange).toHaveBeenNthCalledWith(3, LAYOUT.COLUMNS);
+  });
+
+  it('updates the trigger when the controlled selection changes', () => {
     const { rerender } = render(<FilterLayout selectedTab={LAYOUT.COLUMNS} />);
 
-    let columnsItem = screen.getByText('Columns').closest('[data-testid="filter-item"]');
-    const wideItem = screen.getByText('Wide').closest('[data-testid="filter-item"]');
-    expect(columnsItem).toBeInTheDocument();
-    expect(wideItem).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Layout' })).toHaveTextContent('Columns');
 
     rerender(<FilterLayout selectedTab={LAYOUT.WIDE} />);
-    columnsItem = screen.getByText('Columns').closest('[data-testid="filter-item"]');
-    const wideItem2 = screen.getByText('Wide').closest('[data-testid="filter-item"]');
-    expect(columnsItem).toBeInTheDocument();
-    expect(wideItem2).toBeInTheDocument();
+
+    expect(screen.getByRole('combobox', { name: 'Layout' })).toHaveTextContent('Wide');
   });
 
-  it('renders all items as disabled when disabled prop is true', () => {
-    render(<FilterLayout disabled />);
-
-    const labels = ['Columns', 'Wide', 'List'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  it('does not call onTabChange when disabled', () => {
+  it('disables the dropdown when the filter is disabled', async () => {
     const onTabChange = vi.fn();
+    const user = userEvent.setup();
     render(<FilterLayout disabled onTabChange={onTabChange} />);
 
-    fireEvent.click(screen.getByText('Columns'));
-    fireEvent.click(screen.getByText('Wide'));
-    fireEvent.click(screen.getByText('List'));
+    const trigger = screen.getByRole('combobox', { name: 'Layout' });
+    expect(trigger).toBeDisabled();
 
+    await user.click(trigger);
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
     expect(onTabChange).not.toHaveBeenCalled();
   });
 
-  it('items are not disabled by default', () => {
+  it('renders enabled options by default', async () => {
+    const user = userEvent.setup();
     render(<FilterLayout />);
 
-    const labels = ['Columns', 'Wide', 'List'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).not.toHaveAttribute('aria-disabled', 'true');
-    });
+    await user.click(screen.getByRole('combobox', { name: 'Layout' }));
+
+    for (const label of ['Columns', 'Wide', 'List']) {
+      expect(screen.getByRole('option', { name: label })).not.toHaveAttribute('aria-disabled', 'true');
+    }
   });
 
-  it('renders visual layout when enabled', () => {
+  it('renders visual layout when enabled', async () => {
+    const user = userEvent.setup();
     render(<FilterLayout showVisual />);
 
-    expect(screen.getByText('Visual')).toBeInTheDocument();
+    await user.click(screen.getByRole('combobox', { name: 'Layout' }));
+
+    expect(screen.getByRole('option', { name: 'Visual' })).toBeInTheDocument();
   });
 
-  it('falls back to columns for display when visual is selected but hidden', () => {
+  it('falls back to columns for display when visual is selected but hidden', async () => {
+    const user = userEvent.setup();
     render(<FilterLayout selectedTab={LAYOUT.VISUAL} showVisual={false} />);
 
-    expect(screen.getByLabelText('Columns')).toHaveAttribute('aria-checked', 'true');
-    expect(screen.queryByText('Visual')).not.toBeInTheDocument();
+    const trigger = screen.getByRole('combobox', { name: 'Layout' });
+    expect(trigger).toHaveTextContent('Columns');
+
+    await user.click(trigger);
+
+    expect(screen.queryByRole('option', { name: 'Visual' })).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/molecules/Filters/FilterLayout/FilterLayout.test.tsx.snap
+++ b/src/components/molecules/Filters/FilterLayout/FilterLayout.test.tsx.snap
@@ -19,157 +19,82 @@ exports[`FilterLayout - Snapshots > matches snapshot with Columns selected tab 1
       Layout
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-layout-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-layout-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-layout-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="Columns"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-cy="columns-layout-toggle"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-columns3 lucide-columns-3 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M9 3v18"
-          />
-          <path
-            d="M15 3v18"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-columns3 lucide-columns-3 size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M9 3v18"
+            />
+            <path
+              d="M15 3v18"
+            />
+          </svg>
+        </span>
+        <span>
           Columns
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Wide"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="wide-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows2 lucide-rows-2 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M3 12h18"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Wide
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="List"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="list-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows4 lucide-rows-4 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M21 7.5H3"
-          />
-          <path
-            d="M21 12H3"
-          />
-          <path
-            d="M21 16.5H3"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          List
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -192,157 +117,79 @@ exports[`FilterLayout - Snapshots > matches snapshot with Wide selected tab 1`] 
       Layout
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-layout-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-layout-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-layout-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="Columns"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="columns-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-columns3 lucide-columns-3 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M9 3v18"
-          />
-          <path
-            d="M15 3v18"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          Columns
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-rows2 lucide-rows-2 size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M3 12h18"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Wide"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-cy="wide-layout-toggle"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows2 lucide-rows-2 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M3 12h18"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Wide
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="List"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="list-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows4 lucide-rows-4 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M21 7.5H3"
-          />
-          <path
-            d="M21 12H3"
-          />
-          <path
-            d="M21 16.5H3"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          List
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -365,157 +212,82 @@ exports[`FilterLayout - Snapshots > matches snapshot with default props 1`] = `
       Layout
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-layout-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-layout-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-layout-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="Columns"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-cy="columns-layout-toggle"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-columns3 lucide-columns-3 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M9 3v18"
-          />
-          <path
-            d="M15 3v18"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-columns3 lucide-columns-3 size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M9 3v18"
+            />
+            <path
+              d="M15 3v18"
+            />
+          </svg>
+        </span>
+        <span>
           Columns
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Wide"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="wide-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows2 lucide-rows-2 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M3 12h18"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Wide
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="List"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="list-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows4 lucide-rows-4 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M21 7.5H3"
-          />
-          <path
-            d="M21 12H3"
-          />
-          <path
-            d="M21 16.5H3"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          List
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -538,160 +310,84 @@ exports[`FilterLayout - Snapshots > matches snapshot with disabled state 1`] = `
       Layout
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-layout-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-layout-dropdown"
+    data-disabled=""
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-layout-dropdown"
+    dir="ltr"
+    disabled=""
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-disabled="true"
-        aria-label="Columns"
-        aria-pressed="true"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-cy="columns-layout-toggle"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-columns3 lucide-columns-3 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M9 3v18"
-          />
-          <path
-            d="M15 3v18"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-columns3 lucide-columns-3 size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M9 3v18"
+            />
+            <path
+              d="M15 3v18"
+            />
+          </svg>
+        </span>
+        <span>
           Columns
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Wide"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-cy="wide-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows2 lucide-rows-2 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M3 12h18"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Wide
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="List"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-cy="list-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows4 lucide-rows-4 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M21 7.5H3"
-          />
-          <path
-            d="M21 12H3"
-          />
-          <path
-            d="M21 16.5H3"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          List
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -714,156 +410,81 @@ exports[`FilterLayout - Snapshots > matches snapshot with hidden visual selectio
       Layout
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
-    data-testid="filter-layout-radiogroup"
-    role="radiogroup"
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
+    data-cy="filter-layout-dropdown"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-layout-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="Columns"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-cy="columns-layout-toggle"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-columns3 lucide-columns-3 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M9 3v18"
-          />
-          <path
-            d="M15 3v18"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-columns3 lucide-columns-3 size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M9 3v18"
+            />
+            <path
+              d="M15 3v18"
+            />
+          </svg>
+        </span>
+        <span>
           Columns
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Wide"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="wide-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows2 lucide-rows-2 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M3 12h18"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Wide
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="List"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-cy="list-layout-toggle"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-rows4 lucide-rows-4 h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M21 7.5H3"
-          />
-          <path
-            d="M21 12H3"
-          />
-          <path
-            d="M21 16.5H3"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          List
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;

--- a/src/components/molecules/Filters/FilterLayout/FilterLayout.tsx
+++ b/src/components/molecules/Filters/FilterLayout/FilterLayout.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import * as React from 'react';
 import { Columns3, LayoutGrid, Rows2, Rows4 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { LAYOUT, type LayoutType } from '@/stores/home/home.types';
-import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
+import { FilterDropdown } from '../FilterDropdown/FilterDropdown';
 import { BaseFilterProps, FilterListItem } from '../Filters.types';
 
 interface FilterLayoutProps extends BaseFilterProps<LayoutType> {
@@ -19,49 +18,48 @@ export function FilterLayout({
 }: FilterLayoutProps) {
   const t = useTranslations('filters.layout');
   const displaySelectedTab = !showVisual && selectedTab === LAYOUT.VISUAL ? LAYOUT.COLUMNS : selectedTab;
-  const items = React.useMemo(
-    () =>
-      [
-        {
-          key: LAYOUT.COLUMNS,
-          label: t('columns'),
-          icon: Columns3,
+  const items = [
+    {
+      key: LAYOUT.COLUMNS,
+      label: t('columns'),
+      icon: Columns3,
+      disabled,
+      dataCy: 'columns-layout-toggle',
+    },
+    {
+      key: LAYOUT.WIDE,
+      label: t('wide'),
+      icon: Rows2,
+      disabled,
+      dataCy: 'wide-layout-toggle',
+    },
+    {
+      key: LAYOUT.LIST,
+      label: t('list'),
+      icon: Rows4,
+      disabled,
+      dataCy: 'list-layout-toggle',
+    },
+    showVisual
+      ? {
+          key: LAYOUT.VISUAL,
+          label: t('visual'),
+          icon: LayoutGrid,
           disabled,
-          dataCy: 'columns-layout-toggle',
-        },
-        {
-          key: LAYOUT.WIDE,
-          label: t('wide'),
-          icon: Rows2,
-          disabled,
-          dataCy: 'wide-layout-toggle',
-        },
-        {
-          key: LAYOUT.LIST,
-          label: t('list'),
-          icon: Rows4,
-          disabled,
-          dataCy: 'list-layout-toggle',
-        },
-        showVisual
-          ? {
-              key: LAYOUT.VISUAL,
-              label: t('visual'),
-              icon: LayoutGrid,
-              disabled,
-              dataCy: 'visual-layout-toggle',
-            }
-          : null,
-      ].filter(Boolean) as FilterListItem<LayoutType>[],
-    [t, disabled, showVisual],
-  );
+          dataCy: 'visual-layout-toggle',
+        }
+      : null,
+  ].filter(Boolean) as FilterListItem<LayoutType>[];
+
   return (
-    <FilterRadioGroup
+    <FilterDropdown
       title={t('title')}
       items={items}
       selectedValue={displaySelectedTab}
       defaultValue={defaultSelectedTab}
       onChange={onTabChange}
+      dataCy="filter-layout-dropdown"
+      testId="filter-layout-dropdown"
     />
   );
 }

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { PROFILE_TAG_SCOPE } from '@/stores/home/home.types';
+import { FilterProfileTags } from './FilterProfileTags';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+});
+
+const defaultProps = {
+  selectedTags: [] as string[],
+  onTagAdd: vi.fn(),
+  onTagRemove: vi.fn(),
+  scope: PROFILE_TAG_SCOPE.NETWORK,
+  onScopeChange: vi.fn(),
+};
+
+describe('FilterProfileTags', () => {
+  it('renders the Tagged as controls and current reach scope', () => {
+    const { container } = render(<FilterProfileTags {...defaultProps} />);
+
+    expect(screen.getByRole('heading', { name: 'Tagged as' })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('profile tag')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Choose who tagged these profiles' })).toHaveTextContent(
+      'by my network',
+    );
+    expect(container.querySelector('.lucide-waypoints')).toHaveClass('size-5');
+  });
+
+  it('uses the UsersRound icon and lowercase label for Following', () => {
+    const { container } = render(<FilterProfileTags {...defaultProps} scope={PROFILE_TAG_SCOPE.FOLLOWING} />);
+
+    expect(screen.getByRole('combobox', { name: 'Choose who tagged these profiles' })).toHaveTextContent(
+      'by following',
+    );
+    expect(container.querySelector('.lucide-users-round')).toHaveClass('size-5');
+  });
+
+  it('orders WoT scopes as Network, Following, then Me', async () => {
+    const user = userEvent.setup();
+    render(<FilterProfileTags {...defaultProps} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Choose who tagged these profiles' }));
+
+    expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual([
+      'by my network',
+      'by following',
+      'by me',
+    ]);
+  });
+
+  it('adds a normalized profile tag from the input', async () => {
+    const onTagAdd = vi.fn();
+    render(<FilterProfileTags {...defaultProps} onTagAdd={onTagAdd} />);
+
+    const input = screen.getByPlaceholderText('profile tag');
+    fireEvent.change(input, { target: { value: 'Bitcoin' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(onTagAdd).toHaveBeenCalledWith('bitcoin'));
+  });
+
+  it('renders selected tags in a removable stack', async () => {
+    const onTagRemove = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterProfileTags {...defaultProps} selectedTags={['bitcoin', 'nostr']} onTagRemove={onTagRemove} />);
+
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('nostr')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Remove bitcoin tag'));
+    expect(onTagRemove).toHaveBeenCalledWith('bitcoin');
+  });
+
+  it('changes only the independent WoT scope through the compact dropdown', async () => {
+    const onScopeChange = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterProfileTags {...defaultProps} onScopeChange={onScopeChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Choose who tagged these profiles' }));
+    await user.click(screen.getByRole('option', { name: 'by following' }));
+
+    expect(onScopeChange).toHaveBeenCalledWith(PROFILE_TAG_SCOPE.FOLLOWING);
+  });
+
+  it('offers Me as the Nexus depth-zero scope', async () => {
+    const onScopeChange = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterProfileTags {...defaultProps} onScopeChange={onScopeChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Choose who tagged these profiles' }));
+    await user.click(screen.getByRole('option', { name: 'by me' }));
+
+    expect(onScopeChange).toHaveBeenCalledWith(PROFILE_TAG_SCOPE.ME);
+  });
+
+  it('uses a 100ms collapse transition when hidden', () => {
+    render(<FilterProfileTags {...defaultProps} hidden />);
+
+    expect(screen.getByTestId('filter-profile-tags-collapse')).toHaveClass(
+      'grid-rows-[0fr]',
+      'opacity-0',
+      'pointer-events-none',
+      'duration-100',
+    );
+    expect(screen.getByTestId('filter-profile-tags-collapse')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('keeps the previous chips mounted during the collapse animation', async () => {
+    const { rerender } = render(<FilterProfileTags {...defaultProps} selectedTags={['bitcoin']} />);
+
+    rerender(<FilterProfileTags {...defaultProps} selectedTags={[]} hidden />);
+    expect(screen.getByText('bitcoin')).toBeInTheDocument();
+
+    rerender(<FilterProfileTags {...defaultProps} selectedTags={[]} />);
+    await waitFor(() => expect(screen.queryByText('bitcoin')).not.toBeInTheDocument());
+  });
+
+  it('enforces the five-tag limit', () => {
+    render(<FilterProfileTags {...defaultProps} selectedTags={['one', 'two', 'three', 'four', 'five']} />);
+
+    expect(screen.getByPlaceholderText('5 tags max')).toBeDisabled();
+  });
+
+  it('keeps the section visible while disabling unauthenticated input interaction', async () => {
+    const onInputClick = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterProfileTags {...defaultProps} inputDisabled onInputClick={onInputClick} />);
+
+    expect(screen.getByTestId('filter-profile-tags-collapse')).toHaveClass('grid-rows-[1fr]', 'opacity-100');
+    expect(screen.getByPlaceholderText('profile tag')).toBeDisabled();
+
+    await user.click(screen.getByPlaceholderText('profile tag').parentElement!);
+    expect(onInputClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { UserRound, UsersRound, Waypoints } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Container } from '@/atoms/Container/Container';
+import { FilterHeader, FilterRoot } from '@/atoms/Filter/Filter';
+import { cn } from '@/libs/utils/utils';
+import { FilterDropdown } from '@/molecules/Filters/FilterDropdown/FilterDropdown';
+import { PostTag } from '@/molecules/PostTag/PostTag';
+import { TagInput } from '@/molecules/TagInput/TagInput';
+import { HOME_PROFILE_TAGS_MAX_SELECTED, REACH } from '@/stores/home/home.types';
+import type { FilterProfileTagsProps } from './FilterProfileTags.types';
+
+export function FilterProfileTags({
+  selectedTags,
+  onTagAdd,
+  onTagRemove,
+  scope,
+  onScopeChange,
+  hidden = false,
+  inputDisabled = false,
+  onInputClick,
+  maxTags = HOME_PROFILE_TAGS_MAX_SELECTED,
+}: FilterProfileTagsProps) {
+  const tReach = useTranslations('filters.reach');
+  const tProfile = useTranslations('profile.sidebar');
+  const [displayTags, setDisplayTags] = useState(selectedTags);
+
+  useEffect(() => {
+    if (!hidden) {
+      setDisplayTags(selectedTags);
+    }
+  }, [hidden, selectedTags]);
+
+  const isAtLimit = displayTags.length >= maxTags;
+  const existingTags = displayTags.map((label) => ({ label }));
+  const reachItems = [
+    {
+      key: REACH.NETWORK,
+      label: tReach('taggedBy', { reach: tReach('myNetwork').toLocaleLowerCase() }),
+      icon: Waypoints,
+    },
+    {
+      key: REACH.FOLLOWING,
+      label: tReach('taggedBy', { reach: tReach('following').toLocaleLowerCase() }),
+      icon: UsersRound,
+    },
+    {
+      key: REACH.ME,
+      label: tReach('taggedBy', { reach: tReach('me').toLocaleLowerCase() }),
+      icon: UserRound,
+    },
+  ];
+
+  const handleTagAdd = (tag: string) => {
+    const normalizedTag = tag.trim().toLowerCase();
+    if (normalizedTag && selectedTags.length < maxTags) {
+      onTagAdd(normalizedTag);
+    }
+  };
+
+  return (
+    <Container
+      overrideDefaults
+      aria-hidden={hidden}
+      className={cn(
+        'grid w-full transition-[grid-template-rows,opacity] duration-100 ease-in-out',
+        hidden ? 'pointer-events-none grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100',
+      )}
+      data-testid="filter-profile-tags-collapse"
+    >
+      <Container overrideDefaults className="min-h-0 overflow-hidden">
+        <FilterRoot className="gap-4">
+          <FilterHeader title={tProfile('taggedAs')} />
+
+          <Container overrideDefaults className="flex w-full max-w-52 flex-col gap-2">
+            <TagInput
+              onTagAdd={handleTagAdd}
+              placeholder={tReach('profileTag')}
+              existingTags={existingTags}
+              viewerTags={existingTags}
+              disabled={inputDisabled || isAtLimit}
+              onClick={onInputClick}
+              maxTags={maxTags}
+              currentTagsCount={displayTags.length}
+              limitReachedPlaceholder={tReach('profileTagLimitReached', { max: maxTags })}
+              enableApiSuggestions
+              excludeFromApiSuggestions={displayTags}
+              addOnSuggestionClick
+              className="w-full"
+            />
+
+            {displayTags.map((tag) => (
+              <PostTag
+                key={tag}
+                label={tag}
+                showClose
+                onClose={() => onTagRemove(tag)}
+                className="w-full justify-between"
+              />
+            ))}
+
+            <FilterDropdown
+              ariaLabel={tReach('taggedByLabel')}
+              items={reachItems}
+              selectedValue={scope}
+              onChange={onScopeChange}
+              dataCy="filter-profile-tag-reach-dropdown"
+              testId="filter-profile-tag-reach-dropdown"
+            />
+          </Container>
+        </FilterRoot>
+      </Container>
+    </Container>
+  );
+}

--- a/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.types.ts
+++ b/src/components/molecules/Filters/FilterProfileTags/FilterProfileTags.types.ts
@@ -1,0 +1,13 @@
+import type { ProfileTagScopeType } from '@/stores/home/home.types';
+
+export interface FilterProfileTagsProps {
+  selectedTags: string[];
+  onTagAdd: (tag: string) => void;
+  onTagRemove: (tag: string) => void;
+  scope: ProfileTagScopeType;
+  onScopeChange: (scope: ProfileTagScopeType) => void;
+  hidden?: boolean;
+  inputDisabled?: boolean;
+  onInputClick?: () => void;
+  maxTags?: number;
+}

--- a/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx
@@ -7,13 +7,68 @@ describe('FilterReach', () => {
   it('renders with default selected tab and proper ARIA attributes', () => {
     render(<FilterReach />);
 
-    expect(screen.getByText('Reach')).toBeInTheDocument();
+    expect(screen.getByText('Posts from')).toBeInTheDocument();
 
     // Check radiogroup exists
     const radiogroup = screen.getByTestId('filter-reach-radiogroup');
     expect(radiogroup).toBeInTheDocument();
     expect(radiogroup).toHaveAttribute('role', 'radiogroup');
     expect(radiogroup).toHaveAttribute('aria-labelledby');
+  });
+
+  it('renders the five Figma rings with All selected by default', () => {
+    render(<FilterReach />);
+
+    const radiogroup = screen.getByTestId('filter-reach-radiogroup');
+    expect(radiogroup).toHaveClass('size-[180px]');
+    expect(radiogroup.querySelectorAll('circle')).toHaveLength(5);
+    expect(radiogroup.querySelectorAll('circle.stroke-border')).toHaveLength(4);
+    expect(radiogroup.querySelector('[data-reach-ring="all"]')).toHaveClass('fill-brand/[0.10]', 'stroke-brand');
+    expect(radiogroup.querySelectorAll('circle.fill-transparent')).toHaveLength(4);
+    expect(screen.getByTestId('filter-reach-label')).toHaveTextContent('All');
+    expect(screen.getByTestId('filter-reach-label')).toHaveClass(
+      'text-brand',
+      'drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)]',
+    );
+  });
+
+  it('previews a reach in white on hover and restores the selected state on leave', () => {
+    render(<FilterReach selectedTab={REACH.FRIENDS} />);
+
+    const following = screen.getByLabelText('Following');
+    const radiogroup = screen.getByTestId('filter-reach-radiogroup');
+    const followingRing = radiogroup.querySelector('[data-reach-ring="following"]');
+    const friendsRing = radiogroup.querySelector('[data-reach-ring="friends"]');
+    const label = screen.getByTestId('filter-reach-label');
+
+    fireEvent.mouseEnter(following);
+
+    expect(followingRing).toHaveClass('stroke-foreground');
+    expect(friendsRing).toHaveClass('fill-transparent', 'stroke-brand/[0.32]');
+    expect(label).toHaveTextContent('Following');
+    expect(label).toHaveClass('text-foreground');
+
+    fireEvent.mouseLeave(following);
+
+    expect(followingRing).toHaveClass('stroke-border');
+    expect(friendsRing).toHaveClass('fill-brand/[0.10]', 'stroke-brand');
+    expect(label).toHaveTextContent('Friends');
+    expect(label).toHaveClass('text-brand');
+  });
+
+  it('keeps the selected state green when it is hovered', () => {
+    render(<FilterReach selectedTab={REACH.FRIENDS} />);
+
+    const friends = screen.getByLabelText('Friends');
+    const radiogroup = screen.getByTestId('filter-reach-radiogroup');
+    const friendsRing = radiogroup.querySelector('[data-reach-ring="friends"]');
+    const label = screen.getByTestId('filter-reach-label');
+
+    fireEvent.mouseEnter(friends);
+
+    expect(friendsRing).toHaveClass('fill-brand/[0.10]', 'stroke-brand');
+    expect(label).toHaveTextContent('Friends');
+    expect(label).toHaveClass('text-brand');
   });
 
   it('calls onTabChange when tab is clicked', () => {
@@ -31,9 +86,11 @@ describe('FilterReach', () => {
     render(<FilterReach onTabChange={mockOnTabChange} />);
 
     const tabs = [
-      { value: REACH.ALL, label: 'All' },
-      { value: REACH.FOLLOWING, label: 'Following' },
+      { value: REACH.ME, label: 'Me' },
       { value: REACH.FRIENDS, label: 'Friends' },
+      { value: REACH.FOLLOWING, label: 'Following' },
+      { value: REACH.NETWORK, label: 'My Network' },
+      { value: REACH.ALL, label: 'All' },
     ];
 
     tabs.forEach(({ value, label }) => {
@@ -43,27 +100,63 @@ describe('FilterReach', () => {
     });
   });
 
+  it.each([
+    { label: 'Me', value: REACH.ME },
+    { label: 'My Network', value: REACH.NETWORK },
+  ])('selects $label and reports the reach change', ({ label, value }) => {
+    const mockOnTabChange = vi.fn();
+    render(<FilterReach onTabChange={mockOnTabChange} />);
+
+    fireEvent.click(screen.getByLabelText(label));
+
+    const radiogroup = screen.getByTestId('filter-reach-radiogroup');
+    expect(radiogroup.querySelector(`[data-reach-ring="${value}"]`)).toHaveClass('fill-brand/[0.10]', 'stroke-brand');
+    expect(radiogroup.querySelector('[data-reach-ring="all"]')).toHaveClass('stroke-border');
+    expect(screen.getByLabelText(label)).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByLabelText('All')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByTestId('filter-reach-label')).toHaveTextContent(label);
+    expect(mockOnTabChange).toHaveBeenCalledWith(value);
+
+    fireEvent.mouseEnter(screen.getByLabelText('All'));
+
+    expect(radiogroup.querySelector(`[data-reach-ring="${value}"]`)).toHaveClass(
+      'fill-transparent',
+      'stroke-brand/[0.32]',
+    );
+    expect(radiogroup.querySelector('[data-reach-ring="all"]')).toHaveClass('stroke-foreground');
+
+    fireEvent.mouseLeave(screen.getByLabelText('All'));
+
+    expect(radiogroup.querySelector(`[data-reach-ring="${value}"]`)).toHaveClass('fill-brand/[0.10]', 'stroke-brand');
+  });
+
   it('has proper ARIA attributes for radio items', () => {
     render(<FilterReach selectedTab={REACH.FOLLOWING} />);
 
     const allRadio = screen.getByLabelText('All');
+    const networkRadio = screen.getByLabelText('My Network');
     const followingRadio = screen.getByLabelText('Following');
     const friendsRadio = screen.getByLabelText('Friends');
+    const meRadio = screen.getByLabelText('Me');
 
     // Check aria-checked
     expect(allRadio).toHaveAttribute('aria-checked', 'false');
+    expect(networkRadio).toHaveAttribute('aria-checked', 'false');
     expect(followingRadio).toHaveAttribute('aria-checked', 'true');
     expect(friendsRadio).toHaveAttribute('aria-checked', 'false');
+    expect(meRadio).toHaveAttribute('aria-checked', 'false');
 
     // Check aria-label
     expect(allRadio).toHaveAttribute('aria-label', 'All');
+    expect(networkRadio).toHaveAttribute('aria-label', 'My Network');
     expect(followingRadio).toHaveAttribute('aria-label', 'Following');
     expect(friendsRadio).toHaveAttribute('aria-label', 'Friends');
+    expect(meRadio).toHaveAttribute('aria-label', 'Me');
   });
   it('renders all items as disabled when disabled prop is true', () => {
     render(<FilterReach disabled />);
 
-    const labels = ['All', 'Following', 'Friends'];
+    const labels = ['Me', 'Friends', 'Following', 'My Network', 'All'];
     labels.forEach((label) => {
       expect(screen.getByLabelText(label)).toHaveAttribute('aria-disabled', 'true');
     });
@@ -73,16 +166,19 @@ describe('FilterReach', () => {
     const mockOnTabChange = vi.fn();
     render(<FilterReach disabled onTabChange={mockOnTabChange} />);
 
+    fireEvent.click(screen.getByLabelText('Me'));
     fireEvent.click(screen.getByLabelText('Following'));
     fireEvent.click(screen.getByLabelText('Friends'));
+    fireEvent.click(screen.getByLabelText('My Network'));
 
     expect(mockOnTabChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('All')).toHaveAttribute('aria-checked', 'true');
   });
 
   it('items are not disabled by default', () => {
     render(<FilterReach />);
 
-    const labels = ['All', 'Following', 'Friends'];
+    const labels = ['Me', 'Friends', 'Following', 'My Network', 'All'];
     labels.forEach((label) => {
       expect(screen.getByLabelText(label)).not.toHaveAttribute('aria-disabled', 'true');
     });
@@ -93,86 +189,90 @@ describe('FilterReach - Keyboard Navigation', () => {
   it('manages tabIndex correctly for keyboard navigation', () => {
     render(<FilterReach selectedTab={REACH.FRIENDS} />);
 
-    const allRadio = screen.getByLabelText('All');
-    const followingRadio = screen.getByLabelText('Following');
+    const meRadio = screen.getByLabelText('Me');
     const friendsRadio = screen.getByLabelText('Friends');
+    const followingRadio = screen.getByLabelText('Following');
+    const networkRadio = screen.getByLabelText('My Network');
+    const allRadio = screen.getByLabelText('All');
 
     // Only selected item should have tabIndex 0
-    expect(allRadio).toHaveAttribute('tabIndex', '-1');
-    expect(followingRadio).toHaveAttribute('tabIndex', '-1');
+    expect(meRadio).toHaveAttribute('tabIndex', '-1');
     expect(friendsRadio).toHaveAttribute('tabIndex', '0');
+    expect(followingRadio).toHaveAttribute('tabIndex', '-1');
+    expect(networkRadio).toHaveAttribute('tabIndex', '-1');
+    expect(allRadio).toHaveAttribute('tabIndex', '-1');
   });
 
   it('handles keyboard navigation with ArrowDown', () => {
     render(<FilterReach selectedTab={REACH.ALL} />);
 
     const allRadio = screen.getByLabelText('All');
-    const followingRadio = screen.getByLabelText('Following');
+    const meRadio = screen.getByLabelText('Me');
 
     allRadio.focus();
     fireEvent.keyDown(allRadio, { key: 'ArrowDown' });
 
-    expect(document.activeElement).toBe(followingRadio);
+    expect(document.activeElement).toBe(meRadio);
   });
 
   it('handles keyboard navigation with ArrowUp', () => {
     render(<FilterReach selectedTab={REACH.FOLLOWING} />);
 
-    const allRadio = screen.getByLabelText('All');
+    const friendsRadio = screen.getByLabelText('Friends');
     const followingRadio = screen.getByLabelText('Following');
 
     followingRadio.focus();
     fireEvent.keyDown(followingRadio, { key: 'ArrowUp' });
 
-    expect(document.activeElement).toBe(allRadio);
+    expect(document.activeElement).toBe(friendsRadio);
   });
 
   it('wraps keyboard navigation from last to first with ArrowDown', () => {
-    render(<FilterReach selectedTab={REACH.FRIENDS} />);
+    render(<FilterReach selectedTab={REACH.ALL} />);
 
     const allRadio = screen.getByLabelText('All');
-    const friendsRadio = screen.getByLabelText('Friends');
+    const meRadio = screen.getByLabelText('Me');
 
-    friendsRadio.focus();
-    fireEvent.keyDown(friendsRadio, { key: 'ArrowDown' });
+    allRadio.focus();
+    fireEvent.keyDown(allRadio, { key: 'ArrowDown' });
 
-    expect(document.activeElement).toBe(allRadio);
+    expect(document.activeElement).toBe(meRadio);
   });
 
   it('wraps keyboard navigation from first to last with ArrowUp', () => {
     render(<FilterReach selectedTab={REACH.ALL} />);
 
     const allRadio = screen.getByLabelText('All');
-    const friendsRadio = screen.getByLabelText('Friends');
+    const meRadio = screen.getByLabelText('Me');
 
-    allRadio.focus();
-    fireEvent.keyDown(allRadio, { key: 'ArrowUp' });
+    meRadio.focus();
+    fireEvent.keyDown(meRadio, { key: 'ArrowUp' });
 
-    expect(document.activeElement).toBe(friendsRadio);
+    expect(document.activeElement).toBe(allRadio);
   });
 
   it('handles Home key to jump to first option', () => {
     render(<FilterReach selectedTab={REACH.FRIENDS} />);
 
-    const allRadio = screen.getByLabelText('All');
     const friendsRadio = screen.getByLabelText('Friends');
+    const meRadio = screen.getByLabelText('Me');
 
     friendsRadio.focus();
     fireEvent.keyDown(friendsRadio, { key: 'Home' });
 
-    expect(document.activeElement).toBe(allRadio);
+    expect(document.activeElement).toBe(meRadio);
   });
 
   it('handles End key to jump to last option', () => {
     render(<FilterReach selectedTab={REACH.ALL} />);
 
     const allRadio = screen.getByLabelText('All');
-    const friendsRadio = screen.getByLabelText('Friends');
+    const meRadio = screen.getByLabelText('Me');
 
-    allRadio.focus();
-    fireEvent.keyDown(allRadio, { key: 'End' });
+    meRadio.focus();
+    fireEvent.keyDown(meRadio, { key: 'End' });
 
-    expect(document.activeElement).toBe(friendsRadio);
+    expect(document.activeElement).toBe(allRadio);
   });
 
   it('handles selection with Space key', () => {
@@ -199,28 +299,44 @@ describe('FilterReach - Keyboard Navigation', () => {
     expect(mockOnTabChange).toHaveBeenCalledWith('friends');
   });
 
+  it('selects Network with the keyboard and reports the reach change', () => {
+    const mockOnTabChange = vi.fn();
+    const { rerender } = render(<FilterReach selectedTab={REACH.ALL} onTabChange={mockOnTabChange} />);
+
+    const networkRadio = screen.getByLabelText('My Network');
+    networkRadio.focus();
+    fireEvent.keyDown(networkRadio, { key: 'Enter' });
+
+    expect(mockOnTabChange).toHaveBeenCalledWith(REACH.NETWORK);
+
+    rerender(<FilterReach selectedTab={REACH.NETWORK} onTabChange={mockOnTabChange} />);
+
+    expect(networkRadio).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('filter-reach-label')).toHaveTextContent('My Network');
+  });
+
   it('handles ArrowRight key like ArrowDown', () => {
     render(<FilterReach selectedTab={REACH.ALL} />);
 
     const allRadio = screen.getByLabelText('All');
-    const followingRadio = screen.getByLabelText('Following');
+    const meRadio = screen.getByLabelText('Me');
 
     allRadio.focus();
     fireEvent.keyDown(allRadio, { key: 'ArrowRight' });
 
-    expect(document.activeElement).toBe(followingRadio);
+    expect(document.activeElement).toBe(meRadio);
   });
 
   it('handles ArrowLeft key like ArrowUp', () => {
     render(<FilterReach selectedTab={REACH.FOLLOWING} />);
 
-    const allRadio = screen.getByLabelText('All');
+    const friendsRadio = screen.getByLabelText('Friends');
     const followingRadio = screen.getByLabelText('Following');
 
     followingRadio.focus();
     fireEvent.keyDown(followingRadio, { key: 'ArrowLeft' });
 
-    expect(document.activeElement).toBe(allRadio);
+    expect(document.activeElement).toBe(friendsRadio);
   });
 });
 
@@ -239,6 +355,19 @@ describe('FilterReach - Controlled/Uncontrolled', () => {
 
     expect(screen.getByLabelText('Following')).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByLabelText('All')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('updates a controlled ME selection when the feed value changes', () => {
+    const { rerender } = render(<FilterReach selectedTab={REACH.ME} />);
+
+    expect(screen.getByLabelText('Me')).toHaveAttribute('aria-checked', 'true');
+
+    rerender(<FilterReach selectedTab={REACH.FOLLOWING} />);
+    expect(screen.getByLabelText('Following')).toHaveAttribute('aria-checked', 'true');
+
+    rerender(<FilterReach selectedTab={REACH.ALL} />);
+    expect(screen.getByLabelText('All')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByLabelText('Me')).toHaveAttribute('aria-checked', 'false');
   });
 
   it('works as uncontrolled component with defaultSelectedTab', () => {

--- a/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx.snap
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FilterReach - Snapshots > matches snapshot in uncontrolled mode with defaultSelectedTab 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -16,147 +16,135 @@ exports[`FilterReach - Snapshots > matches snapshot in uncontrolled mode with de
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Following"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Friends"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-label="Friends"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50"
+      data-reach-option="friends"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="0"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Following"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40"
+      data-reach-option="following"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="All"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10"
+      data-reach-option="all"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      Friends
+    </span>
   </div>
 </div>
 `;
 
 exports[`FilterReach - Snapshots > matches snapshot with All selected tab 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -170,147 +158,135 @@ exports[`FilterReach - Snapshots > matches snapshot with All selected tab 1`] = 
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Following"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Friends"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Friends"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50"
+      data-reach-option="friends"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Following"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40"
+      data-reach-option="following"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-label="All"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10"
+      data-reach-option="all"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="0"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      All
+    </span>
   </div>
 </div>
 `;
 
 exports[`FilterReach - Snapshots > matches snapshot with Following selected 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -324,147 +300,135 @@ exports[`FilterReach - Snapshots > matches snapshot with Following selected 1`] 
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Following"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Friends"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Friends"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50"
+      data-reach-option="friends"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-label="Following"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40"
+      data-reach-option="following"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="0"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="All"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10"
+      data-reach-option="all"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      Following
+    </span>
   </div>
 </div>
 `;
 
 exports[`FilterReach - Snapshots > matches snapshot with Friends selected 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -478,147 +442,135 @@ exports[`FilterReach - Snapshots > matches snapshot with Friends selected 1`] = 
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="false"
-        aria-label="All"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Following"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Friends"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-label="Friends"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50"
+      data-reach-option="friends"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="0"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Following"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40"
+      data-reach-option="following"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="All"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10"
+      data-reach-option="all"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      Friends
+    </span>
   </div>
 </div>
 `;
 
 exports[`FilterReach - Snapshots > matches snapshot with default props (All selected) 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -632,147 +584,135 @@ exports[`FilterReach - Snapshots > matches snapshot with default props (All sele
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Following"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Friends"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Friends"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50"
+      data-reach-option="friends"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="Following"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40"
+      data-reach-option="following"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-label="All"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10"
+      data-reach-option="all"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      role="radio"
+      tabindex="0"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      All
+    </span>
   </div>
 </div>
 `;
 
 exports[`FilterReach - Snapshots > matches snapshot with disabled state 1`] = `
 <div
-  class="w-full flex-col flex m-0 min-w-0 gap-2 bg-background p-0"
+  class="w-full flex-col flex m-0 min-w-0 bg-background p-0 gap-4"
   data-slot="filter-root"
   data-testid="filter-root"
 >
@@ -786,143 +726,138 @@ exports[`FilterReach - Snapshots > matches snapshot with disabled state 1`] = `
       class="text-2xl font-light text-muted-foreground"
       data-testid="heading-2"
     >
-      Reach
+      Posts from
     </h2>
   </div>
   <div
     aria-labelledby="radix-normalized"
-    class=""
+    class="relative size-[180px] shrink-0 opacity-40"
     data-cy="filter-reach-radiogroup"
     data-testid="filter-reach-radiogroup"
     role="radiogroup"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <svg
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+      viewBox="0 0 180 180"
     >
-      <button
-        aria-checked="true"
-        aria-disabled="true"
-        aria-label="All"
-        aria-pressed="true"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-radio h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16.247 7.761a6 6 0 0 1 0 8.478"
-          />
-          <path
-            d="M19.075 4.933a10 10 0 0 1 0 14.134"
-          />
-          <path
-            d="M4.925 19.067a10 10 0 0 1 0-14.134"
-          />
-          <path
-            d="M7.753 16.239a6 6 0 0 1 0-8.478"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            r="2"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          All
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Following"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          class="h-5 w-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.00016 17.5C5.00016 15.7319 5.70254 14.0362 6.95278 12.786C8.20303 11.5357 9.89872 10.8333 11.6668 10.8333M11.6668 10.8333C13.4349 10.8333 15.1306 11.5357 16.3809 12.786C17.6311 14.0362 18.3335 15.7319 18.3335 17.5M11.6668 10.8333C9.36564 10.8333 7.50016 8.96785 7.50016 6.66667C7.50016 4.36548 9.36564 2.5 11.6668 2.5C13.968 2.5 15.8335 4.36548 15.8335 6.66667C15.8335 8.96785 13.968 10.8333 11.6668 10.8333ZM1.66679 16.6666C1.66679 13.8583 3.33346 11.25 5.00012 9.99996C4.45227 9.58893 4.01419 9.0492 3.72465 8.42852C3.43511 7.80784 3.30303 7.12535 3.34011 6.44146C3.37719 5.75757 3.58227 5.09336 3.93723 4.50763C4.29218 3.92189 4.78605 3.43268 5.37512 3.08329"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Following
-        </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Friends"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-heart-handshake h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Friends
-        </span>
-      </button>
-    </div>
+      <circle
+        class="transition-colors fill-brand/[0.10] stroke-brand"
+        cx="90"
+        cy="90"
+        data-reach-ring="all"
+        r="89.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="network"
+        r="75.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="following"
+        r="61.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="friends"
+        r="47.5"
+      />
+      <circle
+        class="transition-colors fill-transparent stroke-border"
+        cx="90"
+        cy="90"
+        data-reach-ring="me"
+        r="33.5"
+      />
+    </svg>
+    <button
+      aria-checked="false"
+      aria-disabled="true"
+      aria-label="Me"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[68px] z-60 cursor-default"
+      data-reach-option="me"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      disabled=""
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-disabled="true"
+      aria-label="Friends"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[96px] z-50 cursor-default"
+      data-reach-option="friends"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      disabled=""
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-disabled="true"
+      aria-label="Following"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[124px] z-40 cursor-default"
+      data-reach-option="following"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      disabled=""
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="false"
+      aria-disabled="true"
+      aria-label="My Network"
+      aria-pressed="false"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[152px] z-30 cursor-default"
+      data-reach-option="network"
+      data-selected="false"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      disabled=""
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      aria-checked="true"
+      aria-disabled="true"
+      aria-label="All"
+      aria-pressed="true"
+      class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-transparent p-0 outline-none focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground size-[180px] z-10 cursor-default"
+      data-reach-option="all"
+      data-selected="true"
+      data-slot="filter-item"
+      data-testid="filter-item"
+      disabled=""
+      role="radio"
+      tabindex="-1"
+      type="button"
+    />
+    <span
+      class="text-xs font-medium pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none text-brand"
+      data-testid="filter-reach-label"
+    >
+      All
+    </span>
   </div>
 </div>
 `;

--- a/src/components/molecules/Filters/FilterReach/FilterReach.tsx
+++ b/src/components/molecules/Filters/FilterReach/FilterReach.tsx
@@ -1,12 +1,30 @@
 'use client';
 
 import * as React from 'react';
-import { HeartHandshake, Radio } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { UsersRound2 } from '@/icons';
+import { FilterHeader, FilterRoot } from '@/atoms/Filter/Filter';
+import { Typography } from '@/atoms/Typography/Typography';
+import { useControlledState } from '@/hooks/useControlledState/useControlledState';
+import { useRadiogroupKeyboard } from '@/hooks/useRadiogroupKeyboard/useRadiogroupKeyboard';
+import { cn } from '@/libs/utils/utils';
 import { REACH, type ReachType } from '@/stores/home/home.types';
-import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
-import { BaseFilterProps } from '../Filters.types';
+import type { BaseFilterProps } from '../Filters.types';
+
+interface ReachItem {
+  key: ReachType;
+  label: string;
+  sizeClassName: string;
+  layerClassName: string;
+  disabled?: boolean;
+}
+
+const REACH_RINGS: ReadonlyArray<{ radius: number; value: ReachType }> = [
+  { radius: 89.5, value: REACH.ALL },
+  { radius: 75.5, value: REACH.NETWORK },
+  { radius: 61.5, value: REACH.FOLLOWING },
+  { radius: 47.5, value: REACH.FRIENDS },
+  { radius: 33.5, value: REACH.ME },
+];
 
 export function FilterReach({
   selectedTab,
@@ -15,38 +33,160 @@ export function FilterReach({
   disabled,
 }: BaseFilterProps<ReachType>) {
   const t = useTranslations('filters.reach');
-  const items = React.useMemo(
-    () => [
-      {
-        key: REACH.ALL,
-        label: t('all'),
-        icon: Radio,
-        disabled,
-      },
-      {
-        key: REACH.FOLLOWING,
-        label: t('following'),
-        icon: UsersRound2,
-        disabled,
-      },
-      {
-        key: REACH.FRIENDS,
-        label: t('friends'),
-        icon: HeartHandshake,
-        disabled,
-      },
-    ],
-    [t, disabled],
-  );
+  const headerId = React.useId();
+  const [hoveredValue, setHoveredValue] = React.useState<ReachType>();
+  const items: ReachItem[] = [
+    {
+      key: REACH.ME,
+      label: t('me'),
+      sizeClassName: 'size-[68px]',
+      layerClassName: 'z-60',
+      disabled,
+    },
+    {
+      key: REACH.FRIENDS,
+      label: t('friends'),
+      sizeClassName: 'size-[96px]',
+      layerClassName: 'z-50',
+      disabled,
+    },
+    {
+      key: REACH.FOLLOWING,
+      label: t('following'),
+      sizeClassName: 'size-[124px]',
+      layerClassName: 'z-40',
+      disabled,
+    },
+    {
+      key: REACH.NETWORK,
+      label: t('myNetwork'),
+      sizeClassName: 'size-[152px]',
+      layerClassName: 'z-30',
+      disabled,
+    },
+    {
+      key: REACH.ALL,
+      label: t('all'),
+      sizeClassName: 'size-[180px]',
+      layerClassName: 'z-10',
+      disabled,
+    },
+  ];
+
+  const { value: selectedValue, setValue: setSelectedValue } = useControlledState({
+    value: selectedTab,
+    defaultValue: defaultSelectedTab,
+    onChange: onTabChange,
+  });
+
+  const isPreviewingAnotherValue = hoveredValue !== undefined && hoveredValue !== selectedValue;
+
+  const selectItem = (item: ReachItem) => {
+    if (item.disabled) return;
+    setSelectedValue(item.key);
+  };
+
+  const { listRef, handleKeyDown } = useRadiogroupKeyboard({
+    items,
+    onSelect: selectItem,
+    isDisabled: (item) => item.disabled ?? false,
+  });
+
+  const visibleValue = hoveredValue ?? selectedValue;
+  const visibleLabel = items.find((item) => item.key === visibleValue)?.label;
+
   return (
-    <FilterRadioGroup
-      title={t('title')}
-      items={items}
-      selectedValue={selectedTab}
-      defaultValue={defaultSelectedTab}
-      onChange={onTabChange}
-      testId="filter-reach-radiogroup"
-      dataCy="filter-reach-radiogroup"
-    />
+    <FilterRoot className="gap-4">
+      <FilterHeader title={t('title')} id={headerId} />
+
+      <div
+        ref={listRef}
+        role="radiogroup"
+        aria-labelledby={headerId}
+        className={cn('relative size-[180px] shrink-0', disabled && 'opacity-40')}
+        data-cy="filter-reach-radiogroup"
+        data-testid="filter-reach-radiogroup"
+      >
+        <svg aria-hidden="true" className="pointer-events-none absolute inset-0 size-full" viewBox="0 0 180 180">
+          {REACH_RINGS.map((ring) => {
+            const isHovered = ring.value === hoveredValue;
+            const isSelected = ring.value === selectedValue;
+            const isSelectedPreview = isPreviewingAnotherValue && isSelected;
+            const fillClassName = isSelected
+              ? isSelectedPreview
+                ? 'fill-transparent'
+                : 'fill-brand/[0.10]'
+              : 'fill-transparent';
+            const strokeClassName = isSelected
+              ? isSelectedPreview
+                ? 'stroke-brand/[0.32]'
+                : 'stroke-brand'
+              : isHovered
+                ? 'stroke-foreground'
+                : 'stroke-border';
+
+            return (
+              <circle
+                key={ring.radius}
+                cx="90"
+                cy="90"
+                r={ring.radius}
+                className={cn('transition-colors', fillClassName, strokeClassName)}
+                data-reach-ring={ring.value}
+              />
+            );
+          })}
+        </svg>
+
+        {items.map((item, index) => {
+          const isSelected = selectedValue === item.key;
+
+          return (
+            <button
+              key={item.key}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={item.label}
+              aria-disabled={item.disabled}
+              aria-pressed={isSelected}
+              disabled={item.disabled}
+              tabIndex={isSelected && !item.disabled ? 0 : -1}
+              className={cn(
+                'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-transparent p-0 outline-none',
+                'focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-foreground',
+                item.sizeClassName,
+                item.layerClassName,
+                item.disabled && 'cursor-default',
+              )}
+              data-reach-option={item.key}
+              data-selected={isSelected ? 'true' : 'false'}
+              data-slot="filter-item"
+              data-testid="filter-item"
+              onClick={() => selectItem(item)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              onMouseEnter={() => {
+                if (!item.disabled) {
+                  setHoveredValue(item.key);
+                }
+              }}
+              onMouseLeave={() => setHoveredValue(undefined)}
+            />
+          );
+        })}
+
+        <Typography
+          as="span"
+          size="xs"
+          className={cn(
+            'pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 leading-4 tracking-[1.2px] uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.75)] transition-colors select-none',
+            isPreviewingAnotherValue ? 'text-foreground' : 'text-brand',
+          )}
+          data-testid="filter-reach-label"
+        >
+          {visibleLabel}
+        </Typography>
+      </div>
+    </FilterRoot>
   );
 }

--- a/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx
+++ b/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx
@@ -86,6 +86,7 @@ describe('FilterSort', () => {
     await user.click(screen.getByRole('combobox', { name: 'Sort' }));
 
     expect(screen.getByRole('option', { name: 'Popularity' })).toHaveClass(
+      'font-medium',
       'hover:text-secondary-foreground',
       'data-[highlighted]:text-secondary-foreground',
     );

--- a/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx
+++ b/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx
@@ -1,96 +1,94 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { SORT, type SortType } from '@/stores/home/home.types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { SORT } from '@/stores/home/home.types';
 import { FilterSort } from './FilterSort';
 
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+});
+
+async function selectSortOption(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox', { name: 'Sort' }));
+  await user.click(screen.getByRole('option', { name: label }));
+}
+
 describe('FilterSort', () => {
-  it('renders with default selected tab', () => {
+  it('renders the current option in a dropdown trigger', () => {
     render(<FilterSort />);
 
     expect(screen.getByText('Sort')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Sort' })).toHaveTextContent('Recent');
   });
 
-  it('calls onTabChange when tab is clicked', () => {
-    const mockOnTabChange = vi.fn();
-    render(<FilterSort onTabChange={mockOnTabChange} />);
+  it('calls onTabChange when an option is selected', async () => {
+    const onTabChange = vi.fn();
+    render(<FilterSort onTabChange={onTabChange} />);
 
-    const popularityElement = screen.getByText('Popularity');
-    fireEvent.click(popularityElement);
+    await selectSortOption('Popularity');
 
-    expect(mockOnTabChange).toHaveBeenCalledWith(SORT.ENGAGEMENT); // 'total_engagement'
+    expect(onTabChange).toHaveBeenCalledWith(SORT.ENGAGEMENT);
   });
 
-  it('handles all tab types correctly', () => {
-    const mockOnTabChange = vi.fn();
-    render(<FilterSort onTabChange={mockOnTabChange} />);
+  it('supports both sort options', async () => {
+    const onTabChange = vi.fn();
+    render(<FilterSort onTabChange={onTabChange} />);
 
-    const tabs: SortType[] = ['timeline', 'total_engagement'];
+    await selectSortOption('Popularity');
+    await selectSortOption('Recent');
 
-    tabs.forEach((tab) => {
-      const element = screen.getByText(tab === 'timeline' ? 'Recent' : 'Popularity');
-
-      fireEvent.click(element);
-      expect(mockOnTabChange).toHaveBeenCalledWith(tab);
-    });
+    expect(onTabChange).toHaveBeenNthCalledWith(1, SORT.ENGAGEMENT);
+    expect(onTabChange).toHaveBeenNthCalledWith(2, SORT.TIMELINE);
   });
 
-  it('handles tab switching correctly', () => {
-    const mockOnTabChange = vi.fn();
-    render(<FilterSort selectedTab={SORT.TIMELINE} onTabChange={mockOnTabChange} />);
-
-    // Click on popularity tab
-    const popularityElement = screen.getByText('Popularity');
-    fireEvent.click(popularityElement);
-
-    expect(mockOnTabChange).toHaveBeenCalledWith(SORT.ENGAGEMENT); // 'total_engagement'
-    expect(mockOnTabChange).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders all items as disabled when disabled prop is true', () => {
-    render(<FilterSort disabled />);
-
-    const labels = ['Recent', 'Popularity'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  it('does not call onTabChange when disabled', () => {
-    const mockOnTabChange = vi.fn();
-    render(<FilterSort disabled onTabChange={mockOnTabChange} />);
-
-    fireEvent.click(screen.getByText('Recent'));
-    fireEvent.click(screen.getByText('Popularity'));
-
-    expect(mockOnTabChange).not.toHaveBeenCalled();
-  });
-
-  it('items are not disabled by default', () => {
-    render(<FilterSort />);
-
-    const labels = ['Recent', 'Popularity'];
-    labels.forEach((label) => {
-      expect(screen.getByLabelText(label)).not.toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  it('renders with different selected tabs', () => {
+  it('updates the trigger when the controlled selection changes', () => {
     const { rerender } = render(<FilterSort selectedTab={SORT.TIMELINE} />);
 
-    let recentItem = screen.getByText('Recent').closest('[data-testid="filter-item"]');
-    let popularityItem = screen.getByText('Popularity').closest('[data-testid="filter-item"]');
+    expect(screen.getByRole('combobox', { name: 'Sort' })).toHaveTextContent('Recent');
 
-    expect(recentItem).toBeInTheDocument();
-    expect(popularityItem).toBeInTheDocument();
-
-    // Rerender with different selected tab
     rerender(<FilterSort selectedTab={SORT.ENGAGEMENT} />);
 
-    recentItem = screen.getByText('Recent').closest('[data-testid="filter-item"]');
-    popularityItem = screen.getByText('Popularity').closest('[data-testid="filter-item"]');
+    expect(screen.getByRole('combobox', { name: 'Sort' })).toHaveTextContent('Popularity');
+  });
 
-    expect(recentItem).toBeInTheDocument();
-    expect(popularityItem).toBeInTheDocument();
+  it('disables the dropdown when the filter is disabled', async () => {
+    const onTabChange = vi.fn();
+    const user = userEvent.setup();
+    render(<FilterSort disabled onTabChange={onTabChange} />);
+
+    const trigger = screen.getByRole('combobox', { name: 'Sort' });
+    expect(trigger).toBeDisabled();
+
+    await user.click(trigger);
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  it('renders enabled options by default', async () => {
+    const user = userEvent.setup();
+    render(<FilterSort />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Sort' }));
+
+    expect(screen.getByRole('option', { name: 'Recent' })).not.toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('option', { name: 'Popularity' })).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('uses the secondary foreground color when an option is hovered', async () => {
+    const user = userEvent.setup();
+    render(<FilterSort />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Sort' }));
+
+    expect(screen.getByRole('option', { name: 'Popularity' })).toHaveClass(
+      'hover:text-secondary-foreground',
+      'data-[highlighted]:text-secondary-foreground',
+    );
   });
 });
 

--- a/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx.snap
+++ b/src/components/molecules/Filters/FilterSort/FilterSort.test.tsx.snap
@@ -19,103 +19,72 @@ exports[`FilterSort - Snapshots > matches snapshot with Popularity content selec
       Sort
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
     data-cy="filter-sort-radiogroup"
-    data-testid="filter-sort-radiogroup"
-    role="radiogroup"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-sort-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="false"
-        aria-label="Recent"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-square-asterisk h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M12 8v8"
-          />
-          <path
-            d="m8.5 14 7-4"
-          />
-          <path
-            d="m8.5 10 7 4"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
-          Recent
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-flame size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"
+            />
+          </svg>
         </span>
-      </button>
-      <button
-        aria-checked="true"
-        aria-label="Popularity"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-flame h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"
-          />
-        </svg>
-        <span
-          class=""
-        >
+        <span>
           Popularity
         </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -138,103 +107,85 @@ exports[`FilterSort - Snapshots > matches snapshot with Recent content selected 
       Sort
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
     data-cy="filter-sort-radiogroup"
-    data-testid="filter-sort-radiogroup"
-    role="radiogroup"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-sort-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="Recent"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-square-asterisk h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M12 8v8"
-          />
-          <path
-            d="m8.5 14 7-4"
-          />
-          <path
-            d="m8.5 10 7 4"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-square-asterisk size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M12 8v8"
+            />
+            <path
+              d="m8.5 14 7-4"
+            />
+            <path
+              d="m8.5 10 7 4"
+            />
+          </svg>
+        </span>
+        <span>
           Recent
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Popularity"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-flame h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Popularity
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -257,103 +208,85 @@ exports[`FilterSort - Snapshots > matches snapshot with default props 1`] = `
       Sort
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
     data-cy="filter-sort-radiogroup"
-    data-testid="filter-sort-radiogroup"
-    role="radiogroup"
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-sort-dropdown"
+    dir="ltr"
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-label="Recent"
-        aria-pressed="true"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-square-asterisk h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M12 8v8"
-          />
-          <path
-            d="m8.5 14 7-4"
-          />
-          <path
-            d="m8.5 10 7 4"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-square-asterisk size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M12 8v8"
+            />
+            <path
+              d="m8.5 14 7-4"
+            />
+            <path
+              d="m8.5 10 7 4"
+            />
+          </svg>
+        </span>
+        <span>
           Recent
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-label="Popularity"
-        aria-pressed="false"
-        class="flex cursor-pointer gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-flame h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Popularity
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -376,104 +309,86 @@ exports[`FilterSort - Snapshots > matches snapshot with disabled state 1`] = `
       Sort
     </h2>
   </div>
-  <div
+  <button
+    aria-autocomplete="none"
+    aria-controls="radix-normalized"
+    aria-expanded="false"
     aria-labelledby="radix-normalized"
-    class=""
+    class="flex w-fit cursor-pointer items-center justify-between rounded-md bg-transparent text-base font-bold whitespace-nowrap text-foreground outline-none select-none focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-8 gap-1 border-transparent py-0 transition-opacity hover:opacity-80 focus-visible:border-transparent focus-visible:ring-0 data-[state=open]:[&>svg:last-child]:rotate-180 [&>svg:last-child]:size-6 [&>svg:last-child]:transition-transform [&>svg:last-child]:duration-300"
     data-cy="filter-sort-radiogroup"
-    data-testid="filter-sort-radiogroup"
-    role="radiogroup"
+    data-disabled=""
+    data-size="default"
+    data-slot="select-trigger"
+    data-state="closed"
+    data-testid="filter-sort-dropdown"
+    dir="ltr"
+    disabled=""
+    role="combobox"
+    type="button"
   >
-    <div
-      class="mx-auto w-full flex-col flex"
-      data-slot="filter-list"
-      data-testid="filter-list"
+    <span
+      data-slot="select-value"
+      style="pointer-events: none;"
     >
-      <button
-        aria-checked="true"
-        aria-disabled="true"
-        aria-label="Recent"
-        aria-pressed="true"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-foreground m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="true"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="0"
-        type="button"
+      <span
+        class="flex items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-square-asterisk h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="18"
-            rx="2"
-            width="18"
-            x="3"
-            y="3"
-          />
-          <path
-            d="M12 8v8"
-          />
-          <path
-            d="m8.5 14 7-4"
-          />
-          <path
-            d="m8.5 10 7 4"
-          />
-        </svg>
         <span
-          class=""
+          class="flex size-5 shrink-0 items-center justify-center [&>svg]:size-full"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-square-asterisk size-5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="3"
+            />
+            <path
+              d="M12 8v8"
+            />
+            <path
+              d="m8.5 14 7-4"
+            />
+            <path
+              d="m8.5 10 7 4"
+            />
+          </svg>
+        </span>
+        <span>
           Recent
         </span>
-      </button>
-      <button
-        aria-checked="false"
-        aria-disabled="true"
-        aria-label="Popularity"
-        aria-pressed="false"
-        class="flex gap-2 text-base font-medium transition-colors border-0 bg-transparent p-0 text-left items-center justify-normal text-muted-foreground hover:text-foreground/80 m-0 h-full px-0 py-1 cursor-default opacity-40"
-        data-selected="false"
-        data-slot="filter-item"
-        data-testid="filter-item"
-        role="radio"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-flame h-5 w-5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4"
-          />
-        </svg>
-        <span
-          class=""
-        >
-          Popularity
-        </span>
-      </button>
-    </div>
-  </div>
+      </span>
+    </span>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-chevron-down pointer-events-none size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </button>
 </div>
 `;

--- a/src/components/molecules/Filters/FilterSort/FilterSort.tsx
+++ b/src/components/molecules/Filters/FilterSort/FilterSort.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import * as React from 'react';
 import { Flame, SquareAsterisk } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { SORT, type SortType } from '@/stores/home/home.types';
-import { FilterRadioGroup } from '../FilterRadioGroup/FilterRadioGroup';
+import { FilterDropdown } from '../FilterDropdown/FilterDropdown';
 import { BaseFilterProps } from '../Filters.types';
 
 export function FilterSort({
@@ -14,31 +13,30 @@ export function FilterSort({
   disabled,
 }: BaseFilterProps<SortType>) {
   const t = useTranslations('filters.sort');
-  const items = React.useMemo(
-    () => [
-      {
-        key: SORT.TIMELINE,
-        label: t('recent'),
-        icon: SquareAsterisk,
-        disabled,
-      },
-      {
-        key: SORT.ENGAGEMENT,
-        label: t('popularity'),
-        icon: Flame,
-        disabled,
-      },
-    ],
-    [t, disabled],
-  );
+  const items = [
+    {
+      key: SORT.TIMELINE,
+      label: t('recent'),
+      icon: SquareAsterisk,
+      disabled,
+    },
+    {
+      key: SORT.ENGAGEMENT,
+      label: t('popularity'),
+      icon: Flame,
+      disabled,
+    },
+  ];
+
   return (
-    <FilterRadioGroup
+    <FilterDropdown
       title={t('title')}
       items={items}
       selectedValue={selectedTab}
       defaultValue={defaultSelectedTab}
       onChange={onTabChange}
       dataCy="filter-sort-radiogroup"
+      testId="filter-sort-dropdown"
     />
   );
 }

--- a/src/components/molecules/TagInput/TagInput.tsx
+++ b/src/components/molecules/TagInput/TagInput.tsx
@@ -161,7 +161,6 @@ export const TagInput = forwardRef<TagInputHandle, TagInputProps>(function TagIn
               isDashedVariant && 'border border-dashed border-input shadow-sm transition-all duration-300',
               onClick && 'cursor-pointer',
               className,
-              isAtLimit && 'w-40',
             )}
             style={style}
             // Adding / typing a tag is the only intent here — never navigation.

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { PubkyAppFeedLayout, PubkyAppFeedReach, PubkyAppFeedSort } from 'pubky-app-specs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FeedModelSchema } from '@/models/feed/feed.schema';
+import { useHomeStore } from '@/stores/home/home.store';
+import { REACH } from '@/stores/home/home.types';
 import { FeedNavigation } from './FeedNavigation';
 
 // Mock next/navigation
@@ -185,6 +187,7 @@ describe('FeedNavigation', () => {
     mockRequireAuth.mockImplementation((action: () => unknown) => action());
     mockUsePathname.mockReturnValue('/home');
     mockGetList.mockResolvedValue([]);
+    useHomeStore.setState({ reach: REACH.ALL });
   });
 
   // ── Sanity ───────────────────────────────────────────────────────────────
@@ -195,8 +198,8 @@ describe('FeedNavigation', () => {
     const container = screen.getByTestId('container');
     expect(container).toBeInTheDocument();
 
-    // Home link should always be present
-    expect(screen.getByText('Home')).toBeInTheDocument();
+    // The home-route link reflects the selected Reach.
+    expect(screen.getByText('All')).toBeInTheDocument();
 
     // Create Feed button should always be present
     expect(screen.getByText('Create Feed')).toBeInTheDocument();
@@ -204,13 +207,40 @@ describe('FeedNavigation', () => {
 
   // ── Home feed link ──────────────────────────────────────────────────────
 
-  it('renders the Home feed link with correct href', () => {
+  it('renders the home-route feed link with correct href', () => {
     render(<FeedNavigation />);
 
     const links = screen.getAllByTestId('link');
     const homeLink = links.find((link) => link.getAttribute('href') === '/home');
     expect(homeLink).toBeInTheDocument();
-    expect(homeLink).toHaveTextContent('Home');
+    expect(homeLink).toHaveTextContent('All');
+  });
+
+  it.each([
+    { reach: REACH.ALL, label: 'All' },
+    { reach: REACH.NETWORK, label: 'My Network' },
+    { reach: REACH.FOLLOWING, label: 'Following' },
+    { reach: REACH.FRIENDS, label: 'Friends' },
+    { reach: REACH.ME, label: 'Me' },
+  ])('reflects $label Reach in the home-route feed tab', ({ reach, label }) => {
+    useHomeStore.setState({ reach });
+
+    render(<FeedNavigation />);
+
+    const homeLink = screen.getAllByTestId('link').find((link) => link.getAttribute('href') === '/home');
+    expect(homeLink).toHaveTextContent(label);
+    expect(homeLink?.querySelector(`[data-reach-icon="${reach}"]`)).toBeInTheDocument();
+  });
+
+  it('falls back to All in the home-route feed tab when a guest has a personalized Reach stored', () => {
+    mockIsAuthenticated = false;
+    useHomeStore.setState({ reach: REACH.FRIENDS });
+
+    render(<FeedNavigation />);
+
+    const homeLink = screen.getAllByTestId('link').find((link) => link.getAttribute('href') === '/home');
+    expect(homeLink).toHaveTextContent('All');
+    expect(homeLink?.querySelector('[data-reach-icon="all"]')).toBeInTheDocument();
   });
 
   it('applies active styling to Home link when pathname is /home', () => {
@@ -270,8 +300,8 @@ describe('FeedNavigation', () => {
     const typographies = screen.getAllByTestId('typography');
     const feedNames = typographies.map((t) => t.textContent);
 
-    // Home is first, then custom feeds, then Create Feed
-    expect(feedNames).toEqual(['Home', 'Alpha Feed', 'Beta Feed', 'Gamma Feed', 'Create Feed']);
+    // The Reach tab is first, then custom feeds, then Create Feed.
+    expect(feedNames).toEqual(['All', 'Alpha Feed', 'Beta Feed', 'Gamma Feed', 'Create Feed']);
   });
 
   // ── Active / Inactive custom feed styling ───────────────────────────────
@@ -358,7 +388,7 @@ describe('FeedNavigation', () => {
 
     render(<FeedNavigation />);
 
-    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
     expect(screen.queryByText('Private Feed')).not.toBeInTheDocument();
     expect(screen.queryByTestId('custom-feed-dialog-create')).not.toBeInTheDocument();
     expect(mockGetList).not.toHaveBeenCalled();
@@ -383,8 +413,8 @@ describe('FeedNavigation', () => {
 
     render(<FeedNavigation />);
 
-    // Should still render Home and Create Feed even when getList fails
-    expect(screen.getByText('Home')).toBeInTheDocument();
+    // Should still render the Reach tab and Create Feed even when getList fails.
+    expect(screen.getByText('All')).toBeInTheDocument();
     expect(screen.getByText('Create Feed')).toBeInTheDocument();
   });
 
@@ -422,6 +452,7 @@ describe('FeedNavigation - Snapshots', () => {
     mockRequireAuth.mockImplementation((action: () => unknown) => action());
     mockUsePathname.mockReturnValue('/home');
     mockGetList.mockResolvedValue([]);
+    useHomeStore.setState({ reach: REACH.ALL });
   });
 
   it('matches snapshot with no custom feeds and Home active', () => {

--- a/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-house size-5 shrink-0"
+      class="lucide lucide-radio size-5 shrink-0"
+      data-reach-icon="all"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -33,10 +34,21 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"
+        d="M16.247 7.761a6 6 0 0 1 0 8.478"
       />
       <path
-        d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+        d="M19.075 4.933a10 10 0 0 1 0 14.134"
+      />
+      <path
+        d="M4.925 19.067a10 10 0 0 1 0-14.134"
+      />
+      <path
+        d="M7.753 16.239a6 6 0 0 1 0-8.478"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="2"
       />
     </svg>
     <span
@@ -44,7 +56,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feed active (
       data-override-defaults="true"
       data-testid="typography"
     >
-      Home
+      All
     </span>
   </a>
   <a
@@ -157,7 +169,8 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-house size-5 shrink-0"
+      class="lucide lucide-radio size-5 shrink-0"
+      data-reach-icon="all"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -169,10 +182,21 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"
+        d="M16.247 7.761a6 6 0 0 1 0 8.478"
       />
       <path
-        d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+        d="M19.075 4.933a10 10 0 0 1 0 14.134"
+      />
+      <path
+        d="M4.925 19.067a10 10 0 0 1 0-14.134"
+      />
+      <path
+        d="M7.753 16.239a6 6 0 0 1 0-8.478"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="2"
       />
     </svg>
     <span
@@ -180,7 +204,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with custom feeds and Hom
       data-override-defaults="true"
       data-testid="typography"
     >
-      Home
+      All
     </span>
   </a>
   <a
@@ -317,7 +341,8 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-house size-5 shrink-0"
+      class="lucide lucide-radio size-5 shrink-0"
+      data-reach-icon="all"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -329,10 +354,21 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"
+        d="M16.247 7.761a6 6 0 0 1 0 8.478"
       />
       <path
-        d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+        d="M19.075 4.933a10 10 0 0 1 0 14.134"
+      />
+      <path
+        d="M4.925 19.067a10 10 0 0 1 0-14.134"
+      />
+      <path
+        d="M7.753 16.239a6 6 0 0 1 0-8.478"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="2"
       />
     </svg>
     <span
@@ -340,7 +376,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with multiple custom feed
       data-override-defaults="true"
       data-testid="typography"
     >
-      Home
+      All
     </span>
   </a>
   <a
@@ -521,7 +557,8 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-house size-5 shrink-0"
+      class="lucide lucide-radio size-5 shrink-0"
+      data-reach-icon="all"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -533,10 +570,21 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"
+        d="M16.247 7.761a6 6 0 0 1 0 8.478"
       />
       <path
-        d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+        d="M19.075 4.933a10 10 0 0 1 0 14.134"
+      />
+      <path
+        d="M4.925 19.067a10 10 0 0 1 0-14.134"
+      />
+      <path
+        d="M7.753 16.239a6 6 0 0 1 0-8.478"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="2"
       />
     </svg>
     <span
@@ -544,7 +592,7 @@ exports[`FeedNavigation - Snapshots > matches snapshot with no custom feeds and 
       data-override-defaults="true"
       data-testid="typography"
     >
-      Home
+      All
     </span>
   </a>
   <div

--- a/src/components/organisms/FeedNavigation/FeedNavigation.tsx
+++ b/src/components/organisms/FeedNavigation/FeedNavigation.tsx
@@ -2,10 +2,9 @@
 
 import { usePathname } from 'next/navigation';
 import { useLiveQuery } from 'dexie-react-hooks';
-// Module-level cache: survives remounts within the session so that
-// navigating between /home and /feed/[id] doesn't flash empty tabs.
-import { Home, Pencil, PlusCircle } from 'lucide-react';
+import { HeartHandshake, type LucideProps, Pencil, PlusCircle, Radio, UserRound, Waypoints } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import type { ComponentType } from 'react';
 import { APP_ROUTES } from '@/app/routes';
 import { Button } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
@@ -14,21 +13,45 @@ import { Link } from '@/atoms/Link/Link';
 import { Typography } from '@/atoms/Typography/Typography';
 import { FeedController } from '@/controllers/feed/feed';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
+import { UsersRound2 } from '@/icons';
 import { Logger } from '@/libs/logger/logger';
 import { handleFeedNavClick } from '@/libs/utils/feedScrollTop';
 import { cn } from '@/libs/utils/utils';
 import type { FeedModelSchema } from '@/models/feed/feed.schema';
+import { useHomeStore } from '@/stores/home/home.store';
+import { REACH, type ReachType } from '@/stores/home/home.types';
 import { CustomFeedDialog } from '../CustomFeedDialog/CustomFeedDialog';
 
+// Module-level cache: survives remounts within the session so that
+// navigating between /home and /feed/[id] doesn't flash empty tabs.
 let cachedFeeds: FeedModelSchema[] = [];
+const HOME_FEED_REACH: Record<
+  ReachType,
+  {
+    icon: ComponentType<LucideProps>;
+    labelKey: 'all' | 'myNetwork' | 'following' | 'friends' | 'me';
+  }
+> = {
+  [REACH.ALL]: { icon: Radio, labelKey: 'all' },
+  [REACH.NETWORK]: { icon: Waypoints, labelKey: 'myNetwork' },
+  [REACH.FOLLOWING]: { icon: UsersRound2, labelKey: 'following' },
+  [REACH.FRIENDS]: { icon: HeartHandshake, labelKey: 'friends' },
+  [REACH.ME]: { icon: UserRound, labelKey: 'me' },
+};
+
 interface FeedNavigationProps {
   className?: string;
 }
 export const FeedNavigation = ({ className }: FeedNavigationProps) => {
   const pathname = usePathname();
   const tHeader = useTranslations('header');
+  const tReach = useTranslations('filters.reach');
   const tDialog = useTranslations('dialogs.customFeed');
   const { isAuthenticated, requireAuth } = useRequireAuth();
+  const reach = useHomeStore((state) => state.reach);
+  const effectiveReach = isAuthenticated || reach === REACH.NETWORK ? reach : REACH.ALL;
+  const homeFeedReach = HOME_FEED_REACH[effectiveReach];
+  const HomeFeedReachIcon = homeFeedReach.icon;
   const customFeeds = useLiveQuery(
     async () => {
       try {
@@ -56,8 +79,8 @@ export const FeedNavigation = ({ className }: FeedNavigationProps) => {
   }));
   const feeds = [
     {
-      name: tHeader('home'),
-      icon: <Home className="size-5 shrink-0" />,
+      name: tReach(homeFeedReach.labelKey),
+      icon: <HomeFeedReachIcon className="size-5 shrink-0" data-reach-icon={effectiveReach} />,
       href: APP_ROUTES.HOME,
     },
     ...customFeedsMapped,

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
@@ -236,7 +236,7 @@ describe('HomeFeedSidebar', () => {
     expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-input-disabled', 'true');
   });
 
-  it('keeps Network selected when logged out because it aliases the public All stream', () => {
+  it('falls back to All when logged out with Network persisted', () => {
     mockCurrentUserPubky.value = null;
     mockUseHomeStore.mockReturnValue({
       layout: 'columns',
@@ -256,7 +256,7 @@ describe('HomeFeedSidebar', () => {
 
     render(<HomeFeedSidebar />);
 
-    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'network');
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'all');
     expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-hidden', 'false');
     expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-input-disabled', 'true');
   });

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx
@@ -3,35 +3,60 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { HomeFeedDrawer, HomeFeedDrawerMobile, HomeFeedSidebar } from './HomeFeedSidebar';
 
-const { mockSetContent, mockUseHomeStore, mockFilterContent, mockUseFeedLayoutResolution, mockCurrentUserPubky } =
-  vi.hoisted(() => ({
-    mockSetContent: vi.fn(),
-    mockUseHomeStore: vi.fn(),
-    mockFilterContent: vi.fn(({ disabledTabs, selectedTab }: { disabledTabs?: string[]; selectedTab?: string }) => (
+const {
+  mockSetContent,
+  mockUseHomeStore,
+  mockFilterContent,
+  mockFilterProfileTags,
+  mockUseFeedLayoutResolution,
+  mockCurrentUserPubky,
+  mockSetReach,
+  mockSetProfileTagScope,
+} = vi.hoisted(() => ({
+  mockSetContent: vi.fn(),
+  mockUseHomeStore: vi.fn(),
+  mockFilterContent: vi.fn(({ disabledTabs, selectedTab }: { disabledTabs?: string[]; selectedTab?: string }) => (
+    <div
+      data-testid="filter-content"
+      data-disabled-tabs={(disabledTabs ?? []).length ? disabledTabs?.join(',') : undefined}
+      data-selected-tab={selectedTab}
+    >
+      FilterContent
+    </div>
+  )),
+  mockFilterProfileTags: vi.fn(
+    ({ hidden, inputDisabled, scope }: { hidden?: boolean; inputDisabled?: boolean; scope?: string }) => (
       <div
-        data-testid="filter-content"
-        data-disabled-tabs={(disabledTabs ?? []).length ? disabledTabs?.join(',') : undefined}
-        data-selected-tab={selectedTab}
+        data-testid="filter-profile-tags"
+        data-hidden={hidden ? 'true' : 'false'}
+        data-input-disabled={inputDisabled ? 'true' : 'false'}
+        data-scope={scope}
       >
-        FilterContent
+        FilterProfileTags
       </div>
-    )),
-    mockUseFeedLayoutResolution: vi.fn(() => ({
-      requestedLayout: 'columns',
-      effectiveLayout: 'columns',
-      isVisualRequested: false,
-      isVisualActive: false,
-      isPhoneViewport: false,
-    })),
-    mockCurrentUserPubky: { value: 'viewer-pubky' as string | null },
-  }));
+    ),
+  ),
+  mockUseFeedLayoutResolution: vi.fn(() => ({
+    requestedLayout: 'columns',
+    effectiveLayout: 'columns',
+    isVisualRequested: false,
+    isVisualActive: false,
+    isPhoneViewport: false,
+  })),
+  mockCurrentUserPubky: { value: 'viewer-pubky' as string | null },
+  mockSetReach: vi.fn(),
+  mockSetProfileTagScope: vi.fn(),
+}));
 
 // Mock useHomeStore
 vi.mock('@/stores/home/home.types', () => ({
+  HOME_PROFILE_TAGS_MAX_SELECTED: 5,
   REACH: {
-    ALL: 'all',
-    FOLLOWING: 'following',
+    ME: 'me',
     FRIENDS: 'friends',
+    FOLLOWING: 'following',
+    NETWORK: 'network',
+    ALL: 'all',
   },
   CONTENT: {
     ALL: 'all',
@@ -94,6 +119,11 @@ vi.mock('@/molecules/Filters/FilterReach/FilterReach', () => {
   };
 });
 
+vi.mock('@/molecules/Filters/FilterProfileTags/FilterProfileTags', () => ({
+  FilterProfileTags: (props: { hidden?: boolean; inputDisabled?: boolean; scope?: string }) =>
+    mockFilterProfileTags(props),
+}));
+
 vi.mock('@/molecules/Filters/FilterSort/FilterSort', () => {
   return {
     FilterSort: () => <div data-testid="filter-sort">FilterSort</div>,
@@ -102,18 +132,26 @@ vi.mock('@/molecules/Filters/FilterSort/FilterSort', () => {
 
 beforeEach(() => {
   mockSetContent.mockClear();
+  mockSetReach.mockClear();
+  mockSetProfileTagScope.mockClear();
   mockCurrentUserPubky.value = 'viewer-pubky';
   mockUseHomeStore.mockReturnValue({
     layout: 'columns',
     setLayout: vi.fn(),
     reach: 'following',
-    setReach: vi.fn(),
+    setReach: mockSetReach,
     sort: 'timeline',
     setSort: vi.fn(),
     content: 'all',
     setContent: mockSetContent,
+    profileTags: [],
+    profileTagScope: 'network',
+    addProfileTag: vi.fn(),
+    removeProfileTag: vi.fn(),
+    setProfileTagScope: mockSetProfileTagScope,
   });
   mockFilterContent.mockClear();
+  mockFilterProfileTags.mockClear();
   mockUseFeedLayoutResolution.mockReturnValue({
     requestedLayout: 'columns',
     effectiveLayout: 'columns',
@@ -128,6 +166,8 @@ describe('HomeFeedSidebar', () => {
     render(<HomeFeedSidebar />);
 
     expect(screen.getByTestId('filter-reach')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-hidden', 'false');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-scope', 'network');
     expect(screen.getByTestId('filter-sort')).toBeInTheDocument();
     expect(screen.getByTestId('filter-content')).toBeInTheDocument();
     expect(screen.getByTestId('filter-layout')).toBeInTheDocument();
@@ -161,11 +201,16 @@ describe('HomeFeedSidebar', () => {
       layout: 'visual',
       setLayout: vi.fn(),
       reach: 'following',
-      setReach: vi.fn(),
+      setReach: mockSetReach,
       sort: 'timeline',
       setSort: vi.fn(),
       content: 'short',
       setContent: mockSetContent,
+      profileTags: [],
+      profileTagScope: 'network',
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+      setProfileTagScope: mockSetProfileTagScope,
     });
     mockUseFeedLayoutResolution.mockReturnValue({
       requestedLayout: 'visual',
@@ -187,6 +232,56 @@ describe('HomeFeedSidebar', () => {
     render(<HomeFeedSidebar />);
 
     expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'all');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-hidden', 'false');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-input-disabled', 'true');
+  });
+
+  it('keeps Network selected when logged out because it aliases the public All stream', () => {
+    mockCurrentUserPubky.value = null;
+    mockUseHomeStore.mockReturnValue({
+      layout: 'columns',
+      setLayout: vi.fn(),
+      reach: 'network',
+      setReach: mockSetReach,
+      sort: 'timeline',
+      setSort: vi.fn(),
+      content: 'all',
+      setContent: mockSetContent,
+      profileTags: [],
+      profileTagScope: 'network',
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+      setProfileTagScope: mockSetProfileTagScope,
+    });
+
+    render(<HomeFeedSidebar />);
+
+    expect(screen.getByTestId('filter-reach')).toHaveAttribute('data-selected-tab', 'network');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-hidden', 'false');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-input-disabled', 'true');
+  });
+
+  it('hides Tagged as only for Me reach', () => {
+    mockUseHomeStore.mockReturnValue({
+      layout: 'columns',
+      setLayout: vi.fn(),
+      reach: 'me',
+      setReach: mockSetReach,
+      sort: 'timeline',
+      setSort: vi.fn(),
+      content: 'all',
+      setContent: mockSetContent,
+      profileTags: ['bitcoiner'],
+      profileTagScope: 'following',
+      addProfileTag: vi.fn(),
+      removeProfileTag: vi.fn(),
+      setProfileTagScope: mockSetProfileTagScope,
+    });
+
+    render(<HomeFeedSidebar />);
+
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-hidden', 'true');
+    expect(screen.getByTestId('filter-profile-tags')).toHaveAttribute('data-scope', 'following');
   });
 });
 

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx.snap
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.test.tsx.snap
@@ -7,10 +7,23 @@ exports[`HomeFeedDrawer - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
-      data-selected-tab="following"
-      data-testid="filter-reach"
+      class="flex flex-col transition-[gap] duration-100 gap-6"
+      data-testid="container"
     >
-      FilterReach
+      <div
+        data-selected-tab="following"
+        data-testid="filter-reach"
+      >
+        FilterReach
+      </div>
+      <div
+        data-hidden="false"
+        data-input-disabled="false"
+        data-scope="network"
+        data-testid="filter-profile-tags"
+      >
+        FilterProfileTags
+      </div>
     </div>
     <div
       data-testid="filter-sort"
@@ -40,10 +53,23 @@ exports[`HomeFeedDrawerMobile - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
-      data-selected-tab="following"
-      data-testid="filter-reach"
+      class="flex flex-col transition-[gap] duration-100 gap-6"
+      data-testid="container"
     >
-      FilterReach
+      <div
+        data-selected-tab="following"
+        data-testid="filter-reach"
+      >
+        FilterReach
+      </div>
+      <div
+        data-hidden="false"
+        data-input-disabled="false"
+        data-scope="network"
+        data-testid="filter-profile-tags"
+      >
+        FilterProfileTags
+      </div>
     </div>
     <div
       data-testid="filter-sort"
@@ -67,10 +93,23 @@ exports[`HomeFeedSidebar - Snapshots > matches snapshot 1`] = `
     data-testid="container"
   >
     <div
-      data-selected-tab="following"
-      data-testid="filter-reach"
+      class="flex flex-col transition-[gap] duration-100 gap-6"
+      data-testid="container"
     >
-      FilterReach
+      <div
+        data-selected-tab="following"
+        data-testid="filter-reach"
+      >
+        FilterReach
+      </div>
+      <div
+        data-hidden="false"
+        data-input-disabled="false"
+        data-scope="network"
+        data-testid="filter-profile-tags"
+      >
+        FilterProfileTags
+      </div>
     </div>
     <div
       data-testid="filter-sort"

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
@@ -4,8 +4,10 @@ import { Container } from '@/atoms/Container/Container';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
 import { useRequireAuth } from '@/hooks/useRequireAuth/useRequireAuth';
+import { cn } from '@/libs/utils/utils';
 import { FilterContent } from '@/molecules/Filters/FilterContent/FilterContent';
 import { FilterLayout } from '@/molecules/Filters/FilterLayout/FilterLayout';
+import { FilterProfileTags } from '@/molecules/Filters/FilterProfileTags/FilterProfileTags';
 import { FilterReach } from '@/molecules/Filters/FilterReach/FilterReach';
 import { FilterSort } from '@/molecules/Filters/FilterSort/FilterSort';
 import { useAuthStore } from '@/stores/auth/auth.store';
@@ -33,20 +35,38 @@ function HomeFeedFilters({
   feedVariant = TIMELINE_FEED_VARIANT.HOME,
   variant = 'drawer',
 }: HomeFeedSidebarProps) {
-  const { layout, setLayout, reach, setReach, sort, setSort, content, setContent } = useHomeStore();
+  const {
+    layout,
+    setLayout,
+    reach,
+    setReach,
+    sort,
+    setSort,
+    content,
+    setContent,
+    profileTags,
+    profileTagScope,
+    addProfileTag,
+    removeProfileTag,
+    setProfileTagScope,
+  } = useHomeStore();
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const { requireAuth } = useRequireAuth();
   const isAuthenticated = Boolean(currentUserPubky);
-  const effectiveReach = isAuthenticated ? reach : REACH.ALL;
+  const effectiveReach = isAuthenticated || reach === REACH.NETWORK ? reach : REACH.ALL;
+  const showProfileTags = effectiveReach !== REACH.ME;
   const { isPhoneViewport, isVisualActive } = useFeedLayoutResolution(feedVariant);
 
-  // "All" reach is public; "Following"/"Friends" require an account, so prompt Join Pubky in Explore mode.
+  // ALL and its temporary NETWORK alias are public. Personalized reaches require an account.
   const handleReachChange = (value: ReachType) => {
-    if (value === REACH.ALL) {
+    if (value === REACH.ALL || value === REACH.NETWORK) {
       setReach(value);
       return;
     }
     requireAuth(() => setReach(value));
+  };
+  const handleProfileTagAdd = (tag: string) => {
+    requireAuth(() => addProfileTag(tag));
   };
   const resolvedContent = resolveVisualFeedContent({
     content,
@@ -59,7 +79,24 @@ function HomeFeedFilters({
 
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
-      {!hideReachFilter && <FilterReach selectedTab={effectiveReach} onTabChange={handleReachChange} />}
+      {!hideReachFilter && (
+        <Container
+          overrideDefaults
+          className={cn('flex flex-col transition-[gap] duration-100', showProfileTags ? 'gap-6' : 'gap-0')}
+        >
+          <FilterReach selectedTab={effectiveReach} onTabChange={handleReachChange} />
+          <FilterProfileTags
+            selectedTags={isAuthenticated ? profileTags : []}
+            onTagAdd={handleProfileTagAdd}
+            onTagRemove={removeProfileTag}
+            scope={profileTagScope}
+            onScopeChange={setProfileTagScope}
+            hidden={!showProfileTags}
+            inputDisabled={!isAuthenticated}
+            onInputClick={() => requireAuth(() => undefined)}
+          />
+        </Container>
+      )}
       <FilterSort selectedTab={sort} onTabChange={setSort} />
       {variant === 'sidebar' ? (
         <Container overrideDefaults className="sticky top-[100px] flex w-full flex-col gap-6 self-start">

--- a/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
+++ b/src/components/organisms/HomeFeedSidebar/HomeFeedSidebar.tsx
@@ -53,13 +53,13 @@ function HomeFeedFilters({
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const { requireAuth } = useRequireAuth();
   const isAuthenticated = Boolean(currentUserPubky);
-  const effectiveReach = isAuthenticated || reach === REACH.NETWORK ? reach : REACH.ALL;
+  const effectiveReach = isAuthenticated ? reach : REACH.ALL;
   const showProfileTags = effectiveReach !== REACH.ME;
   const { isPhoneViewport, isVisualActive } = useFeedLayoutResolution(feedVariant);
 
-  // ALL and its temporary NETWORK alias are public. Personalized reaches require an account.
+  // ALL is public. Personalized reaches require an account.
   const handleReachChange = (value: ReachType) => {
-    if (value === REACH.ALL || value === REACH.NETWORK) {
+    if (value === REACH.ALL) {
       setReach(value);
       return;
     }

--- a/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
+++ b/src/components/organisms/HotFeedFilters/HotFeedFilters.tsx
@@ -88,13 +88,13 @@ export function FilterTimeframe({ selectedTab = TIMEFRAME.THIS_MONTH, onTabChang
 /**
  * useGatedReachChange
  *
- * "All" reach is public; "Following"/"Friends" require an account, so prompt
+ * "All" and its temporary "Network" alias are public; personalized reaches prompt
  * Join Pubky in Explore mode (logged out) instead of changing the reach.
  */
 function useGatedReachChange(setReach: (reach: ReachType) => void) {
   const { requireAuth } = useRequireAuth();
   return (value: ReachType) => {
-    if (value === REACH.ALL) {
+    if (value === REACH.ALL || value === REACH.NETWORK) {
       setReach(value);
       return;
     }
@@ -113,7 +113,7 @@ export function HotFeedSidebar() {
   const { reach, setReach, timeframe, setTimeframe } = useHotStore();
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const isAuthenticated = Boolean(currentUserPubky);
-  const effectiveReach = isAuthenticated ? reach : REACH.ALL;
+  const effectiveReach = isAuthenticated || reach === REACH.NETWORK ? reach : REACH.ALL;
 
   const handleReachChange = useGatedReachChange(setReach);
 
@@ -137,7 +137,7 @@ export function HotFeedDrawer() {
   const { reach, setReach, timeframe, setTimeframe } = useHotStore();
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
   const isAuthenticated = Boolean(currentUserPubky);
-  const effectiveReach = isAuthenticated ? reach : REACH.ALL;
+  const effectiveReach = isAuthenticated || reach === REACH.NETWORK ? reach : REACH.ALL;
 
   const handleReachChange = useGatedReachChange(setReach);
 

--- a/src/components/organisms/PostHeader/PostHeader.test.tsx
+++ b/src/components/organisms/PostHeader/PostHeader.test.tsx
@@ -113,6 +113,12 @@ vi.mock('@/molecules/PostHeaderUserInfo/PostHeaderUserInfo', () => {
   };
 });
 
+vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
+  AvatarWithFallback: vi.fn(({ fallbackSeed, size, 'data-testid': dataTestId }) => (
+    <div data-testid={dataTestId} data-fallback-seed={fallbackSeed} data-size={size} />
+  )),
+}));
+
 // Use real libs - use actual implementations
 
 const mockUsePostDetails = vi.mocked(usePostDetails);
@@ -190,6 +196,18 @@ describe('PostHeader', () => {
     renderPostHeader(<PostHeader postId="userpubkykey:post456" isReplyInput={true} />);
 
     expect(screen.getAllByRole('generic').some((el) => el.getAttribute('data-slot') === 'skeleton')).toBe(true);
+  });
+
+  it('renders only an avatar for the minimal new-post header state', () => {
+    mockUsePostDetails.mockReturnValue({ postDetails: null, isLoading: false });
+    mockUseUserDetails.mockReturnValue({ userDetails: null, isLoading: false });
+    mockUseAvatarUrl.mockReturnValue(undefined);
+
+    renderPostHeader(<PostHeader postId="userpubkykey" isReplyInput avatarOnly />);
+
+    expect(screen.getByTestId('post-header-avatar')).toHaveAttribute('data-fallback-seed', 'userpubkykey');
+    expect(screen.queryByTestId('post-header-user-info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test User')).not.toBeInTheDocument();
   });
 
   it('passes size prop to PostHeaderUserInfo', () => {

--- a/src/components/organisms/PostHeader/PostHeader.tsx
+++ b/src/components/organisms/PostHeader/PostHeader.tsx
@@ -7,6 +7,7 @@ import { useRelativeTime } from '@/hooks/useRelativeTime/useRelativeTime';
 import { useUserDetails } from '@/hooks/useUserDetails/useUserDetails';
 import { PostHeaderTimestamp } from '@/molecules/PostHeaderTimestamp/PostHeaderTimestamp';
 import { PostHeaderUserInfo } from '@/molecules/PostHeaderUserInfo/PostHeaderUserInfo';
+import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
 import { PostHeaderSkeleton } from './PostHeader.skeleton';
 import type { PostHeaderProps } from './PostHeader.types';
 
@@ -17,6 +18,7 @@ export function PostHeader({
   showPopover = true,
   size = 'normal',
   timeAgoPlacement = 'top-right',
+  avatarOnly = false,
 }: PostHeaderProps) {
   // Extract userId from postId (format: userId:postId or just userId if isReplyInput is true)
   const userId = isReplyInput ? postId : postId.split(':')[0];
@@ -33,6 +35,18 @@ export function PostHeader({
   const { formatRelativeTime } = useRelativeTime();
 
   const isLoading = !userDetails || (!isReplyInput && !postDetails);
+
+  if (avatarOnly) {
+    return (
+      <AvatarWithFallback
+        avatarUrl={avatarUrl}
+        name={userDetails?.name ?? ''}
+        fallbackSeed={userId}
+        size={size === 'large' ? 'xl' : 'default'}
+        data-testid="post-header-avatar"
+      />
+    );
+  }
 
   if (isLoading) {
     return <PostHeaderSkeleton />;

--- a/src/components/organisms/PostHeader/PostHeader.types.ts
+++ b/src/components/organisms/PostHeader/PostHeader.types.ts
@@ -8,4 +8,5 @@ export interface PostHeaderProps {
   showPopover?: boolean;
   size?: 'normal' | 'large';
   timeAgoPlacement?: 'top-right' | 'bottom-left';
+  avatarOnly?: boolean;
 }

--- a/src/components/organisms/PostInput/PostInput.test.tsx
+++ b/src/components/organisms/PostInput/PostInput.test.tsx
@@ -153,7 +153,7 @@ vi.mock('@/atoms/Typography/Typography', () => {
 
 vi.mock('@/organisms/PostHeader/PostHeader', () => {
   return {
-    PostHeader: vi.fn(({ postId, isReplyInput, characterLimit, size }) => (
+    PostHeader: vi.fn(({ postId, isReplyInput, characterLimit, size, avatarOnly }) => (
       <div
         data-testid="post-header"
         data-post-id={postId}
@@ -161,6 +161,7 @@ vi.mock('@/organisms/PostHeader/PostHeader', () => {
         data-count={characterLimit?.count}
         data-max={characterLimit?.max}
         data-size={size}
+        data-avatar-only={avatarOnly ? 'true' : 'false'}
       />
     )),
   };
@@ -540,8 +541,23 @@ describe('PostInput', () => {
     render(<PostInput variant={POST_INPUT_VARIANT.POST} />);
 
     expect(screen.getByTestId('post-header')).toBeInTheDocument();
+    expect(screen.getByTestId('post-header')).toHaveAttribute('data-avatar-only', 'false');
     expect(screen.getByTestId('textarea')).toBeInTheDocument();
     expect(screen.getByPlaceholderText("What's on your mind?")).toBeInTheDocument();
+  });
+
+  it('uses the minimal avatar and prompt layout for a collapsed new post', () => {
+    mockUsePostInput.mockImplementationOnce((options: UsePostInputOptions) =>
+      createUsePostInputReturn(options, { isExpanded: false }),
+    );
+
+    render(<PostInput variant={POST_INPUT_VARIANT.POST} />);
+
+    expect(screen.getByTestId('post-header')).toHaveAttribute('data-avatar-only', 'true');
+    expect(screen.getByPlaceholderText("What's on your mind?")).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId('container').find((container) => container.className.includes('contain-inline-size')),
+    ).toHaveClass('flex-row', 'items-center');
   });
 
   it('passes characterLimit to header and action bar for non-article mode', () => {
@@ -912,7 +928,7 @@ describe('PostInput', () => {
       render(<PostInput variant={POST_INPUT_VARIANT.POST} />);
 
       const outerContainer = screen.getAllByTestId('container')[0];
-      expect(outerContainer.className).toContain('p-4');
+      expect(outerContainer.className).toContain('p-6');
       expect(outerContainer.className).not.toContain('p-12');
 
       const postHeader = screen.getByTestId('post-header');
@@ -930,7 +946,7 @@ describe('PostInput', () => {
 
       const outerContainer = screen.getAllByTestId('container')[0];
       expect(outerContainer.className).toContain('p-12');
-      expect(outerContainer.className).not.toContain('p-4');
+      expect(outerContainer.className).not.toContain('p-6');
 
       const postHeader = screen.getByTestId('post-header');
       expect(postHeader).toHaveAttribute('data-size', 'large');
@@ -961,7 +977,7 @@ describe('PostInput', () => {
       );
 
       const outerContainer = screen.getAllByTestId('container')[0];
-      expect(outerContainer.className).toContain('p-4');
+      expect(outerContainer.className).toContain('p-6');
       expect(outerContainer.className).not.toContain('p-12');
 
       const postHeader = screen.getByTestId('post-header');

--- a/src/components/organisms/PostInput/PostInput.test.tsx.snap
+++ b/src/components/organisms/PostInput/PostInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostInput - Mobile Snapshots > matches snapshot on mobile viewport 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -10,6 +10,7 @@ exports[`PostInput - Mobile Snapshots > matches snapshot on mobile viewport 1`] 
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -95,7 +96,7 @@ exports[`PostInput - Mobile Snapshots > matches snapshot on mobile viewport 1`] 
 
 exports[`PostInput - Snapshots > matches snapshot for article mode 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -109,6 +110,7 @@ exports[`PostInput - Snapshots > matches snapshot for article mode 1`] = `
       value="Test Article Title"
     />
     <div
+      data-avatar-only="false"
       data-is-reply="true"
       data-post-id="test-user-id:pubkey"
       data-size="normal"
@@ -186,7 +188,7 @@ exports[`PostInput - Snapshots > matches snapshot for article mode 1`] = `
 
 exports[`PostInput - Snapshots > matches snapshot for edit variant 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -194,6 +196,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant 1`] = `
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="21"
       data-is-reply="true"
       data-max="2000"
@@ -269,7 +272,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant 1`] = `
 
 exports[`PostInput - Snapshots > matches snapshot for edit variant with article mode 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -283,6 +286,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant with article 
       value="Existing Article Title"
     />
     <div
+      data-avatar-only="false"
       data-is-reply="true"
       data-post-id="test-user-id:pubkey"
       data-size="normal"
@@ -349,7 +353,7 @@ exports[`PostInput - Snapshots > matches snapshot for edit variant with article 
 
 exports[`PostInput - Snapshots > matches snapshot for post variant when dragging 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-brand"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-brand"
   data-testid="container"
 >
   <div
@@ -369,6 +373,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when dragging
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -454,7 +459,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when dragging
 
 exports[`PostInput - Snapshots > matches snapshot for post variant when submitting 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -462,6 +467,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when submitti
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -548,7 +554,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant when submitti
 
 exports[`PostInput - Snapshots > matches snapshot for post variant with attachments 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -556,6 +562,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with attachme
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -645,7 +652,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with attachme
 
 exports[`PostInput - Snapshots > matches snapshot for post variant with content 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -653,6 +660,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with content 
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="12"
       data-is-reply="true"
       data-max="2000"
@@ -739,7 +747,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with content 
 
 exports[`PostInput - Snapshots > matches snapshot for post variant with custom placeholder 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -747,6 +755,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant with custom p
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -840,6 +849,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant without conte
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -926,7 +936,7 @@ exports[`PostInput - Snapshots > matches snapshot for post variant without conte
 
 exports[`PostInput - Snapshots > matches snapshot for reply variant without content or attachments 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -934,6 +944,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply variant without cont
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -1019,7 +1030,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply variant without cont
 
 exports[`PostInput - Snapshots > matches snapshot for reply with thread connector 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -1031,6 +1042,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply with thread connecto
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"
@@ -1116,7 +1128,7 @@ exports[`PostInput - Snapshots > matches snapshot for reply with thread connecto
 
 exports[`PostInput - Snapshots > matches snapshot for repost variant without content or attachments 1`] = `
 <div
-  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-4 border-input"
+  class="relative cursor-pointer rounded-md border border-dashed transition-colors duration-200 max-w-full min-w-0 p-6 border-input"
   data-testid="container"
 >
   <div
@@ -1124,6 +1136,7 @@ exports[`PostInput - Snapshots > matches snapshot for repost variant without con
     data-testid="container"
   >
     <div
+      data-avatar-only="false"
       data-count="0"
       data-is-reply="true"
       data-max="2000"

--- a/src/components/organisms/PostInput/PostInput.tsx
+++ b/src/components/organisms/PostInput/PostInput.tsx
@@ -197,6 +197,14 @@ export function PostInput({
   const characterLimit = isArticle ? undefined : { count: getCharacterCount(content), max: POST_MAX_CHARACTER_LENGTH };
 
   const isWideLayout = usesWidePostInput(useEffectiveTagsLayout());
+  const isMinimalNewPost =
+    variant === POST_INPUT_VARIANT.POST &&
+    !isExpanded &&
+    !isArticle &&
+    !isDragging &&
+    content.trim().length === 0 &&
+    attachments.length === 0 &&
+    tags.length === 0;
 
   return (
     <Container
@@ -206,8 +214,7 @@ export function PostInput({
       className={cn(
         'relative cursor-pointer rounded-md border border-dashed transition-colors duration-200',
         'max-w-full min-w-0',
-        isWideLayout ? 'p-12' : 'p-4',
-        !isAuthenticated ? 'px-6' : '',
+        isWideLayout ? 'p-12' : 'p-6',
         isDragging ? 'border-brand' : 'border-input',
       )}
       onClick={handleExpandWithAuth}
@@ -227,7 +234,7 @@ export function PostInput({
       )}
 
       {showThreadConnector && <PostThreadConnector variant={POST_THREAD_CONNECTOR_VARIANTS.DIALOG_REPLY} />}
-      <Container className="min-w-0 gap-4 contain-inline-size">
+      <Container className={cn('min-w-0 gap-4 contain-inline-size', isMinimalNewPost && 'flex-row items-center')}>
         {isArticle && (
           <Input
             placeholder={t('articleTitle')}
@@ -246,6 +253,7 @@ export function PostInput({
             characterLimit={characterLimit}
             showPopover={false}
             size={isWideLayout ? 'large' : 'normal'}
+            avatarOnly={isMinimalNewPost}
           />
         )}
 

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx
@@ -10,11 +10,6 @@ type BaseFilterMockProps = {
   disabled?: boolean;
   onTabChange?: (tab: string) => void;
 };
-const mockFilterReach = vi.fn(({ disabled }: BaseFilterMockProps) => (
-  <div data-testid="filter-reach" data-disabled={disabled ? 'true' : 'false'}>
-    FilterReach
-  </div>
-));
 const mockFilterSort = vi.fn(({ disabled }: BaseFilterMockProps) => (
   <div data-testid="filter-sort" data-disabled={disabled ? 'true' : 'false'}>
     FilterSort
@@ -50,10 +45,6 @@ vi.mock('@/atoms/Container/Container', () => ({
   ),
 }));
 
-vi.mock('@/molecules/Filters/FilterReach/FilterReach', () => ({
-  FilterReach: (props: BaseFilterMockProps) => mockFilterReach(props),
-}));
-
 vi.mock('@/molecules/Filters/FilterSort/FilterSort', () => ({
   FilterSort: (props: BaseFilterMockProps) => mockFilterSort(props),
 }));
@@ -70,7 +61,6 @@ vi.mock('@/molecules/Filters/FilterLayout/FilterLayout', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mockSetLayout.mockClear();
-  mockFilterReach.mockClear();
   mockFilterSort.mockClear();
   mockFilterContent.mockClear();
   mockFilterLayout.mockClear();
@@ -81,14 +71,13 @@ beforeEach(() => {
 });
 
 describe('SinglePostLeftSidebar', () => {
-  it('renders only the layout filter', () => {
+  it('renders the remaining filters without Reach', () => {
     render(<SinglePostLeftSidebar />);
 
     expect(screen.getByTestId('filter-layout')).toBeInTheDocument();
-    expect(screen.queryByTestId('filter-reach')).toBeInTheDocument();
+    expect(screen.queryByTestId('filter-reach')).not.toBeInTheDocument();
     expect(screen.queryByTestId('filter-sort')).toBeInTheDocument();
     expect(screen.queryByTestId('filter-content')).toBeInTheDocument();
-    expect(mockFilterReach).toHaveBeenCalled();
     expect(mockFilterSort).toHaveBeenCalled();
     expect(mockFilterContent).toHaveBeenCalled();
   });
@@ -119,10 +108,9 @@ describe('SinglePostLeftDrawer', () => {
     render(<SinglePostLeftDrawer />);
 
     expect(screen.getByTestId('filter-layout')).toBeInTheDocument();
-    expect(screen.queryByTestId('filter-reach')).toBeInTheDocument();
+    expect(screen.queryByTestId('filter-reach')).not.toBeInTheDocument();
     expect(screen.queryByTestId('filter-sort')).toBeInTheDocument();
     expect(screen.queryByTestId('filter-content')).toBeInTheDocument();
-    expect(mockFilterReach).toHaveBeenCalled();
     expect(mockFilterSort).toHaveBeenCalled();
     expect(mockFilterContent).toHaveBeenCalled();
   });
@@ -152,11 +140,10 @@ describe('SinglePostLeftDrawerMobile', () => {
     render(<SinglePostLeftDrawerMobile />);
 
     expect(screen.queryByTestId('filter-layout')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('filter-reach')).toBeInTheDocument();
+    expect(screen.queryByTestId('filter-reach')).not.toBeInTheDocument();
     expect(screen.queryByTestId('filter-sort')).toBeInTheDocument();
     expect(screen.queryByTestId('filter-content')).toBeInTheDocument();
     expect(mockFilterLayout).not.toHaveBeenCalled();
-    expect(mockFilterReach).toHaveBeenCalled();
     expect(mockFilterSort).toHaveBeenCalled();
     expect(mockFilterContent).toHaveBeenCalled();
   });

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx.snap
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.test.tsx.snap
@@ -8,12 +8,6 @@ exports[`SinglePostLeftDrawer > matches snapshot 1`] = `
   >
     <div
       data-disabled="true"
-      data-testid="filter-reach"
-    >
-      FilterReach
-    </div>
-    <div
-      data-disabled="true"
       data-testid="filter-sort"
     >
       FilterSort
@@ -46,12 +40,6 @@ exports[`SinglePostLeftDrawerMobile > matches snapshot 1`] = `
   >
     <div
       data-disabled="true"
-      data-testid="filter-reach"
-    >
-      FilterReach
-    </div>
-    <div
-      data-disabled="true"
       data-testid="filter-sort"
     >
       FilterSort
@@ -72,12 +60,6 @@ exports[`SinglePostLeftSidebar > matches snapshot 1`] = `
     class="flex flex-col gap-6"
     data-testid="container"
   >
-    <div
-      data-disabled="true"
-      data-testid="filter-reach"
-    >
-      FilterReach
-    </div>
     <div
       data-disabled="true"
       data-testid="filter-sort"

--- a/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
+++ b/src/components/organisms/SinglePostLeftSidebar/SinglePostLeftSidebar.tsx
@@ -2,21 +2,19 @@
 import { Container } from '@/atoms/Container/Container';
 import { FilterContent } from '@/molecules/Filters/FilterContent/FilterContent';
 import { FilterLayout } from '@/molecules/Filters/FilterLayout/FilterLayout';
-import { FilterReach } from '@/molecules/Filters/FilterReach/FilterReach';
 import { FilterSort } from '@/molecules/Filters/FilterSort/FilterSort';
 import { useHomeStore } from '@/stores/home/home.store';
 
 /**
  * SinglePostFilters
  *
- * Base filter set for SinglePost page left panels (reach, sort, content).
+ * Base filter set for SinglePost page left panels (sort and content).
  * Layout-aware variants render the layout filter via a separate child so this
  * shared shell stays free of any store subscription.
  */
 function SinglePostFilters({ children }: { children?: React.ReactNode }) {
   return (
     <Container overrideDefaults className="flex flex-col gap-6">
-      <FilterReach selectedTab={undefined} defaultSelectedTab={undefined} disabled />
       <FilterSort selectedTab={undefined} defaultSelectedTab={undefined} disabled />
       {children}
       <FilterContent selectedTab={undefined} defaultSelectedTab={undefined} disabled />

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/models/stream/post/postStream.types';
 import { ProfileProvider } from '@/providers/ProfileProvider/ProfileProvider';
 import { useHomeStore } from '@/stores/home/home.store';
-import { CONTENT, type ContentType, LAYOUT, REACH, SORT } from '@/stores/home/home.types';
+import { CONTENT, type ContentType, LAYOUT, PROFILE_TAG_SCOPE, REACH, SORT } from '@/stores/home/home.types';
 import { asInvalid } from '@/test-utils/type-assertions';
 import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
 import { TimelineFeed, useTimelineFeedContext } from './TimelineFeed';
@@ -266,6 +266,8 @@ describe('TimelineFeed', () => {
       sort: SORT.TIMELINE,
       reach: REACH.ALL,
       content: CONTENT.ALL,
+      profileTags: [],
+      profileTagScope: PROFILE_TAG_SCOPE.NETWORK,
     });
 
     // Default mock implementations
@@ -327,6 +329,90 @@ describe('TimelineFeed', () => {
 
       expect(screen.getByTestId('child-component')).toBeInTheDocument();
       expect(screen.getByTestId('timeline-posts')).toBeInTheDocument();
+    });
+
+    it.each([
+      {
+        reach: REACH.ALL,
+        summary: 'Posts from anyone tagged as ‘bitcoiner’ by my network',
+      },
+      {
+        reach: REACH.FRIENDS,
+        summary: 'Posts from friends tagged as ‘bitcoiner’ by my network',
+      },
+      {
+        reach: REACH.FOLLOWING,
+        summary: 'Posts from people I follow tagged as ‘bitcoiner’ by my network',
+      },
+      {
+        reach: REACH.NETWORK,
+        summary: 'Posts from people in my network tagged as ‘bitcoiner’ by my network',
+      },
+    ])('shows the profile-tag summary for $reach Reach', ({ reach, summary }) => {
+      useHomeStore.setState({ reach, profileTags: ['bitcoiner'] });
+
+      render(<TimelineFeed variant={TIMELINE_FEED_VARIANT.HOME} />);
+
+      const heading = screen.getByRole('heading', { level: 2, name: summary });
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveClass('text-2xl');
+      expect(
+        heading.compareDocumentPosition(screen.getByTestId('timeline-posts')) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    it.each([
+      {
+        profileTagScope: PROFILE_TAG_SCOPE.NETWORK,
+        summary: 'Posts from friends tagged as ‘bitcoiner’ by my network',
+      },
+      {
+        profileTagScope: PROFILE_TAG_SCOPE.FOLLOWING,
+        summary: 'Posts from friends tagged as ‘bitcoiner’ by people I follow',
+      },
+      {
+        profileTagScope: PROFILE_TAG_SCOPE.ME,
+        summary: 'Posts from friends tagged as ‘bitcoiner’ by me',
+      },
+    ])('reflects the $profileTagScope profile-tag curator', ({ profileTagScope, summary }) => {
+      useHomeStore.setState({
+        reach: REACH.FRIENDS,
+        profileTags: ['bitcoiner'],
+        profileTagScope,
+      });
+
+      render(<TimelineFeed variant={TIMELINE_FEED_VARIANT.HOME} />);
+
+      expect(screen.getByRole('heading', { level: 2, name: summary })).toBeInTheDocument();
+    });
+
+    it('summarizes multiple profile tags with OR semantics', () => {
+      useHomeStore.setState({ reach: REACH.NETWORK, profileTags: ['bitcoiner', 'developer'] });
+
+      render(<TimelineFeed variant={TIMELINE_FEED_VARIANT.HOME} />);
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: 'Posts from people in my network tagged as ‘bitcoiner’ or ‘developer’ by my network',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show a profile-tag summary for Me Reach', () => {
+      useHomeStore.setState({ reach: REACH.ME, profileTags: ['bitcoiner'] });
+
+      render(<TimelineFeed variant={TIMELINE_FEED_VARIANT.HOME} />);
+
+      expect(screen.queryByText(/tagged as/)).not.toBeInTheDocument();
+    });
+
+    it('does not show a profile-tag summary without an applied tag', () => {
+      useHomeStore.setState({ reach: REACH.NETWORK, profileTags: [] });
+
+      render(<TimelineFeed variant={TIMELINE_FEED_VARIANT.HOME} />);
+
+      expect(screen.queryByText(/Posts from people/)).not.toBeInTheDocument();
     });
 
     it('should render the visual renderer when visual layout is active', () => {

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/TimelineFeed.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { Heading } from '@/atoms/Heading/Heading';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
 import { useCustomStreamId } from '@/hooks/useCustomStreamId/useCustomStreamId';
 import { useFeedLayoutResolution } from '@/hooks/useFeedLayoutResolution/useFeedLayoutResolution';
@@ -20,6 +22,7 @@ import { getTagsLayoutForSurfaceLayout } from '@/organisms/PostMain/PostMainLayo
 import { useProfileContext } from '@/providers/ProfileProvider/ProfileProvider';
 import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
 import { useHomeStore } from '@/stores/home/home.store';
+import { REACH } from '@/stores/home/home.types';
 import { TimelineFeedWithStream } from '../TimelineFeedContent/TimelineFeedContent';
 import type { TimelineFeedProps } from './TimelineFeed.types';
 import { resolveVisualFeedContent } from './TimelineFeedVisual.helpers';
@@ -91,9 +94,35 @@ function HomeTimelineFeed({ children }: { children?: TimelineFeedProps['children
       variant={TIMELINE_FEED_VARIANT.HOME}
       tagsLayout={tagsLayout}
       layoutResolution={layoutResolution}
+      feedHeader={<HomeProfileTagSummary />}
     >
       {children}
     </TimelineFeedWithStream>
+  );
+}
+
+function HomeProfileTagSummary() {
+  const locale = useLocale();
+  const t = useTranslations('filters.reach.profileTagSummary');
+  const reach = useHomeStore((state) => state.reach);
+  const profileTags = useHomeStore((state) => state.profileTags);
+  const profileTagScope = useHomeStore((state) => state.profileTagScope);
+
+  if (profileTags.length === 0 || reach === REACH.ME) {
+    return null;
+  }
+
+  const tags = new Intl.ListFormat(locale, { style: 'long', type: 'disjunction' }).format(
+    profileTags.map((tag) => `‘${tag}’`),
+  );
+
+  return (
+    <Heading level={2} size="sm" className="text-2xl font-light text-muted-foreground">
+      {t(`reach.${reach}`, {
+        curator: t(`curator.${profileTagScope}`),
+        tags,
+      })}
+    </Heading>
   );
 }
 

--- a/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeedContent/TimelineFeedContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { MuteFilter } from '@/application/stream/posts/muting/mute-filter';
 import { Container } from '@/atoms/Container/Container';
 import { TIMELINE_FEED_VARIANT } from '@/config/feed';
@@ -37,6 +37,7 @@ interface TimelineFeedContentProps {
   collectionId?: TimelineFeedContextValue['collectionId'];
   pullToRefreshContainerRef?: TimelineFeedProps['pullToRefreshContainerRef'];
   gridTrailingSlot?: TimelineFeedGridTrailingSlot;
+  feedHeader?: ReactNode;
 }
 
 interface TimelineFeedWithStreamProps {
@@ -49,6 +50,7 @@ interface TimelineFeedWithStreamProps {
   collectionId?: TimelineFeedContextValue['collectionId'];
   pullToRefreshContainerRef?: TimelineFeedProps['pullToRefreshContainerRef'];
   gridTrailingSlot?: TimelineFeedGridTrailingSlot;
+  feedHeader?: ReactNode;
 }
 
 /**
@@ -67,6 +69,7 @@ export function TimelineFeedWithStream({
   collectionId,
   pullToRefreshContainerRef,
   gridTrailingSlot,
+  feedHeader,
 }: TimelineFeedWithStreamProps) {
   if (!streamId) {
     return <TimelineLoading />;
@@ -82,6 +85,7 @@ export function TimelineFeedWithStream({
       collectionId={collectionId}
       pullToRefreshContainerRef={pullToRefreshContainerRef}
       gridTrailingSlot={gridTrailingSlot}
+      feedHeader={feedHeader}
     >
       {children}
     </TimelineFeedContent>
@@ -111,6 +115,7 @@ function TimelineFeedContent({
   collectionId,
   pullToRefreshContainerRef,
   gridTrailingSlot,
+  feedHeader,
 }: TimelineFeedContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const refreshContainerRef = pullToRefreshContainerRef ?? containerRef;
@@ -212,6 +217,7 @@ function TimelineFeedContent({
         <Container ref={containerRef} className="min-w-0 flex-1 gap-6 lg:overflow-hidden">
           {enablePullToRefresh && <PullToRefreshIndicator state={pullState} pullDistance={pullDistance} />}
           {shouldRenderChildren ? children : null}
+          {feedHeader}
           <NewPostsSection
             streamId={streamId}
             variant={variant}

--- a/src/core/application/user/user.types.ts
+++ b/src/core/application/user/user.types.ts
@@ -1,6 +1,6 @@
 import type { TFollowParams } from '@/controllers/user/user.type';
 import { HttpMethod } from '@/libs/http/http.types';
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import type { PostStreamId } from '@/models/stream/post/postStream.types';
 import type { UserCountsModel } from '@/models/user/counts/userCounts';
 import type { NexusUserCounts } from '@/services/nexus/nexus.types';
 
@@ -11,5 +11,5 @@ export type TUserApplicationFollowParams = TFollowParams & {
   eventType: HttpMethod;
   followUrl: string;
   followJson: Record<string, unknown>;
-  activeStreamId?: PostStreamTypes | null;
+  activeStreamId?: PostStreamId | null;
 };

--- a/src/core/controllers/auth/auth.test.ts
+++ b/src/core/controllers/auth/auth.test.ts
@@ -4,6 +4,7 @@ import { AuthApplication } from '@/application/auth/auth';
 import { BootstrapApplication } from '@/application/bootstrap/bootstrap';
 import { SettingsApplication } from '@/application/settings/settings';
 import { postStreamQueue } from '@/application/stream/posts/muting/post-stream-queue';
+import { UserApplication } from '@/application/user/user';
 import { MUTE_SYNC_CURSOR_STORAGE_PREFIX } from '@/config/mute-sync';
 import { NotificationCoordinator } from '@/coordinators/notifications/notifications';
 import { StreamCoordinator } from '@/coordinators/streams/stream';
@@ -23,6 +24,7 @@ import { SettingsNormalizer } from '@/pipes/settings/settings.normalizer';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import type { AuthStore } from '@/stores/auth/auth.types';
 import { useHomeStore } from '@/stores/home/home.store';
+import { REACH } from '@/stores/home/home.types';
 import { useHotStore } from '@/stores/hot/hot.store';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 import { useMigrationStore } from '@/stores/migration/migration.store';
@@ -151,6 +153,7 @@ const storeMocks = vi.hoisted(() => {
   const resetSearchStore = vi.fn();
   const resetNotificationStore = vi.fn();
   const resetSettingsStore = vi.fn();
+  const setHomeReach = vi.fn();
   const notificationInit = vi.fn();
   const initAuthStore = vi.fn();
   const setAuthUrlResolved = vi.fn();
@@ -190,7 +193,7 @@ const storeMocks = vi.hoisted(() => {
     error: null,
   });
   const localFilesStateFactory = () => ({ reset: resetLocalFilesStore });
-  const homeStateFactory = () => ({ reset: resetHomeStore });
+  const homeStateFactory = () => ({ reset: resetHomeStore, setReach: setHomeReach });
   const hotStateFactory = () => ({ reset: resetHotStore });
   const searchStateFactory = () => ({ reset: resetSearchStore });
   const settingsStateFactory = () => ({ reset: resetSettingsStore });
@@ -205,6 +208,7 @@ const storeMocks = vi.hoisted(() => {
     resetSearchStore,
     resetNotificationStore,
     resetSettingsStore,
+    setHomeReach,
     notificationInit,
     initAuthStore,
     setAuthUrlResolved,
@@ -336,6 +340,7 @@ describe('AuthController', () => {
         wasDbReset: false,
       }),
     );
+    vi.spyOn(UserApplication, 'getOrFetchCounts').mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -1093,6 +1098,56 @@ describe('AuthController', () => {
       expect(authStore.setHasProfile).toHaveBeenCalledWith(true);
     });
 
+    it.each([
+      { following: 2, expectedReach: REACH.ALL },
+      { following: 3, expectedReach: REACH.NETWORK },
+      { following: 4, expectedReach: REACH.NETWORK },
+    ])(
+      'should default Reach to $expectedReach when the signed-in user follows $following people',
+      async ({ following, expectedReach }) => {
+        const mockSession = buildMockSession();
+        const mockPubky = TEST_PUBKY as Pubky;
+
+        vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
+        vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(true);
+        vi.spyOn(BootstrapApplication, 'initialize').mockResolvedValue({
+          unread: 0,
+          lastRead: 0,
+          lastPolledTimestamp: 0,
+        });
+        vi.mocked(UserApplication.getOrFetchCounts).mockResolvedValue(asOpaque({ following }));
+
+        await AuthController.initializeAuthenticatedSession({ session: mockSession });
+
+        expect(UserApplication.getOrFetchCounts).toHaveBeenCalledWith({ userId: mockPubky });
+        expect(storeMocks.setHomeReach).toHaveBeenCalledWith(expectedReach);
+      },
+    );
+
+    it('should default Reach to All without blocking sign-in when user counts fail', async () => {
+      const mockSession = buildMockSession();
+      const mockPubky = TEST_PUBKY as Pubky;
+      const countsError = new Error('Local counts unavailable');
+      const warnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
+
+      vi.spyOn(Identity, 'z32FromSession').mockReturnValue(mockPubky);
+      vi.spyOn(AuthApplication, 'userIsSignedUp').mockResolvedValue(true);
+      vi.spyOn(BootstrapApplication, 'initialize').mockResolvedValue({
+        unread: 0,
+        lastRead: 0,
+        lastPolledTimestamp: 0,
+      });
+      vi.mocked(UserApplication.getOrFetchCounts).mockRejectedValue(countsError);
+
+      await expect(AuthController.initializeAuthenticatedSession({ session: mockSession })).resolves.toBeUndefined();
+
+      expect(storeMocks.setHomeReach).toHaveBeenCalledWith(REACH.ALL);
+      expect(warnSpy).toHaveBeenCalledWith('Failed to resolve default Reach after sign in', {
+        pubky: mockPubky,
+        error: countsError,
+      });
+    });
+
     it('should initialize session without bootstrap if user is not signed up', async () => {
       const mockSession = buildMockSession();
       const mockPubky = TEST_PUBKY as Pubky;
@@ -1114,6 +1169,7 @@ describe('AuthController', () => {
       expect(userIsSignedUpSpy).toHaveBeenCalledWith({ pubky: mockPubky });
       expect(signInStore.setProfileChecked).toHaveBeenCalledWith(true);
       expect(initializeSpy).not.toHaveBeenCalled();
+      expect(UserApplication.getOrFetchCounts).not.toHaveBeenCalled();
       // Session stored early with hasProfile: null, then setHasProfile called after check
       expect(authStore.init).toHaveBeenCalledWith({
         session: mockSession,

--- a/src/core/controllers/auth/auth.ts
+++ b/src/core/controllers/auth/auth.ts
@@ -4,6 +4,7 @@ import { BootstrapApplication, type BootstrapProgressCallback } from '@/applicat
 import { SettingsApplication } from '@/application/settings/settings';
 import { postStreamQueue } from '@/application/stream/posts/muting/post-stream-queue';
 import { TagApplication } from '@/application/tag/tag';
+import { UserApplication } from '@/application/user/user';
 import type {
   TLoginWithEncryptedFileParams,
   TLoginWithMnemonicParams,
@@ -28,6 +29,7 @@ import { SettingsNormalizer } from '@/pipes/settings/settings.normalizer';
 import type { TGenerateAuthUrlResult, THomeserverSessionResult } from '@/services/homeserver/homeserver.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
+import { HOME_NETWORK_REACH_MIN_FOLLOWING, REACH } from '@/stores/home/home.types';
 import { useHotStore } from '@/stores/hot/hot.store';
 import { useLocalFilesStore } from '@/stores/localFiles/localFiles.store';
 import { useMigrationStore } from '@/stores/migration/migration.store';
@@ -139,6 +141,17 @@ export class AuthController {
     }
   }
 
+  private static async setDefaultHomeReach(pubky: Pubky) {
+    try {
+      const counts = await UserApplication.getOrFetchCounts({ userId: pubky });
+      const reach = (counts?.following ?? 0) >= HOME_NETWORK_REACH_MIN_FOLLOWING ? REACH.NETWORK : REACH.ALL;
+      useHomeStore.getState().setReach(reach);
+    } catch (error) {
+      Logger.warn('Failed to resolve default Reach after sign in', { pubky, error });
+      useHomeStore.getState().setReach(REACH.ALL);
+    }
+  }
+
   /**
    * Initializes the authenticated session and checks if the user is signed up (profile.json in homeserver).
    * @param params - Object containing session data from authentication
@@ -162,6 +175,7 @@ export class AuthController {
 
       if (isSignedUp) {
         await this.hydrateMeImAlive({ pubky });
+        await this.setDefaultHomeReach(pubky);
       }
 
       // Update hasProfile after bootstrap completes - triggers redirect via useAuthStatus

--- a/src/core/controllers/user/user.ts
+++ b/src/core/controllers/user/user.ts
@@ -6,7 +6,7 @@ import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
 import { stripPubkyPrefix } from '@/libs/utils/utils';
 import type { Pubky } from '@/models/models.types';
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import type { PostStreamId } from '@/models/stream/post/postStream.types';
 import type { UserCountsModel } from '@/models/user/counts/userCounts';
 import type { UserRelationshipsModelSchema } from '@/models/user/relationships/userRelationships.schema';
 import { FollowNormalizer } from '@/pipes/follow/follow.normalizer';
@@ -195,7 +195,7 @@ export class UserController {
    *
    * @returns The active stream ID, or null if not on /home route or if retrieval fails
    */
-  private static getActiveStreamId(): PostStreamTypes | null {
+  private static getActiveStreamId(): PostStreamId | null {
     if (typeof window === 'undefined' || window.location.pathname !== '/home') {
       return null;
     }

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -100,6 +100,10 @@ export enum PostStreamTypes {
 export type ReplyStreamCompositeId = `${StreamSource.REPLIES}:${string}`;
 export type AuthorStreamCompositeId = `${StreamSource.AUTHOR}:${string}`;
 export type AuthorRepliesStreamCompositeId = `${StreamSource.AUTHOR_REPLIES}:${string}`;
+export type PostStreamKindSegment = 'all' | StreamKind;
+export type WotDomainDepth = 0 | 1 | 2;
+export type WotDomainStreamCompositeId =
+  `${StreamSorting}:${StreamSource.WOT_DOMAIN}:${WotDomainDepth}:${PostStreamKindSegment}:${string}`;
 
 // Collections feature (see `.plans/2026/may/collections-feature-foundation.md`).
 //
@@ -123,6 +127,16 @@ export type CollectionItemsStreamCompositeId = `${StreamSource.COLLECTION}:${str
 
 export function buildPostReplyStreamId(compositePostId: string): ReplyStreamCompositeId {
   return `${StreamSource.REPLIES}:${compositePostId}`;
+}
+
+export function buildWotDomainStreamId(
+  sorting: StreamSorting,
+  depth: WotDomainDepth,
+  kind: PostStreamKindSegment,
+  domainTags: string[],
+): WotDomainStreamCompositeId {
+  const canonicalDomainTags = [...domainTags].sort().join(',');
+  return `${sorting}:${StreamSource.WOT_DOMAIN}:${depth}:${kind}:${canonicalDomainTags}`;
 }
 
 export function buildAuthorCollectionsStreamId(authorPubky: Pubky): AuthorCollectionsStreamId {
@@ -179,6 +193,7 @@ export function isDeletedRetainingStream(streamId: string): boolean {
 
 export type PostStreamId =
   | PostStreamTypes
+  | WotDomainStreamCompositeId
   | ReplyStreamCompositeId
   | AuthorStreamCompositeId
   | AuthorRepliesStreamCompositeId

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -102,6 +102,7 @@ export type AuthorStreamCompositeId = `${StreamSource.AUTHOR}:${string}`;
 export type AuthorRepliesStreamCompositeId = `${StreamSource.AUTHOR_REPLIES}:${string}`;
 export type PostStreamKindSegment = 'all' | StreamKind;
 export type WotDomainDepth = 0 | 1 | 2;
+export type WotStreamCompositeId = `${StreamSorting}:${StreamSource.WOT}:${PostStreamKindSegment}`;
 export type WotDomainStreamCompositeId =
   `${StreamSorting}:${StreamSource.WOT_DOMAIN}:${WotDomainDepth}:${PostStreamKindSegment}:${string}`;
 
@@ -193,6 +194,7 @@ export function isDeletedRetainingStream(streamId: string): boolean {
 
 export type PostStreamId =
   | PostStreamTypes
+  | WotStreamCompositeId
   | WotDomainStreamCompositeId
   | ReplyStreamCompositeId
   | AuthorStreamCompositeId

--- a/src/core/services/local/follow/follow.types.ts
+++ b/src/core/services/local/follow/follow.types.ts
@@ -1,18 +1,18 @@
 import type { TFollowParams } from '@/controllers/user/user.type';
 import type { Pubky } from '@/models/models.types';
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import type { PostStreamId } from '@/models/stream/post/postStream.types';
 
 export interface CreateFollowParams extends TFollowParams {
-  activeStreamId?: PostStreamTypes | null;
+  activeStreamId?: PostStreamId | null;
 }
 
 export interface DeleteFollowParams extends TFollowParams {
-  activeStreamId?: PostStreamTypes | null;
+  activeStreamId?: PostStreamId | null;
 }
 
 export interface InvalidateTimelineStreamsParams {
   includeFriends: boolean;
-  activeStreamId?: PostStreamTypes | null;
+  activeStreamId?: PostStreamId | null;
 }
 
 export interface UpdateUserStreamsParams {
@@ -20,5 +20,5 @@ export interface UpdateUserStreamsParams {
   follower: Pubky;
   followee: Pubky;
   friendshipChanged: boolean;
-  activeStreamId?: PostStreamTypes | null;
+  activeStreamId?: PostStreamId | null;
 }

--- a/src/core/services/nexus/stream/posts/postStream.api.ts
+++ b/src/core/services/nexus/stream/posts/postStream.api.ts
@@ -51,6 +51,9 @@ export const postStreamApi = {
   friends: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.FRIENDS, STREAM_PREFIX.POSTS_KEYS),
 
+  wot_domain: (params: TStreamWithObserverParams) =>
+    buildPostStreamUrl(params, StreamSource.WOT_DOMAIN, STREAM_PREFIX.POSTS_KEYS),
+
   bookmarks: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.BOOKMARKS, STREAM_PREFIX.POSTS_KEYS),
 

--- a/src/core/services/nexus/stream/posts/postStream.api.ts
+++ b/src/core/services/nexus/stream/posts/postStream.api.ts
@@ -51,6 +51,8 @@ export const postStreamApi = {
   friends: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.FRIENDS, STREAM_PREFIX.POSTS_KEYS),
 
+  wot: (params: TStreamWithObserverParams) => buildPostStreamUrl(params, StreamSource.WOT, STREAM_PREFIX.POSTS_KEYS),
+
   wot_domain: (params: TStreamWithObserverParams) =>
     buildPostStreamUrl(params, StreamSource.WOT_DOMAIN, STREAM_PREFIX.POSTS_KEYS),
 

--- a/src/core/services/nexus/stream/posts/postStream.constants.ts
+++ b/src/core/services/nexus/stream/posts/postStream.constants.ts
@@ -1,1 +1,2 @@
 export const POST_STREAM_TAG_DELIMITER = ',';
+export const POST_STREAM_WOT_DEFAULT_DEPTH = 2;

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -45,6 +45,8 @@ function callStreamEndpoint(
       return postStreamApi.followers(params as TStreamWithObserverParams);
     case 'friends':
       return postStreamApi.friends(params as TStreamWithObserverParams);
+    case 'wot':
+      return postStreamApi.wot(params as TStreamWithObserverParams);
     case 'bookmarks':
       return postStreamApi.bookmarks(params as TStreamWithObserverParams);
     case 'post_replies':
@@ -110,6 +112,12 @@ describe('Stream API URL Generation', () => {
         endpoint: 'friends' as const,
         params: { observer_id: mockObserverId, tags: 'dev,opensource', kind: StreamKind.SHORT },
         expectedInUrl: ['source=friends', `observer_id=${mockObserverId}`, 'tags=dev%2Copensource', 'kind=short'],
+      },
+      {
+        name: 'wot',
+        endpoint: 'wot' as const,
+        params: { observer_id: mockObserverId, depth: 2 as const, sorting: StreamSorting.TIMELINE },
+        expectedInUrl: ['source=wot', `observer_id=${mockObserverId}`, 'depth=2', 'sorting=timeline'],
       },
       {
         name: 'bookmarks',
@@ -362,6 +370,7 @@ describe('Stream API URL Generation', () => {
         'following',
         'followers',
         'friends',
+        'wot',
         'wot_domain',
         'bookmarks',
         'post_replies',
@@ -416,6 +425,23 @@ describe('createPostStreamParams', () => {
       expect(result.params.kind).toBe(StreamKind.IMAGE);
       expect(result.params.depth).toBe(2);
       expect(result.params.domain_tags).toBe('artist,bitcoin');
+      expect(result.params.viewer_id).toBe(mockViewerId);
+    });
+  });
+
+  describe('WoT streams', () => {
+    it('uses the Nexus Network depth for a plain WoT stream', () => {
+      const result = createPostStreamParams({
+        streamId: 'timeline:wot:all',
+        streamTail: 0,
+        streamHead: 0,
+        limit: 20,
+        viewerId: mockViewerId,
+      });
+
+      expect(result.invokeEndpoint).toBe(StreamSource.WOT);
+      expect(result.params.sorting).toBe(StreamSorting.TIMELINE);
+      expect(result.params.depth).toBe(2);
       expect(result.params.viewer_id).toBe(mockViewerId);
     });
   });
@@ -858,6 +884,13 @@ describe('NexusPostStreamService', () => {
         expectedInUrl: ['source=friends', 'observer_id=viewer-pubky-id', 'tags=tech%2Cdev'],
       },
       {
+        name: 'WOT',
+        invokeEndpoint: StreamSource.WOT,
+        params: { limit: 15, viewer_id: mockViewerId, depth: 2 as const },
+        extraParams: {},
+        expectedInUrl: ['source=wot', 'observer_id=viewer-pubky-id', 'depth=2'],
+      },
+      {
         name: 'WOT_DOMAIN',
         invokeEndpoint: StreamSource.WOT_DOMAIN,
         params: {
@@ -953,6 +986,13 @@ describe('NexusPostStreamService', () => {
         name: 'FRIENDS requires viewer_id',
         invokeEndpoint: StreamSource.FRIENDS,
         params: { limit: 10 }, // Missing viewer_id
+        extraParams: {},
+        expectedError: 'Viewer ID is required',
+      },
+      {
+        name: 'WOT requires viewer_id',
+        invokeEndpoint: StreamSource.WOT,
+        params: { limit: 10 },
         extraParams: {},
         expectedError: 'Viewer ID is required',
       },

--- a/src/core/services/nexus/stream/posts/postStream.test.ts
+++ b/src/core/services/nexus/stream/posts/postStream.test.ts
@@ -362,6 +362,7 @@ describe('Stream API URL Generation', () => {
         'following',
         'followers',
         'friends',
+        'wot_domain',
         'bookmarks',
         'post_replies',
         'author',
@@ -397,6 +398,25 @@ describe('createPostStreamParams', () => {
       expect(result.params.viewer_id).toBe(mockViewerId);
       expect(result.params.limit).toBe(20);
       expect(result.invokeEndpoint).toBe(StreamSource.BOOKMARKS);
+    });
+  });
+
+  describe('WoT domain streams', () => {
+    it('maps depth and profile tags while preserving sorting and content kind', () => {
+      const result = createPostStreamParams({
+        streamId: 'total_engagement:wot_domain:2:image:artist,bitcoin' as PostStreamId,
+        streamTail: 0,
+        streamHead: 0,
+        limit: 20,
+        viewerId: mockViewerId,
+      });
+
+      expect(result.invokeEndpoint).toBe(StreamSource.WOT_DOMAIN);
+      expect(result.params.sorting).toBe(StreamSorting.ENGAGEMENT);
+      expect(result.params.kind).toBe(StreamKind.IMAGE);
+      expect(result.params.depth).toBe(2);
+      expect(result.params.domain_tags).toBe('artist,bitcoin');
+      expect(result.params.viewer_id).toBe(mockViewerId);
     });
   });
 
@@ -713,6 +733,21 @@ describe('createPostStreamParams', () => {
 });
 
 describe('breakDownStreamId', () => {
+  describe('WoT domain pattern', () => {
+    it('parses sorting, depth, kind, and profile tags', () => {
+      const result = breakDownStreamId('timeline:wot_domain:1:long:bitcoin,writer' as PostStreamId);
+
+      expect(result).toEqual(['timeline', StreamSource.WOT_DOMAIN, 'long', undefined, 1, 'bitcoin,writer']);
+    });
+
+    it('supports the depth-zero Me trust set', () => {
+      const result = breakDownStreamId('timeline:wot_domain:0:all:developer' as PostStreamId);
+
+      expect(result[4]).toBe(0);
+      expect(result[5]).toBe('developer');
+    });
+  });
+
   describe('Timeline pattern', () => {
     it('should parse timeline:endpoint:kind:tags', () => {
       const result = breakDownStreamId('timeline:bookmarks:all:tech,ai' as PostStreamId);
@@ -821,6 +856,25 @@ describe('NexusPostStreamService', () => {
         params: { limit: 15, viewer_id: mockViewerId, tags: 'tech,dev' },
         extraParams: {},
         expectedInUrl: ['source=friends', 'observer_id=viewer-pubky-id', 'tags=tech%2Cdev'],
+      },
+      {
+        name: 'WOT_DOMAIN',
+        invokeEndpoint: StreamSource.WOT_DOMAIN,
+        params: {
+          limit: 15,
+          viewer_id: mockViewerId,
+          depth: 2 as const,
+          domain_tags: 'artist,bitcoin',
+          kind: StreamKind.IMAGE,
+        },
+        extraParams: {},
+        expectedInUrl: [
+          'source=wot_domain',
+          'observer_id=viewer-pubky-id',
+          'depth=2',
+          'domain_tags=artist%2Cbitcoin',
+          'kind=image',
+        ],
       },
       {
         name: 'BOOKMARKS',

--- a/src/core/services/nexus/stream/posts/postStream.ts
+++ b/src/core/services/nexus/stream/posts/postStream.ts
@@ -49,6 +49,7 @@ export class NexusPostStreamService {
         break;
       case StreamSource.FOLLOWING:
       case StreamSource.FRIENDS:
+      case StreamSource.WOT:
       case StreamSource.WOT_DOMAIN:
       case StreamSource.BOOKMARKS:
         // TODO: from now, always is going to be

--- a/src/core/services/nexus/stream/posts/postStream.ts
+++ b/src/core/services/nexus/stream/posts/postStream.ts
@@ -1,3 +1,6 @@
+import { ValidationErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
 import { HttpMethod } from '@/libs/http/http.types';
 import type { NexusPostsKeyStream, NexusPostWithAttachmentMetadata } from '@/services/nexus/nexus.types';
 import { queryNexus } from '@/services/nexus/nexus.utils';
@@ -46,10 +49,19 @@ export class NexusPostStreamService {
         break;
       case StreamSource.FOLLOWING:
       case StreamSource.FRIENDS:
+      case StreamSource.WOT_DOMAIN:
       case StreamSource.BOOKMARKS:
         // TODO: from now, always is going to be
         if (!params.viewer_id) {
-          throw new Error('Viewer ID is required for friends stream');
+          throw Err.validation(
+            ValidationErrorCode.MISSING_FIELD,
+            `Viewer ID is required for ${invokeEndpoint} stream`,
+            {
+              service: ErrorService.Nexus,
+              operation: 'fetchPostStream',
+              context: { invokeEndpoint },
+            },
+          );
         }
         nexusEndpoint = postStreamApi[invokeEndpoint]({ ...params, observer_id: params.viewer_id });
         break;
@@ -67,7 +79,11 @@ export class NexusPostStreamService {
         nexusEndpoint = postStreamApi.collection({ ...params, ...extraParams } as TStreamCollectionParams);
         break;
       default:
-        throw new Error(`Invalid stream type: ${invokeEndpoint}`);
+        throw Err.validation(ValidationErrorCode.INVALID_INPUT, `Invalid stream type: ${invokeEndpoint}`, {
+          service: ErrorService.Nexus,
+          operation: 'fetchPostStream',
+          context: { invokeEndpoint },
+        });
     }
     return await queryNexus<NexusPostsKeyStream>({ url: nexusEndpoint });
   }

--- a/src/core/services/nexus/stream/posts/postStream.types.ts
+++ b/src/core/services/nexus/stream/posts/postStream.types.ts
@@ -1,4 +1,5 @@
 import type { Pubky } from '@/models/models.types';
+import type { WotDomainDepth } from '@/models/stream/post/postStream.types';
 import type { StreamSorting, TPaginationParams, TPaginationRangeParams } from '@/services/nexus/nexus.types';
 
 export enum STREAM_PREFIX {
@@ -12,6 +13,7 @@ export enum StreamSource {
   FOLLOWING = 'following',
   FOLLOWERS = 'followers',
   FRIENDS = 'friends',
+  WOT_DOMAIN = 'wot_domain',
   BOOKMARKS = 'bookmarks',
   REPLIES = 'post_replies',
   AUTHOR = 'author',
@@ -51,6 +53,8 @@ export type TStreamBase = TPaginationParams &
     kind?: StreamKind;
     order?: StreamOrder;
     tags?: string; // Max 5 tags
+    depth?: WotDomainDepth;
+    domain_tags?: string; // Max 5 profile tags
   };
 
 // Specific parameter types for each source
@@ -114,4 +118,6 @@ export type TStreamIdBreakdown = [
   invokeEndpoint: StreamSource,
   kind: string | undefined,
   tags: string | undefined,
+  wotDepth?: WotDomainDepth,
+  domainTags?: string,
 ];

--- a/src/core/services/nexus/stream/posts/postStream.types.ts
+++ b/src/core/services/nexus/stream/posts/postStream.types.ts
@@ -13,6 +13,7 @@ export enum StreamSource {
   FOLLOWING = 'following',
   FOLLOWERS = 'followers',
   FRIENDS = 'friends',
+  WOT = 'wot',
   WOT_DOMAIN = 'wot_domain',
   BOOKMARKS = 'bookmarks',
   REPLIES = 'post_replies',

--- a/src/core/services/nexus/stream/posts/postStream.utils.ts
+++ b/src/core/services/nexus/stream/posts/postStream.utils.ts
@@ -6,7 +6,10 @@ import type {
   TSetStreamPaginationParams,
 } from '@/services/local/stream/posts/post.types';
 import { StreamSorting } from '@/services/nexus/nexus.types';
-import { POST_STREAM_TAG_DELIMITER } from '@/services/nexus/stream/posts/postStream.constants';
+import {
+  POST_STREAM_TAG_DELIMITER,
+  POST_STREAM_WOT_DEFAULT_DEPTH,
+} from '@/services/nexus/stream/posts/postStream.constants';
 import {
   StreamKind,
   StreamOrder,
@@ -42,6 +45,9 @@ export function createPostStreamParams({
   if (invokeEndpoint === StreamSource.WOT_DOMAIN) {
     params.depth = wotDepth;
     params.domain_tags = domainTags;
+  }
+  if (invokeEndpoint === StreamSource.WOT) {
+    params.depth = POST_STREAM_WOT_DEFAULT_DEPTH;
   }
   // REPLIES and COLLECTION use the third segment for an entity id (postId), not a kind.
   if (content && invokeEndpoint !== StreamSource.REPLIES && invokeEndpoint !== StreamSource.COLLECTION) {

--- a/src/core/services/nexus/stream/posts/postStream.utils.ts
+++ b/src/core/services/nexus/stream/posts/postStream.utils.ts
@@ -1,6 +1,6 @@
 import type { TFetchStreamParams } from '@/application/stream/posts/post.types';
 import { getMaxStreamTags } from '@/libs/runtime-config/runtime-config';
-import type { PostStreamId } from '@/models/stream/post/postStream.types';
+import type { PostStreamId, WotDomainDepth } from '@/models/stream/post/postStream.types';
 import type {
   THandleNotCommonStreamParamsParams,
   TSetStreamPaginationParams,
@@ -33,12 +33,16 @@ export function createPostStreamParams({
   viewerId,
   order,
 }: TFetchStreamParams): TPostStreamFetchParams {
-  const [sorting, invokeEndpoint, content, tags] = breakDownStreamId(streamId);
+  const [sorting, invokeEndpoint, content, tags, wotDepth, domainTags] = breakDownStreamId(streamId);
 
   const params: TStreamBase = {};
   params.viewer_id = viewerId ?? undefined;
   params.sorting = parseSorting(sorting);
   params.tags = tags;
+  if (invokeEndpoint === StreamSource.WOT_DOMAIN) {
+    params.depth = wotDepth;
+    params.domain_tags = domainTags;
+  }
   // REPLIES and COLLECTION use the third segment for an entity id (postId), not a kind.
   if (content && invokeEndpoint !== StreamSource.REPLIES && invokeEndpoint !== StreamSource.COLLECTION) {
     params.kind = parseContent(content);
@@ -124,27 +128,35 @@ function toStreamSource({ value }: TStreamSource): StreamSource {
  * @param streamId - The stream ID to break down
  */
 export function breakDownStreamId(streamId: PostStreamId): TStreamIdBreakdown {
-  const [sorting, invokeEndpoint, kind, tags] = streamId.split(':');
+  const [sorting, invokeEndpoint, kind, tags, fifthSegment] = streamId.split(':');
   // Tags are separated by ',' character. Only the first MAX_STREAM_TAGS are considered.
-  const limitTags = tags
-    ? tags.split(POST_STREAM_TAG_DELIMITER).slice(0, getMaxStreamTags()).join(POST_STREAM_TAG_DELIMITER)
-    : undefined;
+  const limitTags = (value: string | undefined) =>
+    value
+      ? value.split(POST_STREAM_TAG_DELIMITER).slice(0, getMaxStreamTags()).join(POST_STREAM_TAG_DELIMITER)
+      : undefined;
+
+  if (invokeEndpoint === StreamSource.WOT_DOMAIN) {
+    const depth = kind === '0' || kind === '1' || kind === '2' ? (Number(kind) as WotDomainDepth) : undefined;
+    return [sorting, StreamSource.WOT_DOMAIN, tags, undefined, depth, limitTags(fifthSegment)];
+  }
+
+  const limitedTags = limitTags(tags);
 
   if (kind) {
     if (sorting === StreamSource.REPLIES || sorting === StreamSource.COLLECTION) {
       // Source-first composite formats:
       // - post_replies:<pubky>:<postId>
       // - collection:<pubky>:<postId>
-      return [invokeEndpoint, toStreamSource({ value: sorting }), kind, limitTags];
+      return [invokeEndpoint, toStreamSource({ value: sorting }), kind, limitedTags];
     }
     // Applies to timeline pattern (sorting:source:kind[:tags]) and to the
     // author-with-kind shape (<pubky>:author:<kind>) where parseSorting falls
     // through to undefined.
-    return [sorting, toStreamSource({ value: invokeEndpoint }), kind, limitTags];
+    return [sorting, toStreamSource({ value: invokeEndpoint }), kind, limitedTags];
   }
   // That case covers StreamSource.AUTHOR_REPLIES and StreamSource.AUTHOR
   // i.e. [pubky, author_replies | author, undefined]
-  return [invokeEndpoint, toStreamSource({ value: sorting }), undefined, limitTags];
+  return [invokeEndpoint, toStreamSource({ value: sorting }), undefined, limitedTags];
 }
 
 /**

--- a/src/core/stores/home/home.actions.ts
+++ b/src/core/stores/home/home.actions.ts
@@ -1,5 +1,32 @@
+import { sanitizeTagInput } from '@/libs/utils/utils';
 import { ZustandSet } from '../stores.types';
-import { HomeActions, HomeActionTypes, homeInitialState, HomeStore } from './home.types';
+import {
+  HOME_PROFILE_TAGS_MAX_SELECTED,
+  HomeActions,
+  HomeActionTypes,
+  homeInitialState,
+  HomeStore,
+} from './home.types';
+
+function normalizeProfileTag(profileTag: string): string {
+  return sanitizeTagInput(profileTag.trim()).toLowerCase();
+}
+
+function normalizeProfileTags(profileTags: string[]): string[] {
+  const normalizedTags = new Set<string>();
+
+  for (const profileTag of profileTags) {
+    const normalizedTag = normalizeProfileTag(profileTag);
+    if (normalizedTag) {
+      normalizedTags.add(normalizedTag);
+    }
+    if (normalizedTags.size >= HOME_PROFILE_TAGS_MAX_SELECTED) {
+      break;
+    }
+  }
+
+  return Array.from(normalizedTags);
+}
 
 // Actions/Mutators - State modification functions
 export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
@@ -17,6 +44,47 @@ export const createHomeActions = (set: ZustandSet<HomeStore>): HomeActions => ({
 
   setContent: (content) => {
     set({ content }, false, HomeActionTypes.SET_HOME_CONTENT);
+  },
+
+  setProfileTags: (profileTags) => {
+    set({ profileTags: normalizeProfileTags(profileTags) }, false, HomeActionTypes.SET_HOME_PROFILE_TAGS);
+  },
+
+  addProfileTag: (profileTag) => {
+    set(
+      (state) => {
+        const normalizedTag = normalizeProfileTag(profileTag);
+        if (
+          !normalizedTag ||
+          state.profileTags.length >= HOME_PROFILE_TAGS_MAX_SELECTED ||
+          state.profileTags.includes(normalizedTag)
+        ) {
+          return { profileTags: state.profileTags };
+        }
+        return { profileTags: [...state.profileTags, normalizedTag] };
+      },
+      false,
+      HomeActionTypes.ADD_HOME_PROFILE_TAG,
+    );
+  },
+
+  removeProfileTag: (profileTag) => {
+    set(
+      (state) => {
+        const normalizedTag = normalizeProfileTag(profileTag);
+        return { profileTags: state.profileTags.filter((tag) => tag !== normalizedTag) };
+      },
+      false,
+      HomeActionTypes.REMOVE_HOME_PROFILE_TAG,
+    );
+  },
+
+  clearProfileTags: () => {
+    set({ profileTags: [] }, false, HomeActionTypes.CLEAR_HOME_PROFILE_TAGS);
+  },
+
+  setProfileTagScope: (profileTagScope) => {
+    set({ profileTagScope }, false, HomeActionTypes.SET_HOME_PROFILE_TAG_SCOPE);
   },
 
   reset: () => {

--- a/src/core/stores/home/home.store.test.ts
+++ b/src/core/stores/home/home.store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useHomeStore } from './home.store';
-import { CONTENT, homeInitialState, LAYOUT, REACH, SORT } from './home.types';
+import { CONTENT, homeInitialState, LAYOUT, PROFILE_TAG_SCOPE, REACH, SORT } from './home.types';
 
 describe('HomeStore', () => {
   beforeEach(() => {
@@ -16,6 +16,8 @@ describe('HomeStore', () => {
       expect(state.sort).toBe(SORT.TIMELINE);
       expect(state.reach).toBe(REACH.ALL);
       expect(state.content).toBe(CONTENT.ALL);
+      expect(state.profileTags).toEqual([]);
+      expect(state.profileTagScope).toBe(PROFILE_TAG_SCOPE.NETWORK);
     });
 
     it('should match homeInitialState', () => {
@@ -120,6 +122,48 @@ describe('HomeStore', () => {
 
       store.setReach(REACH.ALL);
       expect(useHomeStore.getState().reach).toBe(REACH.ALL);
+    });
+
+    it('preserves profile tags while Reach changes independently', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.NETWORK);
+      store.addProfileTag('bitcoin');
+      store.setReach(REACH.ALL);
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin']);
+    });
+  });
+
+  describe('Profile Tag Management', () => {
+    it('normalizes and deduplicates profile tags', () => {
+      const store = useHomeStore.getState();
+
+      store.setProfileTags([' Bitcoin ', 'bitcoin', 'Nostr']);
+
+      expect(useHomeStore.getState().profileTags).toEqual(['bitcoin', 'nostr']);
+    });
+
+    it('limits profile tags to five and removes them by normalized label', () => {
+      const store = useHomeStore.getState();
+
+      for (const tag of ['one', 'two', 'three', 'four', 'five', 'six']) {
+        store.addProfileTag(tag);
+      }
+      expect(useHomeStore.getState().profileTags).toEqual(['one', 'two', 'three', 'four', 'five']);
+
+      store.removeProfileTag(' TWO ');
+      expect(useHomeStore.getState().profileTags).toEqual(['one', 'three', 'four', 'five']);
+    });
+
+    it('changes WoT scope without changing Reach', () => {
+      const store = useHomeStore.getState();
+
+      store.setReach(REACH.ALL);
+      store.setProfileTagScope(PROFILE_TAG_SCOPE.NETWORK);
+
+      expect(useHomeStore.getState().reach).toBe(REACH.ALL);
+      expect(useHomeStore.getState().profileTagScope).toBe(PROFILE_TAG_SCOPE.NETWORK);
     });
   });
 

--- a/src/core/stores/home/home.store.ts
+++ b/src/core/stores/home/home.store.ts
@@ -20,6 +20,8 @@ export const useHomeStore = create<HomeStore>()(
           sort: state.sort,
           reach: state.reach,
           content: state.content,
+          profileTags: state.profileTags,
+          profileTagScope: state.profileTagScope,
         }),
       },
     ),

--- a/src/core/stores/home/home.types.ts
+++ b/src/core/stores/home/home.types.ts
@@ -11,14 +11,25 @@ export const SORT = {
   ENGAGEMENT: 'total_engagement',
 } as const;
 
-// The value of each variant have to be identical to postStreamApi function names
-// Like this, the reach value will invoke the specific API endpoint
+// ME and NETWORK are UI-level reaches:
+// - ME resolves to the signed-in user's existing author/profile stream.
+// - NETWORK currently resolves to the same public stream as ALL.
 export const REACH = {
-  ALL: 'all',
-  FOLLOWING: 'following',
+  ME: 'me',
   FRIENDS: 'friends',
-  //ME: 'me',
+  FOLLOWING: 'following',
+  NETWORK: 'network',
+  ALL: 'all',
 } as const;
+
+export const PROFILE_TAG_SCOPE = {
+  NETWORK: 'network',
+  FOLLOWING: 'following',
+  ME: 'me',
+} as const;
+
+// Nexus domain_tags API limit.
+export const HOME_PROFILE_TAGS_MAX_SELECTED = 5;
 
 export enum CONTENT {
   ALL = 'all',
@@ -35,6 +46,7 @@ export enum CONTENT {
 export type LayoutType = (typeof LAYOUT)[keyof typeof LAYOUT];
 export type SortType = (typeof SORT)[keyof typeof SORT];
 export type ReachType = (typeof REACH)[keyof typeof REACH];
+export type ProfileTagScopeType = (typeof PROFILE_TAG_SCOPE)[keyof typeof PROFILE_TAG_SCOPE];
 export type ContentType = (typeof CONTENT)[keyof typeof CONTENT];
 
 export interface HomeState {
@@ -42,6 +54,8 @@ export interface HomeState {
   sort: SortType;
   reach: ReachType;
   content: ContentType;
+  profileTags: string[];
+  profileTagScope: ProfileTagScopeType;
 }
 
 export interface HomeActions {
@@ -49,6 +63,11 @@ export interface HomeActions {
   setSort: (sort: SortType) => void;
   setReach: (reach: ReachType) => void;
   setContent: (content: ContentType) => void;
+  setProfileTags: (profileTags: string[]) => void;
+  addProfileTag: (profileTag: string) => void;
+  removeProfileTag: (profileTag: string) => void;
+  clearProfileTags: () => void;
+  setProfileTagScope: (profileTagScope: ProfileTagScopeType) => void;
   reset: () => void;
 }
 
@@ -60,6 +79,8 @@ export const homeInitialState: HomeState = {
   sort: SORT.TIMELINE,
   reach: REACH.ALL,
   content: CONTENT.ALL,
+  profileTags: [],
+  profileTagScope: PROFILE_TAG_SCOPE.NETWORK,
 };
 
 // Action types for DevTools
@@ -68,5 +89,10 @@ export enum HomeActionTypes {
   SET_HOME_SORT = 'SET_HOME_SORT',
   SET_HOME_REACH = 'SET_HOME_REACH',
   SET_HOME_CONTENT = 'SET_HOME_CONTENT',
+  SET_HOME_PROFILE_TAGS = 'SET_HOME_PROFILE_TAGS',
+  ADD_HOME_PROFILE_TAG = 'ADD_HOME_PROFILE_TAG',
+  REMOVE_HOME_PROFILE_TAG = 'REMOVE_HOME_PROFILE_TAG',
+  CLEAR_HOME_PROFILE_TAGS = 'CLEAR_HOME_PROFILE_TAGS',
+  SET_HOME_PROFILE_TAG_SCOPE = 'SET_HOME_PROFILE_TAG_SCOPE',
   RESET_HOME = 'RESET_HOME',
 }

--- a/src/core/stores/home/home.types.ts
+++ b/src/core/stores/home/home.types.ts
@@ -28,6 +28,8 @@ export const PROFILE_TAG_SCOPE = {
   ME: 'me',
 } as const;
 
+export const HOME_NETWORK_REACH_MIN_FOLLOWING = 3;
+
 // Nexus domain_tags API limit.
 export const HOME_PROFILE_TAGS_MAX_SELECTED = 5;
 

--- a/src/core/stores/home/home.utils.test.ts
+++ b/src/core/stores/home/home.utils.test.ts
@@ -37,8 +37,8 @@ describe('filters.utils', () => {
       ).toBe('total_engagement:wot_domain:2:image:artist');
     });
 
-    it('keeps the existing untagged Network alias and ignores tags without a viewer', () => {
-      expect(getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, viewer)).toBe('timeline:all:all');
+    it('uses the Network WoT stream and ignores tags without a viewer', () => {
+      expect(getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, viewer)).toBe('timeline:wot:all');
       expect(getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, null, ['bitcoin'])).toBe(
         'timeline:all:all',
       );
@@ -103,9 +103,9 @@ describe('filters.utils', () => {
         expect(streamId).toBe('timeline:friends:all');
       });
 
-      it('should normalize "network" reach to "all"', () => {
+      it('should map "network" reach to "wot"', () => {
         const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL);
-        expect(streamId).toBe('timeline:all:all');
+        expect(streamId).toBe('timeline:wot:all');
       });
 
       it('should safely normalize unresolved "me" reach to "all"', () => {
@@ -188,6 +188,11 @@ describe('filters.utils', () => {
       expect(streamId).toBe('timeline:friends:all');
     });
 
+    it('should return the Network WoT stream', () => {
+      const streamId = getStreamId(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL);
+      expect(streamId).toBe('timeline:wot:all');
+    });
+
     it('should return PostStreamTypes.TIMELINE_ALL_IMAGE', () => {
       const streamId = getStreamId(SORT.TIMELINE, REACH.ALL, CONTENT.IMAGES);
       expect(streamId).toBe(PostStreamTypes.TIMELINE_ALL_IMAGE);
@@ -211,6 +216,7 @@ describe('filters.utils', () => {
     it('should return true for matching filters', () => {
       expect(matchesFilters('timeline:all:all', SORT.TIMELINE, REACH.ALL, CONTENT.ALL)).toBe(true);
       expect(matchesFilters('timeline:following:all', SORT.TIMELINE, REACH.FOLLOWING, CONTENT.ALL)).toBe(true);
+      expect(matchesFilters('timeline:wot:all', SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL)).toBe(true);
       expect(matchesFilters('total_engagement:friends:image', SORT.ENGAGEMENT, REACH.FRIENDS, CONTENT.IMAGES)).toBe(
         true,
       );

--- a/src/core/stores/home/home.utils.test.ts
+++ b/src/core/stores/home/home.utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { PostStreamTypes } from '@/models/stream/post/postStream.types';
-import { CONTENT, ContentType, REACH, ReachType, SORT, SortType } from './home.types';
+import { CONTENT, ContentType, PROFILE_TAG_SCOPE, REACH, ReachType, SORT, SortType } from './home.types';
 import {
+  getHomeStreamIdFromFilters,
   getStreamId,
   getStreamIdFromFilters,
   matchesFilters,
@@ -10,6 +11,69 @@ import {
 } from './home.utils';
 
 describe('filters.utils', () => {
+  describe('getHomeStreamIdFromFilters', () => {
+    const viewer = 'viewer-pubky';
+
+    it.each([
+      { scope: PROFILE_TAG_SCOPE.NETWORK, depth: 2 },
+      { scope: PROFILE_TAG_SCOPE.FOLLOWING, depth: 1 },
+      { scope: PROFILE_TAG_SCOPE.ME, depth: 0 },
+    ])('builds a wot_domain stream for $scope profile-tag scope', ({ scope, depth }) => {
+      expect(
+        getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.ALL, CONTENT.ALL, viewer, ['nostr', 'bitcoin'], scope),
+      ).toBe(`timeline:wot_domain:${depth}:all:bitcoin,nostr`);
+    });
+
+    it('preserves Sort and Content while Nexus applies its default WoT Reach', () => {
+      expect(
+        getHomeStreamIdFromFilters(
+          SORT.ENGAGEMENT,
+          REACH.FOLLOWING,
+          CONTENT.IMAGES,
+          viewer,
+          ['artist'],
+          PROFILE_TAG_SCOPE.NETWORK,
+        ),
+      ).toBe('total_engagement:wot_domain:2:image:artist');
+    });
+
+    it('keeps the existing untagged Network alias and ignores tags without a viewer', () => {
+      expect(getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, viewer)).toBe('timeline:all:all');
+      expect(getHomeStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL, null, ['bitcoin'])).toBe(
+        'timeline:all:all',
+      );
+    });
+
+    it.each([REACH.ALL, REACH.NETWORK, REACH.FOLLOWING, REACH.FRIENDS])(
+      'uses the same Nexus-default WoT request while Reach remains visually %s',
+      (reach) => {
+        expect(
+          getHomeStreamIdFromFilters(
+            SORT.TIMELINE,
+            reach,
+            CONTENT.ALL,
+            viewer,
+            ['bitcoin'],
+            PROFILE_TAG_SCOPE.FOLLOWING,
+          ),
+        ).toBe('timeline:wot_domain:1:all:bitcoin');
+      },
+    );
+
+    it('ignores profile tags for Me Reach so the profile feed can be used', () => {
+      expect(
+        getHomeStreamIdFromFilters(
+          SORT.TIMELINE,
+          REACH.ME,
+          CONTENT.ALL,
+          viewer,
+          ['bitcoin'],
+          PROFILE_TAG_SCOPE.NETWORK,
+        ),
+      ).toBe('timeline:all:all');
+    });
+  });
+
   describe('getStreamIdFromFilters', () => {
     describe('SORT mapping', () => {
       it('should map "recent" to "timeline"', () => {
@@ -37,6 +101,16 @@ describe('filters.utils', () => {
       it('should map "friends" reach', () => {
         const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.FRIENDS, CONTENT.ALL);
         expect(streamId).toBe('timeline:friends:all');
+      });
+
+      it('should normalize "network" reach to "all"', () => {
+        const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.NETWORK, CONTENT.ALL);
+        expect(streamId).toBe('timeline:all:all');
+      });
+
+      it('should safely normalize unresolved "me" reach to "all"', () => {
+        const streamId = getStreamIdFromFilters(SORT.TIMELINE, REACH.ME, CONTENT.ALL);
+        expect(streamId).toBe('timeline:all:all');
       });
     });
 

--- a/src/core/stores/home/home.utils.ts
+++ b/src/core/stores/home/home.utils.ts
@@ -1,8 +1,8 @@
 import type { Pubky } from '@/models/models.types';
 import {
   buildWotDomainStreamId,
+  type PostStreamId,
   type PostStreamKindSegment,
-  type PostStreamTypes,
   type WotDomainDepth,
 } from '@/models/stream/post/postStream.types';
 import { StreamSorting } from '@/services/nexus/nexus.types';
@@ -42,6 +42,7 @@ const SORTING_TO_SORT = reverseMapping(SORT_TO_SORTING);
 /** Maps REACH filter to streamId SOURCE part */
 const REACH_TO_SOURCE = {
   [REACH.ALL]: 'all',
+  [REACH.NETWORK]: 'wot',
   [REACH.FOLLOWING]: 'following',
   [REACH.FRIENDS]: 'friends',
 } as const;
@@ -49,15 +50,11 @@ const REACH_TO_SOURCE = {
 type NexusReachType = keyof typeof REACH_TO_SOURCE;
 
 /**
- * NETWORK is a temporary alias for ALL until Nexus exposes an official stream.
  * ME is resolved to an author stream by the feed hooks; callers without an
  * authenticated author safely fall back to ALL.
  */
 function toNexusReach(reach: ReachType): NexusReachType {
-  if (reach === REACH.FOLLOWING || reach === REACH.FRIENDS) {
-    return reach;
-  }
-  return REACH.ALL;
+  return reach === REACH.ME ? REACH.ALL : reach;
 }
 
 /** Maps streamId SOURCE part to REACH filter (auto-generated) */
@@ -89,7 +86,7 @@ const KIND_TO_CONTENT = reverseMapping(CONTENT_TO_KIND);
  *
  * Pattern breakdown:
  * - SORTING: timeline (recent), total_engagement (popularity)
- * - SOURCE: all, following, friends (NETWORK and unresolved ME normalize to all)
+ * - SOURCE: all, wot, following, friends (unresolved ME normalizes to all)
  * - KIND: all, short (posts), long (articles), collection, image, video, link, file
  *
  * @example
@@ -106,20 +103,17 @@ export function getStreamIdFromFilters(sort: SortType, reach: ReachType, content
 }
 
 /**
- * Type-safe version that returns PostStreamTypes enum for all valid filter combinations
- *
- * Since PostStreamTypes enum values are the actual streamId strings, we can cast directly.
+ * Type-safe version that returns a supported post stream ID.
  *
  * @example
  * getStreamId('recent', 'all', 'all') // => PostStreamTypes.TIMELINE_ALL_ALL
  * getStreamId('recent', 'following', 'images') // => PostStreamTypes.TIMELINE_FOLLOWING_IMAGE
  * getStreamId('popularity', 'friends', 'videos') // => PostStreamTypes.POPULARITY_FRIENDS_VIDEO
  */
-export function getStreamId(sort: SortType, reach: ReachType, content: ContentType): PostStreamTypes {
+export function getStreamId(sort: SortType, reach: ReachType, content: ContentType): PostStreamId {
   const streamId = getStreamIdFromFilters(sort, reach, content);
 
-  // The streamId string matches the enum value exactly, so we can cast directly
-  return streamId as PostStreamTypes;
+  return streamId as PostStreamId;
 }
 
 export function getHomeStreamIdFromFilters(
@@ -143,7 +137,7 @@ export function getHomeStreamIdFromFilters(
     );
   }
 
-  const effectiveReach = currentUserPubky || reach === REACH.NETWORK ? reach : REACH.ALL;
+  const effectiveReach = currentUserPubky ? reach : REACH.ALL;
   return getStreamId(sort, effectiveReach, content);
 }
 

--- a/src/core/stores/home/home.utils.ts
+++ b/src/core/stores/home/home.utils.ts
@@ -1,5 +1,22 @@
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
-import { CONTENT, type ContentType, REACH, type ReachType, SORT, type SortType } from './home.types';
+import type { Pubky } from '@/models/models.types';
+import {
+  buildWotDomainStreamId,
+  type PostStreamKindSegment,
+  type PostStreamTypes,
+  type WotDomainDepth,
+} from '@/models/stream/post/postStream.types';
+import { StreamSorting } from '@/services/nexus/nexus.types';
+import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
+import {
+  CONTENT,
+  type ContentType,
+  PROFILE_TAG_SCOPE,
+  type ProfileTagScopeType,
+  REACH,
+  type ReachType,
+  SORT,
+  type SortType,
+} from './home.types';
 
 // ============================================
 // Bidirectional Mappings (DRY principle)
@@ -27,7 +44,21 @@ const REACH_TO_SOURCE = {
   [REACH.ALL]: 'all',
   [REACH.FOLLOWING]: 'following',
   [REACH.FRIENDS]: 'friends',
-} as const satisfies Record<ReachType, string>;
+} as const;
+
+type NexusReachType = keyof typeof REACH_TO_SOURCE;
+
+/**
+ * NETWORK is a temporary alias for ALL until Nexus exposes an official stream.
+ * ME is resolved to an author stream by the feed hooks; callers without an
+ * authenticated author safely fall back to ALL.
+ */
+function toNexusReach(reach: ReachType): NexusReachType {
+  if (reach === REACH.FOLLOWING || reach === REACH.FRIENDS) {
+    return reach;
+  }
+  return REACH.ALL;
+}
 
 /** Maps streamId SOURCE part to REACH filter (auto-generated) */
 const SOURCE_TO_REACH = reverseMapping(REACH_TO_SOURCE);
@@ -44,6 +75,12 @@ const CONTENT_TO_KIND = {
   [CONTENT.FILES]: 'file',
 } as const satisfies Record<ContentType, string>;
 
+const WOT_DOMAIN_DEPTH_BY_SCOPE = {
+  [PROFILE_TAG_SCOPE.NETWORK]: 2,
+  [PROFILE_TAG_SCOPE.FOLLOWING]: 1,
+  [PROFILE_TAG_SCOPE.ME]: 0,
+} as const satisfies Record<ProfileTagScopeType, WotDomainDepth>;
+
 /** Maps streamId KIND part to CONTENT filter (auto-generated) */
 const KIND_TO_CONTENT = reverseMapping(CONTENT_TO_KIND);
 
@@ -52,7 +89,7 @@ const KIND_TO_CONTENT = reverseMapping(CONTENT_TO_KIND);
  *
  * Pattern breakdown:
  * - SORTING: timeline (recent), total_engagement (popularity)
- * - SOURCE: all, following, friends, me
+ * - SOURCE: all, following, friends (NETWORK and unresolved ME normalize to all)
  * - KIND: all, short (posts), long (articles), collection, image, video, link, file
  *
  * @example
@@ -62,7 +99,7 @@ const KIND_TO_CONTENT = reverseMapping(CONTENT_TO_KIND);
  */
 export function getStreamIdFromFilters(sort: SortType, reach: ReachType, content: ContentType): string {
   const sorting = SORT_TO_SORTING[sort];
-  const source = REACH_TO_SOURCE[reach];
+  const source = REACH_TO_SOURCE[toNexusReach(reach)];
   const kind = CONTENT_TO_KIND[content];
 
   return `${sorting}:${source}:${kind}`;
@@ -83,6 +120,31 @@ export function getStreamId(sort: SortType, reach: ReachType, content: ContentTy
 
   // The streamId string matches the enum value exactly, so we can cast directly
   return streamId as PostStreamTypes;
+}
+
+export function getHomeStreamIdFromFilters(
+  sort: SortType,
+  reach: ReachType,
+  content: ContentType,
+  currentUserPubky?: Pubky | null,
+  profileTags: string[] = [],
+  profileTagScope: ProfileTagScopeType = PROFILE_TAG_SCOPE.NETWORK,
+) {
+  // Nexus currently applies its own default Reach (Network) to `wot_domain`.
+  // Keep the ring's selected Reach in UI state for future Nexus support, but
+  // intentionally do not encode it in this request yet.
+  if (currentUserPubky && profileTags.length > 0 && reach !== REACH.ME) {
+    const depth = WOT_DOMAIN_DEPTH_BY_SCOPE[profileTagScope];
+    return buildWotDomainStreamId(
+      SORT_TO_SORTING[sort] as StreamSorting,
+      depth,
+      CONTENT_TO_KIND[content] as PostStreamKindSegment,
+      profileTags,
+    );
+  }
+
+  const effectiveReach = currentUserPubky || reach === REACH.NETWORK ? reach : REACH.ALL;
+  return getStreamId(sort, effectiveReach, content);
 }
 
 /**
@@ -144,8 +206,15 @@ const POST_KIND_TO_CONTENT = {
  * Unparseable stream ids (profile, author collections, etc.) accept all kinds.
  */
 export function postKindBelongsToStream(postKind: string, streamId: string): boolean {
+  const streamParts = streamId.split(':');
+  const wotDomainContent =
+    streamParts[1] === StreamSource.WOT_DOMAIN
+      ? KIND_TO_CONTENT[streamParts[3] as keyof typeof KIND_TO_CONTENT]
+      : undefined;
   const parsed = parseStreamId(streamId);
-  if (!parsed || parsed.content === CONTENT.ALL) {
+  const streamContent = wotDomainContent ?? parsed?.content;
+
+  if (!streamContent || streamContent === CONTENT.ALL) {
     return true;
   }
 
@@ -154,5 +223,5 @@ export function postKindBelongsToStream(postKind: string, streamId: string): boo
     return false;
   }
 
-  return postContent === parsed.content;
+  return postContent === streamContent;
 }

--- a/src/hooks/useHotStreamId/useHotStreamId.test.ts
+++ b/src/hooks/useHotStreamId/useHotStreamId.test.ts
@@ -87,13 +87,33 @@ describe('useHotStreamId', () => {
     expect(result.current).toBe('total_engagement:all:all');
   });
 
+  it('should use the signed-in user profile stream for Me reach', () => {
+    const { result: setReach } = renderHook(() => useHotStore((state) => state.setReach));
+    setReach.current(REACH.ME);
+
+    const { result } = renderHook(() => useHotStreamId());
+
+    expect(result.current).toBe('author:viewer-pubky');
+  });
+
+  it('should use the All stream for Network reach', () => {
+    const { result: setReach } = renderHook(() => useHotStore((state) => state.setReach));
+    setReach.current(REACH.NETWORK);
+
+    const { result } = renderHook(() => useHotStreamId());
+
+    expect(result.current).toBe(PostStreamTypes.POPULARITY_ALL_ALL);
+  });
+
   it('should handle all reach options', () => {
     const { result: setReach } = renderHook(() => useHotStore((state) => state.setReach));
 
     const reachOptions = [
-      { reach: REACH.ALL, expected: PostStreamTypes.POPULARITY_ALL_ALL },
-      { reach: REACH.FOLLOWING, expected: PostStreamTypes.POPULARITY_FOLLOWING_ALL },
+      { reach: REACH.ME, expected: 'author:viewer-pubky' },
       { reach: REACH.FRIENDS, expected: PostStreamTypes.POPULARITY_FRIENDS_ALL },
+      { reach: REACH.FOLLOWING, expected: PostStreamTypes.POPULARITY_FOLLOWING_ALL },
+      { reach: REACH.NETWORK, expected: PostStreamTypes.POPULARITY_ALL_ALL },
+      { reach: REACH.ALL, expected: PostStreamTypes.POPULARITY_ALL_ALL },
     ];
 
     reachOptions.forEach(({ reach, expected }) => {

--- a/src/hooks/useHotStreamId/useHotStreamId.ts
+++ b/src/hooks/useHotStreamId/useHotStreamId.ts
@@ -1,4 +1,5 @@
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import type { AuthorStreamCompositeId, PostStreamId } from '@/models/stream/post/postStream.types';
+import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { CONTENT, REACH, SORT } from '@/stores/home/home.types';
 import { getStreamId } from '@/stores/home/home.utils';
@@ -8,7 +9,8 @@ import { useHotStore } from '@/stores/hot/hot.store';
  * useHotStreamId
  *
  * Hook that returns the stream ID for hot/trending posts based on the hot store's reach filter.
- * Uses engagement sorting (total_engagement) and all content types.
+ * Standard reaches use engagement sorting and all content types. ME reuses the
+ * current user's author/profile stream; NETWORK resolves through the ALL mapping.
  *
  * @returns The stream ID for trending posts
  *
@@ -20,10 +22,15 @@ import { useHotStore } from '@/stores/hot/hot.store';
  * // Returns PostStreamTypes.POPULARITY_FRIENDS_ALL when reach is 'friends'
  * ```
  */
-export function useHotStreamId(): PostStreamTypes {
+export function useHotStreamId(): PostStreamId {
   const reach = useHotStore((state) => state.reach);
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
-  const effectiveReach = currentUserPubky ? reach : REACH.ALL;
+
+  if (reach === REACH.ME && currentUserPubky) {
+    return `${StreamSource.AUTHOR}:${currentUserPubky}` as AuthorStreamCompositeId;
+  }
+
+  const effectiveReach = currentUserPubky || reach === REACH.NETWORK ? reach : REACH.ALL;
 
   // Hot/Trending posts use engagement sorting (POPULARITY)
   // Content is always 'all' for hot posts

--- a/src/hooks/usePostInput/usePostInput.test.ts
+++ b/src/hooks/usePostInput/usePostInput.test.ts
@@ -266,6 +266,22 @@ describe('usePostInput', () => {
       expect(result.current.isExpanded).toBe(true);
     });
 
+    it('focuses the textarea when the input expands', async () => {
+      const focus = vi.fn();
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+      result.current.textareaRef.current = asOpaque<HTMLTextAreaElement>({ focus });
+
+      act(() => {
+        result.current.handleExpand();
+      });
+
+      await waitFor(() => expect(focus).toHaveBeenCalled());
+    });
+
     it('does not change state when already expanded', () => {
       const { result } = renderHook(() =>
         usePostInput({

--- a/src/hooks/usePostInput/usePostInput.ts
+++ b/src/hooks/usePostInput/usePostInput.ts
@@ -170,6 +170,12 @@ export function usePostInput({
     }
   }, [isExpanded]);
 
+  useEffect(() => {
+    if (isExpanded && !isArticle) {
+      textareaRef.current?.focus();
+    }
+  }, [isExpanded, isArticle]);
+
   const resizeTextarea = useCallback(() => {
     const textarea = textareaRef.current;
     if (!textarea) return;

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
@@ -123,13 +123,13 @@ describe('useStreamIdFromFilters', () => {
     expect(result.current).toBe('author:viewer-pubky');
   });
 
-  it('should use the All stream for Network reach', () => {
+  it('should use the WoT stream for Network reach', () => {
     const { result: setReach } = renderHook(() => useHomeStore((state) => state.setReach));
     setReach.current(REACH.NETWORK);
 
     const { result } = renderHook(() => useStreamIdFromFilters());
 
-    expect(result.current).toBe(PostStreamTypes.TIMELINE_ALL_ALL);
+    expect(result.current).toBe('timeline:wot:all');
   });
 
   it('uses WoT scope depth, Sort, Content, and profile tags while Nexus applies its default Reach', () => {
@@ -269,7 +269,7 @@ describe('useStreamIdFromFilters', () => {
       { reach: REACH.ME, expected: 'author:viewer-pubky' },
       { reach: REACH.FRIENDS, expected: 'timeline:friends:all' },
       { reach: REACH.FOLLOWING, expected: 'timeline:following:all' },
-      { reach: REACH.NETWORK, expected: 'timeline:all:all' },
+      { reach: REACH.NETWORK, expected: 'timeline:wot:all' },
       { reach: REACH.ALL, expected: 'timeline:all:all' },
     ];
 

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PostStreamTypes } from '@/models/stream/post/postStream.types';
 import { useHomeStore } from '@/stores/home/home.store';
-import { CONTENT, REACH, SORT } from '@/stores/home/home.types';
+import { CONTENT, PROFILE_TAG_SCOPE, REACH, SORT } from '@/stores/home/home.types';
 import { useStreamIdFromFilters } from './useStreamIdFromFilters';
 
 let mockCurrentUserPubky: string | null = 'viewer-pubky';
@@ -11,6 +11,8 @@ const mockHomeStore = vi.hoisted(() => {
     sort: 'timeline',
     reach: 'all',
     content: 'all',
+    profileTags: [] as string[],
+    profileTagScope: 'network',
   };
   const state = {
     ...initialState,
@@ -23,10 +25,18 @@ const mockHomeStore = vi.hoisted(() => {
     setContent: (content: string) => {
       state.content = content;
     },
+    setProfileTags: (profileTags: string[]) => {
+      state.profileTags = profileTags;
+    },
+    setProfileTagScope: (profileTagScope: string) => {
+      state.profileTagScope = profileTagScope;
+    },
     reset: () => {
       state.sort = initialState.sort;
       state.reach = initialState.reach;
       state.content = initialState.content;
+      state.profileTags = [];
+      state.profileTagScope = initialState.profileTagScope;
     },
   };
 
@@ -92,6 +102,80 @@ describe('useStreamIdFromFilters', () => {
 
     expect(result.current).toBe(PostStreamTypes.TIMELINE_ALL_ALL);
     expect(result.current).toBe('timeline:all:all');
+  });
+
+  it('should use the signed-in user profile stream for Me reach', () => {
+    const { result: setReach } = renderHook(() => useHomeStore((state) => state.setReach));
+    setReach.current(REACH.ME);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+
+    expect(result.current).toBe('author:viewer-pubky');
+  });
+
+  it('keeps the profile stream for Me even when profile tags are preserved in state', () => {
+    const { result: homeStore } = renderHook(() => useHomeStore());
+
+    homeStore.current.setReach(REACH.ME);
+    homeStore.current.setProfileTags(['developer']);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+    expect(result.current).toBe('author:viewer-pubky');
+  });
+
+  it('should use the All stream for Network reach', () => {
+    const { result: setReach } = renderHook(() => useHomeStore((state) => state.setReach));
+    setReach.current(REACH.NETWORK);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+
+    expect(result.current).toBe(PostStreamTypes.TIMELINE_ALL_ALL);
+  });
+
+  it('uses WoT scope depth, Sort, Content, and profile tags while Nexus applies its default Reach', () => {
+    const { result: homeStore } = renderHook(() => useHomeStore());
+
+    homeStore.current.setReach(REACH.NETWORK);
+    homeStore.current.setSort(SORT.ENGAGEMENT);
+    homeStore.current.setContent(CONTENT.LONG);
+    homeStore.current.setProfileTags(['writer', 'bitcoin']);
+    homeStore.current.setProfileTagScope(PROFILE_TAG_SCOPE.NETWORK);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+    expect(result.current).toBe('total_engagement:wot_domain:2:long:bitcoin,writer');
+  });
+
+  it('keeps Reach unchanged while the independent WoT scope changes', () => {
+    const { result: homeStore } = renderHook(() => useHomeStore());
+
+    homeStore.current.setReach(REACH.ALL);
+    homeStore.current.setProfileTagScope(PROFILE_TAG_SCOPE.ME);
+    homeStore.current.setProfileTags(['bitcoiner']);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+    expect(homeStore.current.reach).toBe(REACH.ALL);
+    expect(result.current).toBe('timeline:wot_domain:0:all:bitcoiner');
+  });
+
+  it('does not activate a WoT-domain stream without an authenticated viewer', () => {
+    mockCurrentUserPubky = null;
+    const { result: homeStore } = renderHook(() => useHomeStore());
+
+    homeStore.current.setReach(REACH.NETWORK);
+    homeStore.current.setProfileTags(['bitcoin']);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+    expect(result.current).toBe('timeline:all:all');
+  });
+
+  it('should fall back to All for Me reach when no user is authenticated', () => {
+    mockCurrentUserPubky = null;
+    const { result: setReach } = renderHook(() => useHomeStore((state) => state.setReach));
+    setReach.current(REACH.ME);
+
+    const { result } = renderHook(() => useStreamIdFromFilters());
+
+    expect(result.current).toBe(PostStreamTypes.TIMELINE_ALL_ALL);
   });
 
   it('should update when content filter changes', () => {
@@ -182,9 +266,11 @@ describe('useStreamIdFromFilters', () => {
 
     // Test each reach option
     const reachOptions = [
-      { reach: REACH.ALL, expected: 'timeline:all:all' },
-      { reach: REACH.FOLLOWING, expected: 'timeline:following:all' },
+      { reach: REACH.ME, expected: 'author:viewer-pubky' },
       { reach: REACH.FRIENDS, expected: 'timeline:friends:all' },
+      { reach: REACH.FOLLOWING, expected: 'timeline:following:all' },
+      { reach: REACH.NETWORK, expected: 'timeline:all:all' },
+      { reach: REACH.ALL, expected: 'timeline:all:all' },
     ];
 
     reachOptions.forEach(({ reach, expected }) => {

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
@@ -1,8 +1,9 @@
-import type { PostStreamTypes } from '@/models/stream/post/postStream.types';
+import type { AuthorStreamCompositeId, PostStreamId } from '@/models/stream/post/postStream.types';
+import { StreamSource } from '@/services/nexus/stream/posts/postStream.types';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { useHomeStore } from '@/stores/home/home.store';
 import { type ContentType, REACH } from '@/stores/home/home.types';
-import { getStreamId } from '@/stores/home/home.utils';
+import { getHomeStreamIdFromFilters } from '@/stores/home/home.utils';
 
 /**
  * Custom hook that returns the current streamId based on global filter state
@@ -10,9 +11,10 @@ import { getStreamId } from '@/stores/home/home.utils';
  * This hook reads the current filter state from the filters store and
  * generates the appropriate streamId following the pattern: sorting:source:kind
  *
- * All valid filter combinations map to PostStreamTypes enum values.
+ * Standard reaches map to PostStreamTypes values. ME reuses the existing
+ * author/profile stream, while NETWORK resolves through the ALL mapping.
  *
- * @returns The current streamId as PostStreamTypes enum
+ * @returns The current post stream ID
  *
  * @example
  * ```tsx
@@ -28,13 +30,18 @@ import { getStreamId } from '@/stores/home/home.utils';
  * }
  * ```
  */
-export function useStreamIdFromFilters(contentOverride?: ContentType): PostStreamTypes {
+export function useStreamIdFromFilters(contentOverride?: ContentType): PostStreamId {
   const sort = useHomeStore((state) => state.sort);
   const reach = useHomeStore((state) => state.reach);
   const content = useHomeStore((state) => state.content);
+  const profileTags = useHomeStore((state) => state.profileTags);
+  const profileTagScope = useHomeStore((state) => state.profileTagScope);
   const currentUserPubky = useAuthStore((state) => state.currentUserPubky);
-  const effectiveReach = currentUserPubky ? reach : REACH.ALL;
   const effectiveContent = contentOverride ?? content;
 
-  return getStreamId(sort, effectiveReach, effectiveContent);
+  if (reach === REACH.ME && currentUserPubky) {
+    return `${StreamSource.AUTHOR}:${currentUserPubky}` as AuthorStreamCompositeId;
+  }
+
+  return getHomeStreamIdFromFilters(sort, reach, effectiveContent, currentUserPubky, profileTags, profileTagScope);
 }

--- a/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
+++ b/src/hooks/useStreamIdFromFilters/useStreamIdFromFilters.ts
@@ -11,8 +11,8 @@ import { getHomeStreamIdFromFilters } from '@/stores/home/home.utils';
  * This hook reads the current filter state from the filters store and
  * generates the appropriate streamId following the pattern: sorting:source:kind
  *
- * Standard reaches map to PostStreamTypes values. ME reuses the existing
- * author/profile stream, while NETWORK resolves through the ALL mapping.
+ * Standard reaches map to Nexus post streams. ME reuses the existing
+ * author/profile stream, while NETWORK resolves through the WoT stream.
  *
  * @returns The current post stream ID
  *


### PR DESCRIPTION
# DESIGN EXPERIMENT: Visual Reach Selector

> [!WARNING]
> **HIGHLY EXPERIMENTAL DEMO**
>
> This PR is purely a UI demo and design experiment.
> It is not a production proposal and is **not intended to be merged**.

See the video below, or try it yourself using the preview link available on this PR.

## What this experiment explores

- A concentric-circle selector for choosing who posts come from:
  - Me
  - Friends
  - Following
  - My Network
  - All
- Hover previews and selected-state treatments
- Reflecting the selected Reach in the first feed tab
- Compact dropdown controls for Sort, Layout, and Content
- Separating post Reach from WoT “Tagged as” curation
- Feed headings such as:
  > Posts from friends tagged as ‘dev’ by my network

## Questions for feedback

- Is the circular Reach selector understandable and discoverable?
- Do the hover and selected states make the hierarchy clear?
- Is the distinction between **Posts from** and **Tagged as** understandable?
- Do the compact dropdowns improve the sidebar?
- Does the active Reach tab provide enough context above the feed?

## Demo limitations

This prototype intentionally fakes or reuses existing behavior where Nexus support is not available yet:

- **Me** loads the signed-in user’s profile posts.
- Tagged-as filtering uses the currently supported Nexus WoT behavior independently of the selected Reach.
- The implementation and API behavior should not be treated as production-ready.

## Supporting UI fixes

The branch also includes supporting UI fixes that production at some point should reflect:

- minimal collapsed post composer with focus on expansion
- composer padding consistent with posts
- correct feed tab titles that reflect selected reach

## Validation

- 696 test files passed
- 11,321 tests passed
- 2 tests skipped
- TypeScript, lint, and production build passed

## Important

Please review this as a design artifact and interaction prototype—not as a request for code approval or merge readiness.

https://github.com/user-attachments/assets/1eb5f9e6-caeb-4d24-a251-b2f18bbd698b

