### PR TITLE
feat(Dialog): add centered prop for consistent dialog positioning across breakpoints

### DIFF
--- a/src/components/atoms/Dialog/Dialog.test.tsx
+++ b/src/components/atoms/Dialog/Dialog.test.tsx
@@ -119,6 +119,54 @@ describe('Dialog', () => {
     expect(spacer).toHaveAttribute('aria-hidden', 'true');
     expect(spacer).toHaveStyle({ height: '120px' });
   });
+
+  it('uses the mobile bottom-drawer treatment by default', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <div>Dialog Content</div>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialogContent = screen.getByTestId('dialog-content');
+    expect(dialogContent.parentElement).toHaveClass('items-end', 'sm:items-center');
+    expect(dialogContent).toHaveClass('data-[state=open]:slide-in-from-bottom', 'rounded-t-lg', 'm-0', 'sm:m-4');
+  });
+
+  it('centers on every breakpoint with a mobile gutter when centered', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent centered>
+          <div>Dialog Content</div>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialogContent = screen.getByTestId('dialog-content');
+    expect(dialogContent.parentElement).toHaveClass('items-center');
+    expect(dialogContent.parentElement).not.toHaveClass('items-end');
+    // No drawer slide — fade + zoom at all widths, fully rounded, with its own margin.
+    expect(dialogContent).not.toHaveClass('data-[state=open]:slide-in-from-bottom');
+    expect(dialogContent).toHaveClass('data-[state=open]:zoom-in-95', 'data-[state=open]:fade-in-0');
+    expect(dialogContent).toHaveClass('rounded-xl', 'm-6', 'sm:m-4');
+    expect(dialogContent).not.toHaveClass('rounded-t-lg');
+  });
+
+  it('keeps centered layout classes when overrideDefaults drops the default styling', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent centered overrideDefaults>
+          <div>Dialog Content</div>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialogContent = screen.getByTestId('dialog-content');
+    expect(dialogContent.parentElement).toHaveClass('items-center');
+    expect(dialogContent).toHaveClass('m-6', 'sm:m-4', 'data-[state=open]:zoom-in-95');
+    expect(dialogContent).not.toHaveClass('rounded-xl', 'bg-background');
+  });
 });
 
 describe('Dialog - Snapshots', () => {

--- a/src/components/atoms/Dialog/Dialog.test.tsx.snap
+++ b/src/components/atoms/Dialog/Dialog.test.tsx.snap
@@ -8,11 +8,11 @@ exports[`Dialog - Snapshots > matches snapshot for Dialog with default props 1`]
 
 exports[`Dialog - Snapshots > matches snapshot for DialogContent with close button 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -63,11 +63,11 @@ exports[`Dialog - Snapshots > matches snapshot for DialogContent with close butt
 
 exports[`Dialog - Snapshots > matches snapshot for DialogContent with default props 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -118,7 +118,7 @@ exports[`Dialog - Snapshots > matches snapshot for DialogContent with default pr
 
 exports[`Dialog - Snapshots > matches snapshot for DialogContent with overrideDefaults 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
@@ -187,11 +187,11 @@ exports[`Dialog - Snapshots > matches snapshot for DialogContent with overrideDe
 
 exports[`Dialog - Snapshots > matches snapshot for DialogContent without close button 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -242,11 +242,11 @@ exports[`Dialog - Snapshots > matches snapshot for DialogContent without close b
 
 exports[`Dialog - Snapshots > matches snapshot for DialogContent without overrideDefaults 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -379,11 +379,11 @@ exports[`Dialog - Snapshots > matches snapshot for DialogTrigger with default pr
 
 exports[`Dialog - Snapshots > matches snapshot for complete dialog structure 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"

--- a/src/components/atoms/Dialog/Dialog.tsx
+++ b/src/components/atoms/Dialog/Dialog.tsx
@@ -67,6 +67,7 @@ function DialogContent({
   hiddenTitle,
   overrideDefaults = false,
   avoidKeyboard = false,
+  centered = false,
   style,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
@@ -74,6 +75,8 @@ function DialogContent({
   hiddenTitle?: string;
   overrideDefaults?: boolean;
   avoidKeyboard?: boolean;
+  /** Opt out of the mobile bottom-drawer treatment and center the dialog on every breakpoint. */
+  centered?: boolean;
 }) {
   const closeRef = React.useRef<HTMLButtonElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
@@ -85,7 +88,12 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay onCloseRef={closeRef} contentRef={contentRef} />
-      <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      <div
+        className={cn(
+          'fixed inset-0 z-50 flex justify-center',
+          centered ? 'items-center' : 'items-end sm:items-center',
+        )}
+      >
         <DialogPrimitive.Content
           ref={contentRef}
           aria-describedby={undefined}
@@ -95,17 +103,26 @@ function DialogContent({
           className={cn(
             'relative z-50 grid',
             'duration-200',
-            'm-0 sm:m-4',
+            // Centered on mobile has no drawer edge to sit flush against, so it needs its own gutter.
+            centered ? 'm-6 sm:m-4' : 'm-0 sm:m-4',
             'data-[state=closed]:animate-out data-[state=open]:animate-in',
-            // Mobile: clean slide up/down from the bottom (the overlay handles the dimming).
-            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-            // Desktop: reset the slide and fade + zoom in/out instead.
-            'sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0',
-            'sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0',
-            'sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95',
+            centered
+              ? // Centered exception: fade + zoom at every breakpoint, no drawer slide.
+                'data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95'
+              : [
+                  // Mobile: clean slide up/down from the bottom (the overlay handles the dimming).
+                  'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+                  // Desktop: reset the slide and fade + zoom in/out instead.
+                  'sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0',
+                  'sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0',
+                  'sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95',
+                ],
             overrideDefaults
               ? ''
-              : 'max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8',
+              : cn(
+                  'max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8',
+                  centered ? 'rounded-xl' : 'rounded-t-lg border-b-0 sm:border-b',
+                ),
             className,
           )}
           style={contentStyle}

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
       hiddenTitle,
       showCloseButton,
       overrideDefaults,
+      centered,
       onClick,
       'aria-describedby': ariaDescribedBy,
       'data-testid': dataTestId,
@@ -50,6 +51,7 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
       hiddenTitle?: string;
       showCloseButton?: boolean;
       overrideDefaults?: boolean;
+      centered?: boolean;
       onClick?: (e: React.MouseEvent) => void;
       'aria-describedby'?: string;
       'data-testid'?: string;
@@ -64,6 +66,7 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
           data-hidden-title={hiddenTitle}
           data-show-close-button={showCloseButton}
           data-override-defaults={overrideDefaults}
+          data-centered={centered}
           aria-describedby={ariaDescribedBy}
           onClick={onClick}
         >
@@ -544,6 +547,14 @@ describe('PostAttachmentsImagesAndVideos', () => {
 
       const dialogContent = screen.getByTestId('dialog-content');
       expect(dialogContent).toHaveAttribute('data-hidden-title', 'Post Attachments Media Carousel');
+    });
+
+    it('opts the media preview out of the mobile drawer so it stays centered', () => {
+      setDialogOpen(true);
+      const imagesAndVideos = [createMockImage()];
+      render(<PostAttachmentsImagesAndVideos imagesAndVideos={imagesAndVideos} />);
+
+      expect(screen.getByTestId('dialog-content')).toHaveAttribute('data-centered', 'true');
     });
 
     it('does not render dialog content when closed', () => {

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     />
   </div>
   <div
+    data-centered="true"
     data-hidden-title="Post Attachments Media Carousel"
     data-override-defaults="true"
     data-show-close-button="false"
@@ -268,6 +269,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     </div>
   </div>
   <div
+    data-centered="true"
     data-hidden-title="Post Attachments Media Carousel"
     data-override-defaults="true"
     data-show-close-button="false"
@@ -448,6 +450,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     </div>
   </div>
   <div
+    data-centered="true"
     data-hidden-title="Post Attachments Media Carousel"
     data-override-defaults="true"
     data-show-close-button="false"
@@ -567,6 +570,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     />
   </div>
   <div
+    data-centered="true"
     data-hidden-title="Post Attachments Media Carousel"
     data-override-defaults="true"
     data-show-close-button="false"
@@ -690,6 +694,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     />
   </div>
   <div
+    data-centered="true"
     data-hidden-title="Post Attachments Media Carousel"
     data-override-defaults="true"
     data-show-close-button="false"

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </svg>
     </button>
     <div
-      class="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+      class="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
       data-duration="15"
       data-loop="true"
       data-start-index="0"
@@ -301,7 +301,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </svg>
     </button>
     <div
-      class="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+      class="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
       data-duration="15"
       data-loop="true"
       data-start-index="0"
@@ -482,7 +482,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </svg>
     </button>
     <div
-      class="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+      class="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
       data-duration="15"
       data-loop="true"
       data-start-index="0"
@@ -602,7 +602,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </svg>
     </button>
     <div
-      class="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+      class="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
       data-duration="15"
       data-loop="true"
       data-start-index="0"
@@ -726,7 +726,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </svg>
     </button>
     <div
-      class="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+      class="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
       data-duration="15"
       data-loop="true"
       data-start-index="0"

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -198,6 +198,7 @@ export const PostAttachmentsImagesAndVideos = ({
         aria-describedby={undefined}
         showCloseButton={false}
         overrideDefaults
+        centered
         onClick={(e) => {
           e.stopPropagation();
         }}

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -215,7 +215,7 @@ export const PostAttachmentsImagesAndVideos = ({
             watchDrag: !isFullscreen,
           }}
           setApi={setApi}
-          className="w-full max-w-80 xsm:max-w-dvw sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
+          className="w-full max-w-80 xsm:max-w-full sm:max-w-[75dvw] 2xl:max-w-[50dvw]"
         >
           <CarouselContent className="-ml-3 items-center">
             {imagesAndVideos.map((media, i) => (

--- a/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogAddContent/DialogAddContent.test.tsx.snap
@@ -213,11 +213,11 @@ exports[`DialogAddContent - Snapshots > matches the opened desktop dialog snapsh
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 rounded-t-lg border border-b-0 p-6 sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 flex w-xl flex-col overflow-hidden border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
+      class="relative z-50 duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 border p-6 sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b flex w-xl flex-col overflow-hidden border-border bg-popover shadow-2xl outline-none focus:outline-none focus-visible:outline-none"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/Collections/DialogCollectionForm/DialogCollectionForm.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogCollectionForm/DialogCollectionForm.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`DialogCollectionForm - Snapshots > matches snapshot in the default (no 
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"
@@ -404,11 +404,11 @@ exports[`DialogCollectionForm - Snapshots > matches snapshot in the saving state
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"
@@ -790,11 +790,11 @@ exports[`DialogCollectionForm - Snapshots > matches snapshot with a cover previe
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/Collections/DialogCollectionsIntro/DialogCollectionsIntro.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogCollectionsIntro/DialogCollectionsIntro.test.tsx.snap
@@ -27,11 +27,11 @@ exports[`DialogCollectionsIntro - Snapshots > matches snapshot when open 1`] = `
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/Collections/DialogEditCollection/DialogEditCollection.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogEditCollection/DialogEditCollection.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`DialogEditCollection - Snapshots > matches snapshot when open with the 
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/Collections/DialogNewCollection/DialogNewCollection.test.tsx.snap
+++ b/src/components/organisms/Collections/DialogNewCollection/DialogNewCollection.test.tsx.snap
@@ -32,11 +32,11 @@ exports[`DialogNewCollection - Snapshots > matches snapshot when open 1`] = `
     style="pointer-events: auto;"
   />
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
   >
     <div
       aria-labelledby="radix-normalized"
-      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl border-border bg-popover"
+      class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl border-border bg-popover"
       data-cy="dialog-content"
       data-slot="dialog-content"
       data-state="open"

--- a/src/components/organisms/DialogAddLink/DialogAddLink.test.tsx.snap
+++ b/src/components/organisms/DialogAddLink/DialogAddLink.test.tsx.snap
@@ -49,11 +49,11 @@ exports[`DialogAddLink - Snapshots > matches snapshot for DialogAddLink with ico
 
 exports[`DialogAddLink - Snapshots > matches snapshot for default DialogAddLink 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl max-w-xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl max-w-xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"

--- a/src/components/organisms/DialogCheckLink/DialogCheckLink.test.tsx.snap
+++ b/src/components/organisms/DialogCheckLink/DialogCheckLink.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`DialogCheckLink - Snapshots > matches snapshot for default DialogCheckLink 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-2xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-2xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -156,11 +156,11 @@ exports[`DialogCheckLink - Snapshots > matches snapshot when closed 1`] = `<div 
 
 exports[`DialogCheckLink - Snapshots > matches snapshot with long URL 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-2xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-2xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -308,11 +308,11 @@ exports[`DialogCheckLink - Snapshots > matches snapshot with long URL 1`] = `
 
 exports[`DialogCheckLink - Snapshots > matches snapshot with short URL 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-2xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-2xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"

--- a/src/components/organisms/DialogReportPost/DialogReportPost.test.tsx.snap
+++ b/src/components/organisms/DialogReportPost/DialogReportPost.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`DialogReportPost - Snapshots > matches snapshot for issue selection step 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -86,11 +86,11 @@ exports[`DialogReportPost - Snapshots > matches snapshot for issue selection ste
 
 exports[`DialogReportPost - Snapshots > matches snapshot for reason step 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"
@@ -180,11 +180,11 @@ exports[`DialogReportPost - Snapshots > matches snapshot for reason step 1`] = `
 
 exports[`DialogReportPost - Snapshots > matches snapshot for success state 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-xl"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] gap-6 overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-xl"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"

--- a/src/components/organisms/DialogSignIn/DialogSignIn.test.tsx.snap
+++ b/src/components/organisms/DialogSignIn/DialogSignIn.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`DialogSignIn - Snapshots > matches snapshot when closed 1`] = `null`;
 
 exports[`DialogSignIn - Snapshots > matches snapshot when open 1`] = `
 <div
-  class="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+  class="fixed inset-0 z-50 flex justify-center items-end sm:items-center"
 >
   <div
     aria-labelledby="radix-normalized"
-    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] overflow-y-auto rounded-t-lg border border-b-0 bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:border-b sm:p-8 w-[576px] gap-6"
+    class="relative z-50 grid duration-200 m-0 sm:m-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95 max-h-[calc(100dvh-2rem)] max-w-[100vw] overflow-y-auto border bg-background p-6 shadow-lg sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:rounded-b-lg sm:p-8 rounded-t-lg border-b-0 sm:border-b w-[576px] gap-6"
     data-cy="dialog-content"
     data-slot="dialog-content"
     data-state="open"


### PR DESCRIPTION
resolves #2205

- Introduced a new `centered` prop to the Dialog component, allowing dialogs to be centered on all screen sizes, including mobile.
- Updated styling to accommodate the centered layout, ensuring proper margins and animations based on the `centered` state.
- Adjusted the PostAttachmentsImagesAndVideos component to utilize the new `centered` prop for media previews.

This enhancement improves the user experience by providing a more consistent dialog presentation across devices.

Demo
<img width="943" height="775" alt="Screenshot 2026-07-30 at 09 49 40" src="https://github.com/user-attachments/assets/0fc34f08-9049-495f-b33d-07828bdd38e3" />
<img width="359" height="776" alt="Screenshot 2026-07-30 at 09 49 35" src="https://github.com/user-attachments/assets/95c9fd3f-98b3-4387-83b8-8745b57fa3c9" />
<img width="362" height="754" alt="Screenshot 2026-07-30 at 09 49 27" src="https://github.com/user-attachments/assets/b30a6171-962c-475e-8b5a-7ba83d371965" />