### PR TITLE
chore: cleanup sms strings

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -272,7 +272,6 @@
       "blockedDescription": "لا يمكن استخدام رقم الهاتف هذا للتحقق.",
       "tooManyAttempts": "محاولات تحقق كثيرة جدا",
       "tooManyAttemptsDescription": "محاولات تحقق كثيرة جداً",
-      "sendFailed": "فشل ارسال رمز الرسالة القصيرة",
       "sendFailedDescription": "تعذر إرسال رمز التحقق. حاول لاحقاً.",
       "rateLimitedWithRetry": "محاولات تحقق كثيرة جداً. أعد المحاولة خلال {seconds} ث.",
       "weeklyLimitReached": "محاولات تحقق كثيرة جداً",
@@ -292,7 +291,6 @@
       "verify": "تحقق من الرمز",
       "valid": "رمز التحقق صحيح",
       "invalid": "رمز التحقق غير صحيح. حاول مرة اخرى.",
-      "verifyFailed": "فشل التحقق من رمز الرسالة القصيرة",
       "verifyFailedDescription": "تعذر التحقق من الرمز. حاول لاحقاً."
     },
     "lightning": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -272,7 +272,6 @@
       "blockedDescription": "Diese Telefonnummer kann nicht zur Verifizierung verwendet werden.",
       "tooManyAttempts": "Zu viele Verifizierungsversuche",
       "tooManyAttemptsDescription": "Zu viele Verifizierungsversuche",
-      "sendFailed": "SMS-Code konnte nicht gesendet werden",
       "sendFailedDescription": "Verifizierungscode konnte nicht gesendet werden. Versuchen Sie es später erneut.",
       "rateLimitedWithRetry": "Zu viele Verifizierungsversuche. Erneut versuchen in {seconds}s.",
       "weeklyLimitReached": "Zu viele Verifizierungsversuche",
@@ -292,7 +291,6 @@
       "verify": "Code verifizieren",
       "valid": "Verifizierungscode gültig",
       "invalid": "Verifizierungscode ungültig. Versuchen Sie es erneut.",
-      "verifyFailed": "SMS-Code konnte nicht verifiziert werden",
       "verifyFailedDescription": "Code konnte nicht verifiziert werden. Versuchen Sie es später erneut."
     },
     "lightning": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -276,7 +276,6 @@
       "yearlyLimitReached": "Too many verification attempts",
       "yearlyLimitDescription": "Too many verification attempts",
       "verificationFailed": "Phone verification failed. Try again.",
-      "sendFailed": "Failed to send SMS code",
       "sendFailedDescription": "Could not send verification code. Try again later."
     },
     "phoneCode": {
@@ -290,7 +289,6 @@
       "verify": "Verify Code",
       "valid": "Verification code valid",
       "invalid": "Verification Code Invalid. Try again.",
-      "verifyFailed": "Failed to verify sms code",
       "verifyFailedDescription": "Could not verify code. Try again later."
     },
     "lightning": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -276,7 +276,6 @@
       "yearlyLimitReached": "Demasiados intentos de verificación",
       "yearlyLimitDescription": "Demasiados intentos de verificación",
       "verificationFailed": "La verificación del teléfono falló. Inténtalo de nuevo.",
-      "sendFailed": "Error al enviar código SMS",
       "sendFailedDescription": "No se pudo enviar el código de verificación. Inténtalo más tarde."
     },
     "phoneCode": {
@@ -290,7 +289,6 @@
       "verify": "Verificar código",
       "valid": "Código de verificación válido",
       "invalid": "Código de verificación inválido. Intenta de nuevo.",
-      "verifyFailed": "Error al verificar código SMS",
       "verifyFailedDescription": "No se pudo verificar el código. Inténtalo más tarde."
     },
     "lightning": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -270,7 +270,6 @@
       "blockedDescription": "Ce numéro de téléphone ne peut pas etre utilise pour la vérification.",
       "tooManyAttempts": "Trop de tentatives de vérification",
       "tooManyAttemptsDescription": "Trop de tentatives de vérification",
-      "sendFailed": "Échec de l'envoi du code SMS",
       "sendFailedDescription": "Impossible d'envoyer le code de vérification. Réessayez plus tard.",
       "rateLimitedWithRetry": "Trop de tentatives de vérification. Réessayez dans {seconds}s.",
       "weeklyLimitReached": "Trop de tentatives de vérification",
@@ -290,7 +289,6 @@
       "verify": "Verifier le code",
       "valid": "Code de vérification valide",
       "invalid": "Code de vérification invalide. Reessayez.",
-      "verifyFailed": "Échec de la vérification du code SMS",
       "verifyFailedDescription": "Impossible de vérifier le code. Réessayez plus tard."
     },
     "lightning": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -270,7 +270,6 @@
       "blockedDescription": "Questo numero di telefono non può essere usato per la verifica.",
       "tooManyAttempts": "Troppi tentativi di verifica",
       "tooManyAttemptsDescription": "Troppi tentativi di verifica",
-      "sendFailed": "Invio codice SMS fallito",
       "sendFailedDescription": "Impossibile inviare il codice di verifica. Riprova più tardi.",
       "rateLimitedWithRetry": "Troppi tentativi di verifica. Riprova tra {seconds}s.",
       "weeklyLimitReached": "Troppi tentativi di verifica",
@@ -290,7 +289,6 @@
       "verify": "Verifica codice",
       "valid": "Codice di verifica valido",
       "invalid": "Codice di verifica non valido. Riprova.",
-      "verifyFailed": "Verifica codice SMS fallita",
       "verifyFailedDescription": "Impossibile verificare il codice. Riprova più tardi."
     },
     "lightning": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -270,7 +270,6 @@
       "blockedDescription": "この電話番号は確認に使用できません。",
       "tooManyAttempts": "確認の試行回数が多すぎます",
       "tooManyAttemptsDescription": "認証試行回数が多すぎます",
-      "sendFailed": "SMSコードの送信に失敗しました",
       "sendFailedDescription": "認証コードを送信できませんでした。後でもう一度お試しください。",
       "rateLimitedWithRetry": "認証試行回数が多すぎます。{seconds}秒後に再試行してください。",
       "weeklyLimitReached": "認証試行回数が多すぎます",
@@ -290,7 +289,6 @@
       "verify": "コードを確認",
       "valid": "確認コードは有効です",
       "invalid": "確認コードが無効です。再試行してください。",
-      "verifyFailed": "SMSコードの確認に失敗しました",
       "verifyFailedDescription": "コードを確認できませんでした。後でもう一度お試しください。"
     },
     "lightning": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -270,7 +270,6 @@
       "blockedDescription": "Este número de telefone não pode ser usado para verificação.",
       "tooManyAttempts": "Muitas tentativas de verificação",
       "tooManyAttemptsDescription": "Muitas tentativas de verificação",
-      "sendFailed": "Falha ao enviar código SMS",
       "sendFailedDescription": "Não foi possível enviar o código de verificação. Tente mais tarde.",
       "rateLimitedWithRetry": "Muitas tentativas de verificação. Tente novamente em {seconds}s.",
       "weeklyLimitReached": "Muitas tentativas de verificação",
@@ -290,7 +289,6 @@
       "verify": "Verificar Código",
       "valid": "Código de Verificacao Válido",
       "invalid": "Código de Verificacao Inválido. Tente novamente.",
-      "verifyFailed": "Falha ao verificar código SMS",
       "verifyFailedDescription": "Não foi possível verificar o código. Tente mais tarde."
     },
     "lightning": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -270,7 +270,6 @@
       "blockedDescription": "此手机号无法用于验证。",
       "tooManyAttempts": "验证尝试次数过多",
       "tooManyAttemptsDescription": "验证尝试次数过多",
-      "sendFailed": "发送短信验证码失败",
       "sendFailedDescription": "无法发送验证码。请稍后重试。",
       "rateLimitedWithRetry": "验证尝试次数过多。请在{seconds}秒后重试。",
       "weeklyLimitReached": "验证尝试次数过多",
@@ -290,7 +289,6 @@
       "verify": "验证",
       "valid": "验证码有效",
       "invalid": "验证码无效。请重试。",
-      "verifyFailed": "短信验证码验证失败",
       "verifyFailedDescription": "无法验证验证码。请稍后重试。"
     },
     "lightning": {

--- a/src/components/molecules/HumanSmsCard/HumanSmsCard.test.tsx.snap
+++ b/src/components/molecules/HumanSmsCard/HumanSmsCard.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SmsVerificationCard > matches snapshot 1`] = `
         data-slot="illustrated-card-visual"
       >
         <img
-          alt="Lime Pubky phone representing SMS verification"
+          alt="Lime Pubky phone representing phone number verification"
           class="max-w-full size-48"
           height="600"
           src="/images/sms-verification-phone.webp"
@@ -201,7 +201,7 @@ exports[`SmsVerificationCard > matches snapshot when geoblocked 1`] = `
         data-slot="illustrated-card-visual"
       >
         <img
-          alt="Lime Pubky phone representing SMS verification"
+          alt="Lime Pubky phone representing phone number verification"
           class="max-w-full size-48"
           height="600"
           src="/images/sms-verification-phone.webp"

--- a/src/components/molecules/HumanSmsCard/HumanSmsCard.tsx
+++ b/src/components/molecules/HumanSmsCard/HumanSmsCard.tsx
@@ -37,7 +37,7 @@ export const HumanSmsCard = ({ onClick }: HumanSmsCardProps) => {
           <Image
             priority
             src="/images/sms-verification-phone.webp"
-            alt="Lime Pubky phone representing SMS verification"
+            alt="Lime Pubky phone representing phone number verification"
             className="size-48"
           />
         }


### PR DESCRIPTION
## 🎯 Summary

Fixes #2198. Removes the last remaining "SMS" references from the Proof of Phone onboarding flow.

**Context:** the visible copy this issue reported ("Proof of Phone." title, "…verification code via SMS…" subtitle, "SMS or payment verification not available…" invite text) was already replaced with generic phone wording by #2250 (merged Jul 27, after this issue was filed Jul 15). What remained was non-visual residue, which this PR cleans up.

## ✅ What changed

### 🌐 Dead SMS toast strings removed from all 9 locales

`onboarding.phone.sendFailed` ("Failed to send SMS code") and `onboarding.phoneCode.verifyFailed` ("Failed to verify sms code") are deleted from `ar`, `de`, `en`, `es`, `fr`, `it`, `ja`, `pt-BR`, and `zh`.

These were former toast *titles*, orphaned since #1892 switched the onboarding error toasts to description-only. No component references them (verified repo-wide, including Cypress). The toasts users actually see are unchanged — they use the sibling `sendFailedDescription` / `verifyFailedDescription` keys, which were already SMS-free ("Could not send verification code. Try again later." / "Could not verify code. Try again later.").

### ♿ Alt text on the phone verification card

`HumanSmsCard` illustration alt text: "Lime Pubky phone representing SMS verification" → "Lime Pubky phone representing phone number verification" (screen-reader only). Test snapshot regenerated accordingly.

## 🔍 Intentionally left alone

- **"It was likely sent by SMS, WhatsApp, or Telegram."** on the Enter Code page — this is *by design*: the current Figma handoff frame ("Create account - SMS verify") contains this exact line, added deliberately in #2250. Here SMS is listed as one delivery channel among several, which is the "other means of messaging" the issue refers to.
- **Terms of Service / Privacy Policy dialogs** — legal copy accurately describing the SMS verification service.
- **Internal identifiers** (`HumanSmsCard`, `useSmsVerificationInfo`, `sendSmsCode`, `data-testid`s, image filenames) — not user-facing; renaming would ripple through the homegate service layer for no UI benefit.

## 🧪 Testing

- Unit tests for `HumanSmsCard`, `HumanSelection`, `HumanPhoneInput`, `HumanPhoneCode`, and the `Human` template all pass (24 tests); `HumanSmsCard` snapshot updated.
- `eslint` and `tsc --noEmit` clean.
- Locale files edited by pure line deletion (no reformatting); all 9 validated as JSON.
- No VRT baseline changes expected: the deleted keys were unused and alt text only renders when an image fails to load, so no pixels change. The checked-in onboarding VRT baseline already shows the SMS-free "Phone Number" card.

## 📋 Follow-up

#1892 also orphaned the other former toast title keys (`blocked`, `tooManyAttempts`, `weeklyLimitReached`, `yearlyLimitReached`). They contain no SMS wording, so they were left out of this fix — candidates for a separate locale cleanup.

_This pull request summary was generated, for full implementation details please reference the file changes._
