### PR TITLE
fix(ui): scope post header popover to the user profile block

### DIFF
--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
@@ -468,10 +468,28 @@ describe('PostHeaderUserInfo - Navigation', () => {
     const usernameLink = profileLinks[1];
     const userInfoRoot = usernameLink.parentElement?.parentElement;
 
-    expect(userInfoRoot).toHaveClass('grid', 'w-full', 'max-w-full', 'min-w-0', 'grid-cols-[auto_minmax(0,1fr)]');
+    expect(userInfoRoot).toHaveClass('grid', 'w-fit', 'max-w-full', 'min-w-0', 'grid-cols-[auto_minmax(0,1fr)]');
     expect(usernameLink.parentElement).toHaveClass('max-w-full', 'min-w-0');
-    expect(usernameLink).toHaveClass('block', 'w-full', 'min-w-0', 'max-w-full', 'overflow-hidden');
+    expect(usernameLink).toHaveClass('block', 'w-fit', 'min-w-0', 'max-w-full', 'overflow-hidden');
     expect(screen.getByText(longName)).toHaveClass('w-full', 'truncate', 'max-w-full');
+  });
+
+  it('keeps the popover hover target hugging the user info instead of the whole header row', () => {
+    render(<PostHeaderUserInfo userId="testuser123" userName="Test User" />);
+
+    const userInfoRoot = screen.getByTestId('popover-trigger').firstElementChild;
+
+    expect(userInfoRoot).toHaveClass('w-fit', 'max-w-full');
+    expect(userInfoRoot).not.toHaveClass('w-full');
+  });
+
+  it('keeps the username link hugging its text so it is not clickable across the header row', () => {
+    render(<PostHeaderUserInfo userId="testuser123" userName="Test User" showPopover={false} />);
+
+    const usernameLink = screen.getAllByTestId('profile-link')[1];
+
+    expect(usernameLink).toHaveClass('w-fit', 'max-w-full');
+    expect(usernameLink).not.toHaveClass('w-full');
   });
 });
 

--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx.snap
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot for current user (no 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -36,7 +36,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot for current user (no 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile"
         >
@@ -94,7 +94,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot when following 1`] = 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -120,7 +120,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot when following 1`] = 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/otherUser123"
         >
@@ -178,7 +178,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all new props 1`
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-4"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-4"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -209,7 +209,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all new props 1`
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -272,7 +272,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all props 1`] = 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -303,7 +303,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all props 1`] = 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -361,7 +361,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with bio 1`] = `
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -387,7 +387,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with bio 1`] = `
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -445,7 +445,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with large size 1`] =
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-4"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-4"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -471,7 +471,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with large size 1`] =
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -529,7 +529,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with minimal props 1`
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -555,7 +555,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with minimal props 1`
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/user123"
         >
@@ -613,7 +613,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with timeAgo 1`] = `
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -639,7 +639,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with timeAgo 1`] = `
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -702,7 +702,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot without avatarUrl 1`]
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -728,7 +728,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot without avatarUrl 1`]
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >

--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
@@ -37,11 +37,14 @@ export function PostHeaderUserInfo({
     e.stopPropagation();
   };
 
+  // This container is also the UserInfoPopover hover target, so it must hug the avatar and
+  // name instead of stretching across the header row — otherwise the empty space next to the
+  // timestamp opens the popover. `max-w-full` keeps long names truncating inside tight layouts.
   const content = (
     <Container
       overrideDefaults
       className={cn(
-        'grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center',
+        'grid w-fit max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center',
         size === 'large' ? 'gap-4' : 'gap-3',
       )}
     >
@@ -54,7 +57,7 @@ export function PostHeaderUserInfo({
         />
       </Link>
       <Container overrideDefaults className="max-w-full min-w-0">
-        <Link href={profileUrl} onClick={handleLinkClick} className="block w-full max-w-full min-w-0 overflow-hidden">
+        <Link href={profileUrl} onClick={handleLinkClick} className="block w-fit max-w-full min-w-0 overflow-hidden">
           <Typography
             className={cn(
               'block w-full max-w-full cursor-pointer truncate font-bold text-foreground',


### PR DESCRIPTION
## Summary

- fix #2303
- The user info popover was opening from anywhere on the post header line, not just the user profile. Regression from #2113.
- #2113 made the `PostHeaderUserInfo` root container `w-full` so long display names could truncate — but that container is also the `UserInfoPopover` hover target (`PopoverTrigger asChild`), so the hover area grew to span the whole header row. The username `<a>` grew with it, making the empty space clickable through to the profile too.

## Changes

- `PostHeaderUserInfo.tsx`: root container `w-full` → `w-fit` (keeping `max-w-full min-w-0`), so the popover trigger hugs the avatar + name and still falls back to the available width — and truncates — when the name is long.
- `PostHeaderUserInfo.tsx`: username link `w-full` → `w-fit` for the same reason, so its click target ends with the text.
- Added a comment on the container explaining that it doubles as the hover target, so it doesn't get reverted to `w-full` by the next layout fix.
- Added two regression tests: one asserting the popover trigger is not full-width, one asserting the username link is not full-width.
- Updated the existing long-name truncation assertions and 9 snapshots.

## Test plan

- [x] `npm run test` — full unit suite green (737 files, 11,758 tests)
- [x] `npm run test:vrt` — 30 files / 63 tests green, no baseline changes needed (the container is invisible; only its box width changed)
- [x] `npm run typecheck`, `npm run lint`, Prettier — clean
- [x] Manual browser check on `/home` at 1440px: post header popover trigger went from **696px wide → 143px**; a point 20px left of the timestamp is no longer inside the trigger
- [x] Real hover: hovering the timestamp no longer opens the popover; hovering the display name and avatar still does
- [x] Long-name regression (the #2112 fix): forced a 96-char name and a 74-char unbreakable name into the header — truncates with no overflow and no horizontal page scroll, on the feed, in the reply dialog (both the composer header and the replied-to preview), and at mobile width
- [x] Checked the `size="large"` / `timeAgoPlacement="bottom-left"` variant on the article detail page

## Notes

- Fixing the username link width is slightly beyond the reported hover bug, but it's the same root cause on the same element tree: pre-#2113 that link was `w-fit`, and while it was `w-full` a click in the empty header space navigated to the author's profile.
- `w-fit` is `min(max-content, available)`, and `max-w-full` caps the pathological case of a single unbreakable word whose `min-content` exceeds the column — both verified in the browser.
