### PR TITLE
fix(ui): enable arrow keys on media carousel open

### DIFF
--- a/src/components/atoms/Carousel/Carousel.test.tsx
+++ b/src/components/atoms/Carousel/Carousel.test.tsx
@@ -45,6 +45,7 @@ describe('Carousel', () => {
     expect(carousel).toBeInTheDocument();
     expect(carousel).toHaveAttribute('aria-roledescription', 'carousel');
     expect(carousel).toHaveAttribute('data-slot', 'carousel');
+    expect(carousel).toHaveAttribute('tabIndex', '0');
   });
 
   it('renders carousel content with correct structure', () => {

--- a/src/components/atoms/Carousel/Carousel.test.tsx.snap
+++ b/src/components/atoms/Carousel/Carousel.test.tsx.snap
@@ -3,9 +3,10 @@
 exports[`Carousel - Snapshots > matches snapshot for horizontal orientation 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -94,9 +95,10 @@ exports[`Carousel - Snapshots > matches snapshot for horizontal orientation 1`] 
 exports[`Carousel - Snapshots > matches snapshot for vertical orientation 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -185,9 +187,10 @@ exports[`Carousel - Snapshots > matches snapshot for vertical orientation 1`] = 
 exports[`Carousel - Snapshots > matches snapshot with both navigation buttons disabled 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -278,9 +281,10 @@ exports[`Carousel - Snapshots > matches snapshot with both navigation buttons di
 exports[`Carousel - Snapshots > matches snapshot with complex slide content 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -393,9 +397,10 @@ exports[`Carousel - Snapshots > matches snapshot with complex slide content 1`] 
 exports[`Carousel - Snapshots > matches snapshot with custom button sizes 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -484,9 +489,10 @@ exports[`Carousel - Snapshots > matches snapshot with custom button sizes 1`] = 
 exports[`Carousel - Snapshots > matches snapshot with custom button variants 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -575,9 +581,10 @@ exports[`Carousel - Snapshots > matches snapshot with custom button variants 1`]
 exports[`Carousel - Snapshots > matches snapshot with custom className on Carousel 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative custom-carousel"
+  class="relative outline-none custom-carousel"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -602,9 +609,10 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with custom className on CarouselContent 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -629,9 +637,10 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with custom className on CarouselItem 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -656,9 +665,10 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with default props 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -683,9 +693,10 @@ exports[`Carousel - Snapshots > matches snapshot with default props 1`] = `
 exports[`Carousel - Snapshots > matches snapshot with disabled next button 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -743,9 +754,10 @@ exports[`Carousel - Snapshots > matches snapshot with disabled next button 1`] =
 exports[`Carousel - Snapshots > matches snapshot with disabled previous button 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -803,9 +815,10 @@ exports[`Carousel - Snapshots > matches snapshot with disabled previous button 1
 exports[`Carousel - Snapshots > matches snapshot with multiple slides 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"
@@ -846,9 +859,10 @@ exports[`Carousel - Snapshots > matches snapshot with multiple slides 1`] = `
 exports[`Carousel - Snapshots > matches snapshot with navigation buttons 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative"
+  class="relative outline-none"
   data-slot="carousel"
   role="region"
+  tabindex="0"
 >
   <div
     class="overflow-hidden"

--- a/src/components/atoms/Carousel/Carousel.test.tsx.snap
+++ b/src/components/atoms/Carousel/Carousel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Carousel - Snapshots > matches snapshot for horizontal orientation 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -95,7 +95,7 @@ exports[`Carousel - Snapshots > matches snapshot for horizontal orientation 1`] 
 exports[`Carousel - Snapshots > matches snapshot for vertical orientation 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -187,7 +187,7 @@ exports[`Carousel - Snapshots > matches snapshot for vertical orientation 1`] = 
 exports[`Carousel - Snapshots > matches snapshot with both navigation buttons disabled 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -281,7 +281,7 @@ exports[`Carousel - Snapshots > matches snapshot with both navigation buttons di
 exports[`Carousel - Snapshots > matches snapshot with complex slide content 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -397,7 +397,7 @@ exports[`Carousel - Snapshots > matches snapshot with complex slide content 1`] 
 exports[`Carousel - Snapshots > matches snapshot with custom button sizes 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -489,7 +489,7 @@ exports[`Carousel - Snapshots > matches snapshot with custom button sizes 1`] = 
 exports[`Carousel - Snapshots > matches snapshot with custom button variants 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -581,7 +581,7 @@ exports[`Carousel - Snapshots > matches snapshot with custom button variants 1`]
 exports[`Carousel - Snapshots > matches snapshot with custom className on Carousel 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none custom-carousel"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring custom-carousel"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -609,7 +609,7 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with custom className on CarouselContent 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -637,7 +637,7 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with custom className on CarouselItem 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -665,7 +665,7 @@ exports[`Carousel - Snapshots > matches snapshot with custom className on Carous
 exports[`Carousel - Snapshots > matches snapshot with default props 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -693,7 +693,7 @@ exports[`Carousel - Snapshots > matches snapshot with default props 1`] = `
 exports[`Carousel - Snapshots > matches snapshot with disabled next button 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -754,7 +754,7 @@ exports[`Carousel - Snapshots > matches snapshot with disabled next button 1`] =
 exports[`Carousel - Snapshots > matches snapshot with disabled previous button 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -815,7 +815,7 @@ exports[`Carousel - Snapshots > matches snapshot with disabled previous button 1
 exports[`Carousel - Snapshots > matches snapshot with multiple slides 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"
@@ -859,7 +859,7 @@ exports[`Carousel - Snapshots > matches snapshot with multiple slides 1`] = `
 exports[`Carousel - Snapshots > matches snapshot with navigation buttons 1`] = `
 <div
   aria-roledescription="carousel"
-  class="relative outline-none"
+  class="relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-slot="carousel"
   role="region"
   tabindex="0"

--- a/src/components/atoms/Carousel/Carousel.tsx
+++ b/src/components/atoms/Carousel/Carousel.tsx
@@ -116,10 +116,11 @@ function Carousel({
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn('relative', className)}
+        className={cn('relative outline-none', className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
+        tabIndex={0}
         {...props}
       >
         {children}

--- a/src/components/atoms/Carousel/Carousel.tsx
+++ b/src/components/atoms/Carousel/Carousel.tsx
@@ -116,7 +116,7 @@ function Carousel({
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn('relative outline-none', className)}
+        className={cn('relative outline-none focus-visible:ring-2 focus-visible:ring-ring', className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"

--- a/src/components/atoms/Video/Video.test.tsx.snap
+++ b/src/components/atoms/Video/Video.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Video - Snapshots > matches snapshot with MP4 video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -12,7 +12,7 @@ exports[`Video - Snapshots > matches snapshot with MP4 video 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with OGG video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -22,7 +22,7 @@ exports[`Video - Snapshots > matches snapshot with OGG video 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with WebM video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -33,7 +33,7 @@ exports[`Video - Snapshots > matches snapshot with WebM video 1`] = `
 exports[`Video - Snapshots > matches snapshot with autoPlay and muted 1`] = `
 <video
   autoplay=""
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -43,7 +43,7 @@ exports[`Video - Snapshots > matches snapshot with autoPlay and muted 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with controls disabled 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   data-testid="video"
   preload="metadata"
   src="/video.mp4"
@@ -52,7 +52,7 @@ exports[`Video - Snapshots > matches snapshot with controls disabled 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with custom className 1`] = `
 <video
-  class="h-auto max-w-full bg-black outline-none focus:outline-none rounded-lg shadow-lg"
+  class="h-auto max-w-full bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg shadow-lg"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -62,7 +62,7 @@ exports[`Video - Snapshots > matches snapshot with custom className 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with data-testid prop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="custom-test-id"
   preload="metadata"
@@ -72,7 +72,7 @@ exports[`Video - Snapshots > matches snapshot with data-testid prop 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with id prop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   id="hero-video"
@@ -83,7 +83,7 @@ exports[`Video - Snapshots > matches snapshot with id prop 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with loop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   loop=""
@@ -95,7 +95,7 @@ exports[`Video - Snapshots > matches snapshot with loop 1`] = `
 exports[`Video - Snapshots > matches snapshot with multiple custom attributes 1`] = `
 <video
   autoplay=""
-  class="h-auto max-w-full bg-black outline-none focus:outline-none rounded-xl border-2"
+  class="h-auto max-w-full bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl border-2"
   controls=""
   data-testid="video"
   height="720"
@@ -110,7 +110,7 @@ exports[`Video - Snapshots > matches snapshot with multiple custom attributes 1`
 
 exports[`Video - Snapshots > matches snapshot with playsInline 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   playsinline=""
@@ -121,7 +121,7 @@ exports[`Video - Snapshots > matches snapshot with playsInline 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with poster 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   poster="/thumbnail.jpg"
@@ -132,7 +132,7 @@ exports[`Video - Snapshots > matches snapshot with poster 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with preload attribute 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="none"
@@ -142,7 +142,7 @@ exports[`Video - Snapshots > matches snapshot with preload attribute 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with required props 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -152,7 +152,7 @@ exports[`Video - Snapshots > matches snapshot with required props 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with width and height 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring"
   controls=""
   data-testid="video"
   height="600"

--- a/src/components/atoms/Video/Video.test.tsx.snap
+++ b/src/components/atoms/Video/Video.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Video - Snapshots > matches snapshot with MP4 video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -12,7 +12,7 @@ exports[`Video - Snapshots > matches snapshot with MP4 video 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with OGG video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -22,7 +22,7 @@ exports[`Video - Snapshots > matches snapshot with OGG video 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with WebM video 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -33,7 +33,7 @@ exports[`Video - Snapshots > matches snapshot with WebM video 1`] = `
 exports[`Video - Snapshots > matches snapshot with autoPlay and muted 1`] = `
 <video
   autoplay=""
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -43,7 +43,7 @@ exports[`Video - Snapshots > matches snapshot with autoPlay and muted 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with controls disabled 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   data-testid="video"
   preload="metadata"
   src="/video.mp4"
@@ -52,7 +52,7 @@ exports[`Video - Snapshots > matches snapshot with controls disabled 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with custom className 1`] = `
 <video
-  class="h-auto max-w-full bg-black rounded-lg shadow-lg"
+  class="h-auto max-w-full bg-black outline-none focus:outline-none rounded-lg shadow-lg"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -62,7 +62,7 @@ exports[`Video - Snapshots > matches snapshot with custom className 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with data-testid prop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="custom-test-id"
   preload="metadata"
@@ -72,7 +72,7 @@ exports[`Video - Snapshots > matches snapshot with data-testid prop 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with id prop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   id="hero-video"
@@ -83,7 +83,7 @@ exports[`Video - Snapshots > matches snapshot with id prop 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with loop 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   loop=""
@@ -95,7 +95,7 @@ exports[`Video - Snapshots > matches snapshot with loop 1`] = `
 exports[`Video - Snapshots > matches snapshot with multiple custom attributes 1`] = `
 <video
   autoplay=""
-  class="h-auto max-w-full bg-black rounded-xl border-2"
+  class="h-auto max-w-full bg-black outline-none focus:outline-none rounded-xl border-2"
   controls=""
   data-testid="video"
   height="720"
@@ -110,7 +110,7 @@ exports[`Video - Snapshots > matches snapshot with multiple custom attributes 1`
 
 exports[`Video - Snapshots > matches snapshot with playsInline 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   playsinline=""
@@ -121,7 +121,7 @@ exports[`Video - Snapshots > matches snapshot with playsInline 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with poster 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   poster="/thumbnail.jpg"
@@ -132,7 +132,7 @@ exports[`Video - Snapshots > matches snapshot with poster 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with preload attribute 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="none"
@@ -142,7 +142,7 @@ exports[`Video - Snapshots > matches snapshot with preload attribute 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with required props 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   preload="metadata"
@@ -152,7 +152,7 @@ exports[`Video - Snapshots > matches snapshot with required props 1`] = `
 
 exports[`Video - Snapshots > matches snapshot with width and height 1`] = `
 <video
-  class="h-auto max-w-full rounded-md bg-black"
+  class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none"
   controls=""
   data-testid="video"
   height="600"

--- a/src/components/atoms/Video/Video.tsx
+++ b/src/components/atoms/Video/Video.tsx
@@ -38,7 +38,7 @@ export const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video(
         }
       }}
       data-testid={dataTestId || 'video'}
-      className={cn('h-auto max-w-full rounded-md bg-black', className)}
+      className={cn('h-auto max-w-full rounded-md bg-black outline-none focus:outline-none', className)}
       src={src}
       controls={controls}
       preload={preload}

--- a/src/components/atoms/Video/Video.tsx
+++ b/src/components/atoms/Video/Video.tsx
@@ -38,7 +38,10 @@ export const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video(
         }
       }}
       data-testid={dataTestId || 'video'}
-      className={cn('h-auto max-w-full rounded-md bg-black outline-none focus:outline-none', className)}
+      className={cn(
+        'h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className,
+      )}
       src={src}
       controls={controls}
       preload={preload}

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { useEffect, useLayoutEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AttachmentConstructed } from '@/organisms/PostAttachments/PostAttachments.types';
 import { PostAttachmentsImagesAndVideos } from './PostAttachmentsImagesAndVideos';
@@ -44,6 +44,7 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
       overrideDefaults,
       centered,
       onClick,
+      onOpenAutoFocus,
       'aria-describedby': ariaDescribedBy,
       'data-testid': dataTestId,
     }: {
@@ -53,9 +54,19 @@ vi.mock('@/atoms/Dialog/Dialog', () => {
       overrideDefaults?: boolean;
       centered?: boolean;
       onClick?: (e: React.MouseEvent) => void;
+      onOpenAutoFocus?: (e: Event) => void;
       'aria-describedby'?: string;
       'data-testid'?: string;
     }) => {
+      // Mimic Radix Dialog open autofocus after children (and refs) are committed
+      useLayoutEffect(() => {
+        if (!dialogOpenState || !onOpenAutoFocus) {
+          return;
+        }
+        const event = new Event('focus', { cancelable: true });
+        onOpenAutoFocus(event);
+      }, [onOpenAutoFocus]);
+
       // Only render content when dialog is open (mimics real DialogContent behavior)
       if (!dialogOpenState) {
         return null;
@@ -160,11 +171,15 @@ vi.mock('@/atoms/Carousel/Carousel', () => {
       opts,
       setApi,
       className,
+      ref,
+      tabIndex = 0,
     }: {
       children: React.ReactNode;
       opts?: { startIndex?: number; loop?: boolean; duration?: number; watchDrag?: boolean };
       setApi?: (api: unknown) => void;
       className?: string;
+      ref?: React.Ref<HTMLDivElement>;
+      tabIndex?: number;
     }) => {
       // Simulate setting the API in useEffect to avoid infinite re-renders
       useEffect(() => {
@@ -172,11 +187,14 @@ vi.mock('@/atoms/Carousel/Carousel', () => {
           setApi({
             selectedScrollSnap: () => 0,
             on: vi.fn(),
+            off: vi.fn(),
           });
         }
       }, [setApi]);
       return (
         <div
+          ref={ref}
+          tabIndex={tabIndex}
           data-testid="carousel"
           data-start-index={opts?.startIndex}
           data-loop={opts?.loop}
@@ -626,6 +644,17 @@ describe('PostAttachmentsImagesAndVideos', () => {
       render(<PostAttachmentsImagesAndVideos imagesAndVideos={imagesAndVideos} />);
 
       expect(screen.queryByText('1/1')).not.toBeInTheDocument();
+    });
+
+    it('focuses the carousel on open so arrow keys work without clicking nav', async () => {
+      setDialogOpen(true);
+      const imagesAndVideos = [createMockImage(), createMockImage()];
+      render(<PostAttachmentsImagesAndVideos imagesAndVideos={imagesAndVideos} />);
+
+      const carousel = screen.getByTestId('carousel');
+      await waitFor(() => {
+        expect(carousel).toHaveFocus();
+      });
     });
   });
 

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with GIF 
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -43,7 +43,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -106,6 +106,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-start-index="0"
       data-testid="carousel"
       data-watch-drag="true"
+      tabindex="0"
     >
       <div
         class="-ml-3 items-center"
@@ -214,7 +215,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -232,7 +233,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -250,7 +251,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -307,6 +308,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-start-index="0"
       data-testid="carousel"
       data-watch-drag="true"
+      tabindex="0"
     >
       <div
         class="-ml-3 items-center"
@@ -431,7 +433,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -488,6 +490,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-start-index="0"
       data-testid="carousel"
       data-watch-drag="true"
+      tabindex="0"
     >
       <div
         class="-ml-3 items-center"
@@ -608,6 +611,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-start-index="0"
       data-testid="carousel"
       data-watch-drag="true"
+      tabindex="0"
     >
       <div
         class="-ml-3 items-center"
@@ -732,6 +736,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       data-start-index="0"
       data-testid="carousel"
       data-watch-drag="true"
+      tabindex="0"
     >
       <div
         class="-ml-3 items-center"
@@ -851,7 +856,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -869,7 +874,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -887,7 +892,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -905,7 +910,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -937,7 +942,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -961,7 +966,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       src="https://example.com/mixed-video.mp4"
     />
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -993,7 +998,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1011,7 +1016,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1029,7 +1034,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1093,7 +1098,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer only:static"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
       data-aschild="true"
       data-testid="dialog-trigger"
     >

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with GIF 
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -43,7 +43,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -215,7 +215,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -233,7 +233,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -251,7 +251,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -433,7 +433,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with dial
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -856,7 +856,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -874,7 +874,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -892,7 +892,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -910,7 +910,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with four
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -942,7 +942,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -966,7 +966,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mixe
       src="https://example.com/mixed-video.mp4"
     />
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -998,7 +998,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1016,7 +1016,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1034,7 +1034,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with mult
       </button>
     </div>
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >
@@ -1098,7 +1098,7 @@ exports[`PostAttachmentsImagesAndVideos - Snapshots > matches snapshot with sing
     data-testid="container"
   >
     <div
-      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none"
+      class="h-52 w-full max-w-full relative only:h-auto sm:last:odd:col-span-2 cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring"
       data-aschild="true"
       data-testid="dialog-trigger"
     >

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -146,7 +146,7 @@ export const PostAttachmentsImagesAndVideos = ({
                 className={cn(
                   isListVariant ? LIST_TILE_CLASS : 'h-52 w-full max-w-full',
                   isListVariant ? LIST_TILE_FRAME_CLASS : TILE_FRAME_CLASS,
-                  'cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none',
+                  'cursor-pointer outline-none only:static focus-visible:ring-2 focus-visible:ring-ring',
                 )}
               >
                 <Button overrideDefaults onClick={(e) => openPreview(i, e)}>

--- a/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
+++ b/src/components/molecules/PostAttachmentsImagesAndVideos/PostAttachmentsImagesAndVideos.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { type MouseEvent, type ReactNode, useEffect, useState } from 'react';
+import { type MouseEvent, type ReactNode, useEffect, useRef, useState } from 'react';
 import { Maximize, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/atoms/Button/Button';
@@ -52,6 +52,7 @@ export const PostAttachmentsImagesAndVideos = ({
   const [api, setApi] = useState<CarouselApi>();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const carouselRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
   const tFullscreen = useTranslations('toast.fullscreen');
 
@@ -76,9 +77,14 @@ export const PostAttachmentsImagesAndVideos = ({
     if (!api) {
       return;
     }
-    api.on('settle', () => {
+    const onSelect = () => {
       setCurrentIndex(api.selectedScrollSnap());
-    });
+    };
+    onSelect();
+    api.on('select', onSelect);
+    return () => {
+      api.off('select', onSelect);
+    };
   }, [api]);
 
   // Disable carousel swipe when in fullscreen mode
@@ -140,7 +146,7 @@ export const PostAttachmentsImagesAndVideos = ({
                 className={cn(
                   isListVariant ? LIST_TILE_CLASS : 'h-52 w-full max-w-full',
                   isListVariant ? LIST_TILE_FRAME_CLASS : TILE_FRAME_CLASS,
-                  'cursor-pointer only:static',
+                  'cursor-pointer outline-none only:static focus:outline-none focus-visible:outline-none',
                 )}
               >
                 <Button overrideDefaults onClick={(e) => openPreview(i, e)}>
@@ -199,6 +205,10 @@ export const PostAttachmentsImagesAndVideos = ({
         showCloseButton={false}
         overrideDefaults
         centered
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          carouselRef.current?.focus();
+        }}
         onClick={(e) => {
           e.stopPropagation();
         }}
@@ -208,6 +218,7 @@ export const PostAttachmentsImagesAndVideos = ({
         </DialogClose>
 
         <Carousel
+          ref={carouselRef}
           opts={{
             startIndex: currentIndex,
             loop: true,

--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`GenericPreview - Snapshots > matches snapshot for loading state 1`] = `
 exports[`GenericPreview - Snapshots > matches snapshot for video type 1`] = `
 <div>
   <video
-    class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none w-full cursor-auto object-contain"
+    class="h-auto max-w-full rounded-md bg-black outline-none focus-visible:ring-2 focus-visible:ring-ring w-full cursor-auto object-contain"
     controls=""
     data-testid="video"
     preload="metadata"

--- a/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
+++ b/src/components/molecules/PostLinkEmbeds/Providers/Generic/ProviderGeneric.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`GenericPreview - Snapshots > matches snapshot for loading state 1`] = `
 exports[`GenericPreview - Snapshots > matches snapshot for video type 1`] = `
 <div>
   <video
-    class="h-auto max-w-full rounded-md bg-black w-full cursor-auto object-contain"
+    class="h-auto max-w-full rounded-md bg-black outline-none focus:outline-none w-full cursor-auto object-contain"
     controls=""
     data-testid="video"
     preload="metadata"


### PR DESCRIPTION
## Summary
- Focus the media carousel on lightbox open so ←/→ work without clicking Prev/Next first (#1775)
- Update the `1/N` counter on Embla `select` instead of `settle` so it tracks slide changes immediately
- Remove focus outlines on carousel, post image tiles, and videos after keyboard/pointer interaction

## Test plan
- [ ] Open a multi-image post lightbox and press ←/→ immediately (no click on nav buttons)
- [ ] Confirm the `1/N` counter updates as soon as the slide changes
- [ ] Confirm no white focus ring around the lightbox carousel or post image/video tiles after interaction
- [ ] Confirm Esc still closes the lightbox and Fullscreen still works


Made with [Cursor](https://cursor.com)