### PR TITLE
feat(ui): group repeated deleted and edited notifications

### DIFF
--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -326,38 +326,56 @@ describe('notifications', () => {
     checkLatestNotification([profile1.username, 'deleted a post'], LatestNotificationReadState.Read);
   });
 
-  it('can be notified for a post being deleted that you reposted', () => {
-    // * profile 1 creates a post (1) that will be reposted and then deleted
-    const postContent = `The one who reposts this post will be notified when it is deleted! ${Date.now()}`;
-    createQuickPost(postContent);
+  it('groups notifications for posts being deleted that you reposted', () => {
+    // * profile 1 creates two posts that will be reposted and then deleted. Two posts
+    // make the test self-contained: it forms a grouped row on its own, so it also passes
+    // in isolation. The copy assertions stay count-agnostic because earlier deletions by
+    // profile 1 (from the preceding test, or Cypress retries) join the same run.
+    const timestamp = Date.now();
+    const firstPostContent = `The one who reposts this post will be notified when it is deleted! ${timestamp}`;
+    const secondPostContent = `Repost this one too and hear about its deletion as well! ${timestamp}`;
+    createQuickPost(firstPostContent);
+    createQuickPost(secondPostContent);
 
-    // * profile 2 reposts profile 1's post
+    // * profile 2 reposts both of profile 1's posts
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile2.username));
-    cy.findFirstPostInFeed().innerTextContains(postContent);
-    repostPost({ repostContent: 'I reposted your post!', filterText: postContent });
+    // The newest post visible in the feed proves both have been indexed.
+    cy.findFirstPostInFeed().innerTextContains(secondPostContent);
+    repostPost({ repostContent: 'I reposted your post!', filterText: firstPostContent });
+    repostPost({ repostContent: 'I reposted this one as well!', filterText: secondPostContent });
 
-    // * profile 1 deletes own post (1)
+    // * profile 1 deletes both own posts
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile1.username));
     // Go to profile page and click Posts tab to see own posts (home feed shows followed users' posts)
     goToProfilePageFromHeader();
     cy.get('[data-cy="profile-filter-item-posts"]').click();
     cy.get('[data-cy="profile-filter-item-posts"]').closest('[data-selected="true"]').should('exist');
-    deletePost({ postIdx: 0, filterText: postContent });
+    deletePost({ postIdx: 0, filterText: firstPostContent });
+    deletePost({ postIdx: 0, filterText: secondPostContent });
 
-    // * profile 2 checks for notification for post being deleted
+    // * profile 2 checks for the grouped deletion notification
+    // (see https://github.com/pubky/pubky-app/issues/1570)
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile2.username));
-    verifyNotificationCounter(1);
+    verifyNotificationCounter(2);
     goToProfilePageFromHeader();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile1.username, 'deleted a post'], LatestNotificationReadState.Unread);
+    // 'posts you interacted with' is the grouped copy; a lone row says 'deleted a post'.
+    checkLatestNotification(
+      [profile1.username, 'deleted', 'posts you interacted with'],
+      LatestNotificationReadState.Unread,
+    );
+    cy.get('[data-cy="notifications-list"]').children().first().should('have.attr', 'data-cy', 'notification-group');
 
     // * toggle tabs to check unread dot disappears
     causeNotificationsToBeRead();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile1.username, 'deleted a post'], LatestNotificationReadState.Read);
+    checkLatestNotification(
+      [profile1.username, 'deleted', 'posts you interacted with'],
+      LatestNotificationReadState.Read,
+    );
   });
 
   it('can be notified for a post being edited that you replied to', () => {
@@ -393,38 +411,73 @@ describe('notifications', () => {
     checkLatestNotification([profile1.username, 'edited a post'], LatestNotificationReadState.Read);
   });
 
-  it('can be notified for a post being edited that you reposted', () => {
-    // * profile 1 creates a post (1) that will be reposted and then edited
-    const postContent = `The one who reposts this post will be notified when it is edited! ${Date.now()}`;
-    const editedContent = `This post has been edited! ${Date.now()}`;
-    createQuickPost(postContent);
+  it('groups notifications for posts being edited that you reposted', () => {
+    // * profile 1 creates two posts that will be reposted and then edited. Two distinct
+    // posts make the test self-contained: they form a grouped row on their own (repeated
+    // edits of one post deduplicate instead), so the test also passes in isolation. The
+    // copy assertions stay count-agnostic because earlier edits by profile 1 (from the
+    // preceding test, or Cypress retries) join the same run.
+    const timestamp = Date.now();
+    const firstPostContent = `The one who reposts this post will be notified when it is edited! ${timestamp}`;
+    const secondPostContent = `Repost this one too and hear about its edit as well! ${timestamp}`;
+    createQuickPost(firstPostContent);
+    createQuickPost(secondPostContent);
 
-    // * profile 2 reposts profile 1's post
+    // * profile 2 reposts both of profile 1's posts
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile2.username));
-    cy.findFirstPostInFeed().innerTextContains(postContent);
-    repostPost({ repostContent: 'I reposted your post!', filterText: postContent });
+    // The newest post visible in the feed proves both have been indexed.
+    cy.findFirstPostInFeed().innerTextContains(secondPostContent);
+    repostPost({ repostContent: 'I reposted your post!', filterText: firstPostContent });
+    repostPost({ repostContent: 'I reposted this one as well!', filterText: secondPostContent });
 
-    // * profile 1 edits own post (1)
+    // * profile 1 edits both own posts
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile1.username));
     goToProfilePageFromHeader();
     cy.get('[data-cy="profile-filter-item-posts"]').click();
     cy.get('[data-cy="profile-filter-item-posts"]').closest('[data-selected="true"]').should('exist');
-    editPost({ newPostContent: editedContent, postIdx: 0, filterText: postContent });
+    editPost({ newPostContent: `This post has been edited! ${timestamp}`, postIdx: 0, filterText: firstPostContent });
+    editPost({
+      newPostContent: `This post has also been edited! ${timestamp}`,
+      postIdx: 0,
+      filterText: secondPostContent,
+    });
 
-    // * profile 2 checks for notification for post being edited
+    // * profile 2 checks for the grouped edit notification, which keeps a link to every
+    // edited post (see issue #1570)
     cy.signOut(HasBackedUp.Yes);
     cy.signInWithEncryptedFile(backupDownloadFilePath(profile2.username));
-    verifyNotificationCounter(1);
+    verifyNotificationCounter(2);
     goToProfilePageFromHeader();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile1.username, 'edited a post'], LatestNotificationReadState.Unread);
+    // 'posts you interacted with' is the grouped copy; a lone row says 'edited a post'.
+    checkLatestNotification(
+      [profile1.username, 'edited', 'posts you interacted with'],
+      LatestNotificationReadState.Unread,
+    );
+
+    // * every edited post sits behind the Show/Hide disclosure on desktop, while mobile
+    // renders the title list permanently without a toggle
+    cy.get('[data-cy="notifications-list"]').children().first().as('editedGroup');
+    if (Cypress.expose('isMobile')) {
+      cy.get('@editedGroup').find('[data-cy="notification-group-toggle"]').should('not.exist');
+      cy.get('@editedGroup').find('[data-cy="notification-group-item"]').should('have.length.at.least', 2);
+    } else {
+      cy.get('@editedGroup').find('[data-cy="notification-group-toggle"]').should('contain.text', 'Show');
+      cy.get('@editedGroup').find('[data-cy="notification-group-item"]').should('have.length', 0);
+      cy.get('@editedGroup').find('[data-cy="notification-group-toggle"]').click();
+      cy.get('@editedGroup').find('[data-cy="notification-group-item"]').should('have.length.at.least', 2);
+      cy.get('@editedGroup').find('[data-cy="notification-group-toggle"]').should('contain.text', 'Hide');
+    }
 
     // * toggle tabs to check unread dot disappears
     causeNotificationsToBeRead();
     verifyNotificationCounter(0);
-    checkLatestNotification([profile1.username, 'edited a post'], LatestNotificationReadState.Read);
+    checkLatestNotification(
+      [profile1.username, 'edited', 'posts you interacted with'],
+      LatestNotificationReadState.Read,
+    );
   });
 
   it('can be notified when a followed collection is updated with a new post', () => {

--- a/src/components/atoms/Collapsible/Collapsible.test.tsx
+++ b/src/components/atoms/Collapsible/Collapsible.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './Collapsible';
+
+function Example({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  return (
+    <Collapsible defaultOpen={defaultOpen}>
+      <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+      <CollapsibleContent>
+        <span>Hidden content</span>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+describe('Collapsible', () => {
+  it('keeps content out of the tree while closed', () => {
+    render(<Example />);
+
+    expect(screen.queryByText('Hidden content')).not.toBeInTheDocument();
+  });
+
+  it('renders content when opened by default', () => {
+    render(<Example defaultOpen />);
+
+    expect(screen.getByText('Hidden content')).toBeInTheDocument();
+  });
+
+  it('unmounts content on close rather than only hiding it', async () => {
+    // Consumers rely on this: children that fetch on mount must not fetch while collapsed.
+    render(<Example defaultOpen />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Hidden content')).not.toBeInTheDocument();
+  });
+
+  it('toggles content and the trigger state on click', async () => {
+    render(<Example />);
+
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Hidden content')).toBeInTheDocument();
+  });
+
+  it('points the trigger at the content it controls', async () => {
+    render(<Example defaultOpen />);
+
+    const trigger = screen.getByRole('button');
+    const controlledId = trigger.getAttribute('aria-controls');
+
+    expect(controlledId).toBeTruthy();
+    expect(screen.getByTestId('collapsible-content')).toHaveAttribute('id', controlledId);
+  });
+
+  it('exposes slot hooks on every part', () => {
+    render(<Example defaultOpen />);
+
+    expect(screen.getByTestId('collapsible')).toHaveAttribute('data-slot', 'collapsible');
+    expect(screen.getByTestId('collapsible-trigger')).toHaveAttribute('data-slot', 'collapsible-trigger');
+    expect(screen.getByTestId('collapsible-content')).toHaveAttribute('data-slot', 'collapsible-content');
+  });
+
+  it('forwards className to the content', () => {
+    render(
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent className="custom-content">Body</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    expect(screen.getByTestId('collapsible-content')).toHaveClass('custom-content');
+  });
+});
+
+describe('Collapsible - Snapshots', () => {
+  it('matches snapshot when closed', () => {
+    const { container } = render(<Example />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot when open', () => {
+    const { container } = render(<Example defaultOpen />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/atoms/Collapsible/Collapsible.test.tsx.snap
+++ b/src/components/atoms/Collapsible/Collapsible.test.tsx.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Collapsible - Snapshots > matches snapshot when closed 1`] = `
+<div
+  data-slot="collapsible"
+  data-state="closed"
+  data-testid="collapsible"
+>
+  <button
+    aria-controls="radix-normalized"
+    aria-expanded="false"
+    data-slot="collapsible-trigger"
+    data-state="closed"
+    data-testid="collapsible-trigger"
+    type="button"
+  >
+    Toggle
+  </button>
+  <div
+    data-slot="collapsible-content"
+    data-state="closed"
+    data-testid="collapsible-content"
+    hidden=""
+    id="radix-normalized"
+    style=""
+  />
+</div>
+`;
+
+exports[`Collapsible - Snapshots > matches snapshot when open 1`] = `
+<div
+  data-slot="collapsible"
+  data-state="open"
+  data-testid="collapsible"
+>
+  <button
+    aria-controls="radix-normalized"
+    aria-expanded="true"
+    data-slot="collapsible-trigger"
+    data-state="open"
+    data-testid="collapsible-trigger"
+    type="button"
+  >
+    Toggle
+  </button>
+  <div
+    data-slot="collapsible-content"
+    data-state="open"
+    data-testid="collapsible-content"
+    id="radix-normalized"
+    style="transition-duration: 0s; animation-name: none;"
+  >
+    <span>
+      Hidden content
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/atoms/Collapsible/Collapsible.tsx
+++ b/src/components/atoms/Collapsible/Collapsible.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Collapsible as CollapsiblePrimitive } from 'radix-ui';
+
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" data-testid="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      data-testid="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+/** Children unmount while closed, so anything they fetch stays lazy. */
+function CollapsibleContent({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      data-testid="collapsible-content"
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/src/components/molecules/NotificationRowChrome/NotificationRowChrome.test.tsx
+++ b/src/components/molecules/NotificationRowChrome/NotificationRowChrome.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NotificationType } from '@/models/notification/notification.types';
+import {
+  NotificationActorAvatar,
+  NotificationActorHeading,
+  NotificationTimestampAndIcon,
+} from './NotificationRowChrome';
+
+vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
+  AvatarWithFallback: ({ name, className }: { name: string; className?: string }) => (
+    <div data-testid="avatar-with-fallback" data-name={name} className={className} />
+  ),
+}));
+
+vi.mock('@/molecules/NotificationIcon/NotificationIcon', () => ({
+  NotificationIcon: ({ type, postKind }: { type: NotificationType; postKind?: string }) => (
+    <div data-testid="notification-icon" data-type={type} data-post-kind={postKind} />
+  ),
+}));
+
+vi.mock('@/molecules/RelativeTimestamp/RelativeTimestamp', () => ({
+  RelativeTimestamp: ({ timeAgo }: { timeAgo: string }) => <span data-testid="relative-timestamp">{timeAgo}</span>,
+}));
+
+vi.mock('@/hooks/useRelativeTime/useRelativeTime', () => ({
+  useRelativeTime: () => ({ formatRelativeTime: () => '37m' }),
+}));
+
+describe('NotificationActorAvatar', () => {
+  it('links the avatar to the profile when a link is given', () => {
+    render(
+      <NotificationActorAvatar
+        avatarUrl={undefined}
+        userName="Oliver"
+        fallbackSeed="oliver"
+        userProfileLink="/profile/oliver"
+      />,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/profile/oliver');
+    expect(screen.getByTestId('avatar-with-fallback')).toHaveAttribute('data-name', 'Oliver');
+  });
+
+  it('renders a plain avatar without a profile link', () => {
+    render(
+      <NotificationActorAvatar avatarUrl={undefined} userName="Oliver" fallbackSeed="oliver" userProfileLink={null} />,
+    );
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByTestId('avatar-with-fallback')).toHaveClass('shrink-0');
+  });
+});
+
+describe('NotificationActorHeading', () => {
+  it('links the username and the action to their targets', () => {
+    render(
+      <NotificationActorHeading
+        userName="Oliver"
+        userProfileLink="/profile/oliver"
+        actionText="followed you"
+        actionLink="/post/oliver/123"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Oliver' })).toHaveAttribute('href', '/profile/oliver');
+    expect(screen.getByRole('link', { name: 'followed you' })).toHaveAttribute('href', '/post/oliver/123');
+  });
+
+  it('falls back to plain text when there are no targets', () => {
+    render(<NotificationActorHeading userName="Oliver" userProfileLink={null} actionText="followed you" />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText('Oliver')).toBeInTheDocument();
+    expect(screen.getByText('followed you')).toBeInTheDocument();
+  });
+});
+
+describe('NotificationTimestampAndIcon', () => {
+  const baseProps = {
+    timestampDate: new Date('2026-01-01T12:00:00Z'),
+    isMobile: false,
+    type: NotificationType.Follow,
+    showBadge: false,
+  };
+
+  it('wraps the cluster in a link to the notification target', () => {
+    render(<NotificationTimestampAndIcon {...baseProps} link="/post/oliver/123" />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/post/oliver/123');
+    expect(screen.getByTestId('relative-timestamp')).toHaveTextContent('37m');
+    expect(screen.getByTestId('notification-icon')).toBeInTheDocument();
+  });
+
+  it('renders a plain cluster with extra classes when there is no target', () => {
+    const { container } = render(<NotificationTimestampAndIcon {...baseProps} className="shrink-0" />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(container.firstElementChild).toHaveClass('flex', 'items-center', 'gap-2', 'shrink-0');
+  });
+
+  it('passes the post kind through to the icon', () => {
+    render(<NotificationTimestampAndIcon {...baseProps} type={NotificationType.PostEdited} postKind="collection" />);
+
+    expect(screen.getByTestId('notification-icon')).toHaveAttribute('data-post-kind', 'collection');
+  });
+});
+
+describe('NotificationRowChrome - Snapshots', () => {
+  it('matches snapshot for a linked avatar', () => {
+    const { container } = render(
+      <NotificationActorAvatar
+        avatarUrl={undefined}
+        userName="Oliver"
+        fallbackSeed="oliver"
+        userProfileLink="/profile/oliver"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for a fully linked heading', () => {
+    const { container } = render(
+      <NotificationActorHeading
+        userName="Oliver"
+        userProfileLink="/profile/oliver"
+        actionText="followed you"
+        actionLink="/post/oliver/123"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for a plain-text heading', () => {
+    const { container } = render(
+      <NotificationActorHeading userName="Oliver" userProfileLink={null} actionText="followed you" />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for a linked timestamp cluster', () => {
+    const { container } = render(
+      <NotificationTimestampAndIcon
+        timestampDate={new Date('2026-01-01T12:00:00Z')}
+        isMobile={false}
+        type={NotificationType.Follow}
+        showBadge={true}
+        link="/post/oliver/123"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for a plain timestamp cluster', () => {
+    const { container } = render(
+      <NotificationTimestampAndIcon
+        timestampDate={new Date('2026-01-01T12:00:00Z')}
+        isMobile={false}
+        type={NotificationType.PostEdited}
+        postKind="collection"
+        showBadge={false}
+        className="shrink-0"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/NotificationRowChrome/NotificationRowChrome.test.tsx.snap
+++ b/src/components/molecules/NotificationRowChrome/NotificationRowChrome.test.tsx.snap
@@ -1,0 +1,89 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NotificationRowChrome - Snapshots > matches snapshot for a fully linked heading 1`] = `
+<p
+  class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+  data-testid="typography"
+>
+  <a
+    class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+    href="/profile/oliver"
+  >
+    Oliver
+  </a>
+   
+  <a
+    class="text-foreground hover:underline lg:shrink-0"
+    href="/post/oliver/123"
+  >
+    followed you
+  </a>
+</p>
+`;
+
+exports[`NotificationRowChrome - Snapshots > matches snapshot for a linked avatar 1`] = `
+<a
+  class="shrink-0 transition-opacity hover:opacity-80"
+  href="/profile/oliver"
+>
+  <div
+    class="lg:size-8"
+    data-name="Oliver"
+    data-testid="avatar-with-fallback"
+  />
+</a>
+`;
+
+exports[`NotificationRowChrome - Snapshots > matches snapshot for a linked timestamp cluster 1`] = `
+<a
+  class="flex shrink-0 items-center gap-2 transition-opacity hover:opacity-80"
+  href="/post/oliver/123"
+>
+  <span
+    data-testid="relative-timestamp"
+  >
+    37m
+  </span>
+  <div
+    data-testid="notification-icon"
+    data-type="follow"
+  />
+</a>
+`;
+
+exports[`NotificationRowChrome - Snapshots > matches snapshot for a plain timestamp cluster 1`] = `
+<div
+  class="flex items-center gap-2 shrink-0"
+  data-testid="container"
+>
+  <span
+    data-testid="relative-timestamp"
+  >
+    37m
+  </span>
+  <div
+    data-post-kind="collection"
+    data-testid="notification-icon"
+    data-type="post_edited"
+  />
+</div>
+`;
+
+exports[`NotificationRowChrome - Snapshots > matches snapshot for a plain-text heading 1`] = `
+<p
+  class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+  data-testid="typography"
+>
+  <span
+    class="inline-block max-w-full min-w-0 truncate align-bottom"
+  >
+    Oliver
+  </span>
+   
+  <span
+    class="text-foreground lg:shrink-0"
+  >
+    followed you
+  </span>
+</p>
+`;

--- a/src/components/molecules/NotificationRowChrome/NotificationRowChrome.tsx
+++ b/src/components/molecules/NotificationRowChrome/NotificationRowChrome.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import Link from 'next/link';
+import { Container } from '@/atoms/Container/Container';
+import { Typography } from '@/atoms/Typography/Typography';
+import { useRelativeTime } from '@/hooks/useRelativeTime/useRelativeTime';
+import { cn } from '@/libs/utils/utils';
+import type { NotificationType } from '@/models/notification/notification.types';
+import { NotificationIcon } from '@/molecules/NotificationIcon/NotificationIcon';
+import { RelativeTimestamp } from '@/molecules/RelativeTimestamp/RelativeTimestamp';
+import { AvatarWithFallback } from '@/organisms/AvatarWithFallback/AvatarWithFallback';
+
+/**
+ * The chrome a notification row shares whether it is a single item or a grouped run:
+ * actor avatar, actor heading (username + action text) and the timestamp/icon cluster.
+ * Keeping these here stops the single and grouped rows from drifting apart visually.
+ */
+
+interface NotificationActorAvatarProps {
+  avatarUrl?: string;
+  userName: string;
+  fallbackSeed: string;
+  /** Wraps the avatar in a profile link when present. */
+  userProfileLink: string | null;
+}
+
+export function NotificationActorAvatar({
+  avatarUrl,
+  userName,
+  fallbackSeed,
+  userProfileLink,
+}: NotificationActorAvatarProps) {
+  if (userProfileLink) {
+    return (
+      <Link href={userProfileLink} className="shrink-0 transition-opacity hover:opacity-80">
+        <AvatarWithFallback
+          avatarUrl={avatarUrl}
+          name={userName}
+          fallbackSeed={fallbackSeed}
+          size="sm"
+          className="lg:size-8"
+        />
+      </Link>
+    );
+  }
+
+  return (
+    <AvatarWithFallback
+      avatarUrl={avatarUrl}
+      name={userName}
+      fallbackSeed={fallbackSeed}
+      size="sm"
+      className="shrink-0 lg:size-8"
+    />
+  );
+}
+
+interface NotificationActorHeadingProps {
+  userName: string;
+  /** Makes the username a profile link when present. */
+  userProfileLink: string | null;
+  actionText: string;
+  /** Makes the action text a link to the notification target when present. */
+  actionLink?: string | null;
+}
+
+export function NotificationActorHeading({
+  userName,
+  userProfileLink,
+  actionText,
+  actionLink,
+}: NotificationActorHeadingProps) {
+  return (
+    <Typography
+      as="p"
+      className="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+    >
+      {/* Username - truncated independently so long names do not overlap timestamp/icon */}
+      {userProfileLink ? (
+        <Link
+          href={userProfileLink}
+          className="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+        >
+          {userName}
+        </Link>
+      ) : (
+        <span className="inline-block max-w-full min-w-0 truncate align-bottom">{userName}</span>
+      )}{' '}
+      {/* Action text - links to the notification target when there is one */}
+      {actionLink ? (
+        <Link href={actionLink} className="text-foreground hover:underline lg:shrink-0">
+          {actionText}
+        </Link>
+      ) : (
+        <span className="text-foreground lg:shrink-0">{actionText}</span>
+      )}
+    </Typography>
+  );
+}
+
+interface NotificationTimestampAndIconProps {
+  timestampDate: Date;
+  isMobile: boolean;
+  type: NotificationType;
+  postKind?: string;
+  showBadge: boolean;
+  /** Wraps the cluster in a link to the notification target when present. */
+  link?: string | null;
+  /** Extra classes for the non-link wrapper. */
+  className?: string;
+}
+
+export function NotificationTimestampAndIcon({
+  timestampDate,
+  isMobile,
+  type,
+  postKind,
+  showBadge,
+  link,
+  className,
+}: NotificationTimestampAndIconProps) {
+  const { formatRelativeTime } = useRelativeTime();
+
+  const content = (
+    <>
+      <RelativeTimestamp
+        timeAgo={formatRelativeTime(timestampDate)}
+        date={timestampDate}
+        isMobile={isMobile}
+        className="text-xs font-medium tracking-widest text-muted-foreground"
+      />
+
+      <NotificationIcon type={type} postKind={postKind} showBadge={showBadge} />
+    </>
+  );
+
+  if (link) {
+    return (
+      <Link href={link} className="flex shrink-0 items-center gap-2 transition-opacity hover:opacity-80">
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <Container overrideDefaults={true} className={cn('flex items-center gap-2', className)}>
+      {content}
+    </Container>
+  );
+}

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.test.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.test.tsx
@@ -1,0 +1,525 @@
+import { render as rtlRender, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/atoms/Tooltip/Tooltip';
+import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
+import { NotificationType, PostChangedSource } from '@/models/notification/notification.types';
+import type { GroupableNotification } from '@/organisms/NotificationsList/NotificationsList.types';
+import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
+import { NotificationGroupItem } from './NotificationGroupItem';
+
+const mockUseNotificationPostContent = vi.hoisted(() =>
+  vi.fn<(options: { compositeId: string | null }) => { content: string | null; isResolving: boolean }>(() => ({
+    content: 'Apple releases the new iPhone',
+    isResolving: false,
+  })),
+);
+
+vi.mock('@/hooks/useUserProfile/useUserProfile', () => ({
+  useUserProfile: vi.fn(() => ({ profile: { name: 'Oliver', avatarUrl: undefined }, isLoading: false })),
+}));
+
+vi.mock('@/hooks/useNotificationPostContent/useNotificationPostContent', () => ({
+  useNotificationPostContent: mockUseNotificationPostContent,
+}));
+
+vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => ({
+  AvatarWithFallback: ({ name, avatarUrl }: { name: string; avatarUrl?: string }) => (
+    <div data-testid="avatar-with-fallback" data-name={name} data-avatar={avatarUrl} />
+  ),
+}));
+
+function render(ui: ReactElement) {
+  return rtlRender(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+/** Titles are tagged with data-cy (Cypress hooks), not data-testid. */
+const groupTitles = () => [...document.querySelectorAll('[data-cy="notification-group-item"]')];
+
+const unreadDot = () => document.querySelector('[data-cy="notification-unread-dot"]');
+
+/**
+ * The distinct posts whose titles have been asked for. Counting calls would instead count
+ * re-renders, which says nothing about how many posts were fetched.
+ */
+const requestedPosts = () => new Set(mockUseNotificationPostContent.mock.calls.map(([options]) => options.compositeId));
+
+/** Fixed so fixtures do not shift when tests are added or reordered. */
+const NOW = new Date('2026-01-01T12:00:00Z').getTime();
+
+function member(
+  type: NotificationType.PostDeleted | NotificationType.PostEdited,
+  index: number,
+  postKind?: string,
+): GroupableNotification {
+  // 37 minutes back, matching the design's example row, then one minute per member.
+  const timestamp = NOW - 37 * 60_000 - index * 60_000;
+  const postUri = `pubky://oliver/pub/pubky.app/posts/post-${timestamp}`;
+  const shared = {
+    id: `${type}:${timestamp}:oliver`,
+    timestamp,
+    linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
+    post_kind: postKind,
+  };
+
+  return type === NotificationType.PostDeleted
+    ? {
+        ...shared,
+        type: NotificationType.PostDeleted,
+        delete_source: PostChangedSource.Reply,
+        deleted_by: 'oliver',
+        deleted_uri: postUri,
+      }
+    : {
+        ...shared,
+        type: NotificationType.PostEdited,
+        edit_source: PostChangedSource.Reply,
+        edited_by: 'oliver',
+        edited_uri: postUri,
+      };
+}
+
+function buildGroup(
+  type: NotificationType.PostDeleted | NotificationType.PostEdited,
+  size: number,
+  kindBucket: 'collection' | 'long' | 'post' = 'post',
+): GroupableNotification[] {
+  const postKind = kindBucket === 'post' ? 'short' : kindBucket;
+  return Array.from({ length: size }, (_, index) => member(type, index, postKind));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(NOW);
+  vi.clearAllMocks();
+  mockUseNotificationPostContent.mockReturnValue({ content: 'Apple releases the new iPhone', isResolving: false });
+  vi.mocked(useUserProfile).mockReturnValue({
+    profile: { name: 'Oliver', avatarUrl: undefined },
+    isLoading: false,
+  } as ReturnType<typeof useUserProfile>);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('NotificationGroupItem - deleted groups', () => {
+  it('renders the total as a single flat row', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 8)} isUnread={false} />);
+
+    expect(screen.getByText('deleted 8 posts you interacted with')).toBeInTheDocument();
+  });
+
+  it('renders no post titles, no toggle and no post link', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 8)} isUnread={false} />,
+    );
+
+    expect(groupTitles()).toHaveLength(0);
+    expect(document.querySelector('[data-cy="notification-group-toggle"]')).not.toBeInTheDocument();
+    expect(mockUseNotificationPostContent).not.toHaveBeenCalled();
+
+    // The only links are the avatar and the username, both pointing at the actor's profile.
+    const hrefs = [...container.querySelectorAll('a')].map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs).toEqual(['/profile/oliver', '/profile/oliver']);
+  });
+
+  it('uses kind-specific copy for a collection group', () => {
+    render(
+      <NotificationGroupItem
+        notifications={buildGroup(NotificationType.PostDeleted, 3, 'collection')}
+        isUnread={false}
+      />,
+    );
+
+    expect(screen.getByText('deleted 3 collections you interacted with')).toBeInTheDocument();
+  });
+
+  it('uses kind-specific copy for an article group', () => {
+    render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 4, 'long')} isUnread={false} />,
+    );
+
+    expect(screen.getByText('deleted 4 articles you interacted with')).toBeInTheDocument();
+  });
+});
+
+describe('NotificationGroupItem - edited groups', () => {
+  it('hides every title behind a Show toggle while collapsed', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    expect(screen.getByText('edited 3 posts you interacted with')).toBeInTheDocument();
+    expect(groupTitles()).toHaveLength(0);
+    expect(screen.getByRole('button')).toHaveTextContent('Show');
+  });
+
+  it('does not resolve any title until expanded, keeping the fetches lazy', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 5)} isUnread={false} />);
+
+    expect(mockUseNotificationPostContent).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    // Every title is fetched only once it is actually on screen — this is what
+    // regresses if the collapsed titles are ever force-mounted.
+    expect(groupTitles()).toHaveLength(5);
+    expect(requestedPosts().size).toBe(5);
+  });
+
+  it('uses kind-specific copy for a collection group', () => {
+    render(
+      <NotificationGroupItem
+        notifications={buildGroup(NotificationType.PostEdited, 3, 'collection')}
+        isUnread={false}
+      />,
+    );
+
+    expect(screen.getByText('updated 3 collections')).toBeInTheDocument();
+  });
+
+  it('uses kind-specific copy for an article group', () => {
+    render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3, 'long')} isUnread={false} />,
+    );
+
+    expect(screen.getByText('updated 3 articles')).toBeInTheDocument();
+  });
+
+  it('names the toggle for screen readers by the group it belongs to', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Show the 3 posts edited by Oliver');
+
+    await userEvent.click(screen.getByRole('button'));
+
+    // The toggle relocates below the list on expand, so it must be queried afresh.
+    expect(screen.getByRole('button')).toHaveAccessibleName('Hide the posts edited by Oliver');
+  });
+
+  it('counts every post in the toggle name, including for the smallest group', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 2)} isUnread={false} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Show the 2 posts edited by Oliver');
+  });
+
+  it.each([
+    ['collection', 'Show the 3 collections updated by Oliver', 'Hide the collections updated by Oliver'],
+    ['long', 'Show the 3 articles updated by Oliver', 'Hide the articles updated by Oliver'],
+  ])('matches the toggle name to the %s copy, which says updated', async (kindBucket, showLabel, hideLabel) => {
+    render(
+      <NotificationGroupItem
+        notifications={buildGroup(NotificationType.PostEdited, 3, kindBucket as 'collection' | 'long')}
+        isUnread={false}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(showLabel);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(hideLabel);
+  });
+
+  it('mounts no titles before the first expand, keeping every fetch lazy', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 5)} isUnread={false} />);
+
+    expect(groupTitles()).toHaveLength(0);
+    expect(requestedPosts().size).toBe(0);
+  });
+
+  it('renders nothing for an empty run instead of crashing', () => {
+    const { container } = render(<NotificationGroupItem notifications={[]} isUnread={false} />);
+
+    expect(container.querySelector('[data-cy="notification-group"]')).toBeNull();
+  });
+
+  it('expands to every title and swaps the toggle to Hide, then collapses again', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(screen.getByRole('button'));
+
+    // The toggle relocates below the list on expand, so it must be queried afresh.
+    expect(groupTitles()).toHaveLength(3);
+    expect(screen.getByRole('button')).toHaveTextContent('Hide');
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(screen.getByRole('button'));
+
+    // Collapsing unmounts the titles again — the local-first cache makes a re-expand a
+    // cheap local re-read, so nothing needs to stay mounted while hidden.
+    expect(groupTitles()).toHaveLength(0);
+    expect(screen.getByRole('button')).toHaveTextContent('Show');
+  });
+
+  it('never fetches new posts across collapse and re-expand cycles', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+    const postsAfterFirstExpand = requestedPosts();
+    expect(postsAfterFirstExpand.size).toBe(3);
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button'));
+
+    // Re-expanding re-reads the same three posts — no additional post is ever requested.
+    expect(groupTitles()).toHaveLength(3);
+    expect(requestedPosts()).toEqual(postsAfterFirstExpand);
+  });
+
+  it('renders each title truncated to 40 characters and wrapped in double quotes', async () => {
+    mockUseNotificationPostContent.mockReturnValue({
+      content: 'Apple releases the new iPhone and everybody rushes to buy it',
+      isResolving: false,
+    });
+
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 2)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getAllByText('"Apple releases the new iPhone and everyb..."')).toHaveLength(2);
+  });
+
+  it('links each title to its post', async () => {
+    const notifications = buildGroup(NotificationType.PostEdited, 2);
+    const firstPostId = `post-${notifications[0].timestamp}`;
+
+    render(<NotificationGroupItem notifications={notifications} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getAllByText('"Apple releases the new iPhone"')[0].closest('a')).toHaveAttribute(
+      'href',
+      `/post/oliver/${firstPostId}`,
+    );
+  });
+
+  it('shows a skeleton rather than empty quotes while a title is still loading', async () => {
+    mockUseNotificationPostContent.mockReturnValue({ content: null, isResolving: true });
+
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 2)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('""')).not.toBeInTheDocument();
+    expect(groupTitles()).toHaveLength(2);
+    expect(groupTitles()[0].querySelector('[data-slot="skeleton"]')).toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder once a title has settled with nothing, never a stuck skeleton', async () => {
+    mockUseNotificationPostContent.mockReturnValue({ content: null, isResolving: false });
+
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 2)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getAllByText('Untitled post')).toHaveLength(2);
+    expect(groupTitles()[0].querySelector('[data-slot="skeleton"]')).not.toBeInTheDocument();
+  });
+
+  it('keeps the row count in step with the group size, not with resolved titles', async () => {
+    mockUseNotificationPostContent.mockReturnValue({ content: null, isResolving: false });
+
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 4)} isUnread={false} />);
+
+    expect(screen.getByText('edited 4 posts you interacted with')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(groupTitles()).toHaveLength(4);
+  });
+});
+
+describe('NotificationGroupItem - toggle placement and focus', () => {
+  const header = () => document.querySelector('[data-cy="notification-group-header"]') as HTMLElement;
+  // The disclosure block is the header's sibling; the collapsible content inside it is
+  // not rendered at all before the first expand, so it cannot anchor the query.
+  const disclosureBlock = () => header().nextElementSibling as HTMLElement;
+
+  it('sits inline in the header row while collapsed on desktop, with the list block hidden', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    expect(within(header()).getByRole('button')).toHaveTextContent('Show');
+    expect(disclosureBlock()).toHaveClass('hidden');
+  });
+
+  it('moves below the expanded list on desktop while keeping Tab order into the titles', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(within(header()).queryByRole('button')).not.toBeInTheDocument();
+    expect(disclosureBlock()).not.toHaveClass('hidden');
+    // The toggle precedes the titles in the DOM (so Tab moves from it into the links it
+    // just revealed) and order-last renders it visually below the list.
+    expect(disclosureBlock().firstElementChild).toHaveAttribute('data-cy', 'notification-group-toggle');
+    expect(within(disclosureBlock()).getByRole('button')).toHaveClass('order-last');
+  });
+
+  it('moves focus with the toggle as it relocates on desktop', async () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('Hide');
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('Show');
+    expect(screen.getByRole('button')).toHaveFocus();
+  });
+
+  it('always renders every title without any toggle on mobile', () => {
+    render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} isMobile />,
+    );
+
+    // The list stacks vertically anyway, so mobile keeps the expanded state permanently.
+    expect(groupTitles()).toHaveLength(3);
+    expect(requestedPosts().size).toBe(3);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(disclosureBlock()).not.toHaveClass('hidden');
+  });
+});
+
+describe('NotificationGroupItem - shared row chrome', () => {
+  it('shows the unread badge when the group is unread', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 2)} isUnread={true} />);
+
+    expect(unreadDot()).toBeInTheDocument();
+  });
+
+  it('hides the unread badge when the group is read', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 2)} isUnread={false} />);
+
+    expect(unreadDot()).toBeNull();
+  });
+
+  it('uses the trash icon for a deleted group', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 2)} isUnread={false} />,
+    );
+
+    expect(container.querySelector('.lucide-trash-2')).toBeInTheDocument();
+  });
+
+  it('keeps the notification-type icon for a plain post group', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 2)} isUnread={false} />,
+    );
+
+    expect(container.querySelector('.lucide-sticky-note')).toBeInTheDocument();
+    expect(container.querySelector('.lucide-library')).not.toBeInTheDocument();
+  });
+
+  it('uses the collection icon for a collection group', () => {
+    const { container } = render(
+      <NotificationGroupItem
+        notifications={buildGroup(NotificationType.PostEdited, 2, 'collection')}
+        isUnread={false}
+      />,
+    );
+
+    expect(container.querySelector('.lucide-library')).toBeInTheDocument();
+  });
+
+  it('keeps the media kind icon when every member shares one kind', () => {
+    const { container } = render(
+      <NotificationGroupItem
+        notifications={[
+          member(NotificationType.PostEdited, 0, 'image'),
+          member(NotificationType.PostEdited, 1, 'image'),
+        ]}
+        isUnread={false}
+      />,
+    );
+
+    // The same two notifications rendered as single rows would show the Image icon too.
+    expect(container.querySelector('.lucide-image')).toBeInTheDocument();
+    expect(container.querySelector('.lucide-sticky-note')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the notification-type icon when members mix media kinds', () => {
+    const { container } = render(
+      <NotificationGroupItem
+        notifications={[
+          member(NotificationType.PostEdited, 0, 'image'),
+          member(NotificationType.PostEdited, 1, 'video'),
+        ]}
+        isUnread={false}
+      />,
+    );
+
+    expect(container.querySelector('.lucide-sticky-note')).toBeInTheDocument();
+    expect(container.querySelector('.lucide-image')).not.toBeInTheDocument();
+  });
+
+  it('shows the newest member timestamp', () => {
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 3)} isUnread={false} />);
+
+    // Members are one minute apart, so only the head's 37m may show.
+    expect(screen.getByText('37m')).toBeInTheDocument();
+    expect(screen.queryByText('38m')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the generic user label when the profile is missing', () => {
+    vi.mocked(useUserProfile).mockReturnValue({ profile: null, isLoading: false } as ReturnType<typeof useUserProfile>);
+
+    render(<NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 2)} isUnread={false} />);
+
+    expect(screen.getByText('User')).toBeInTheDocument();
+  });
+});
+
+describe('NotificationGroupItem - Snapshots', () => {
+  it('matches snapshot for a deleted group', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 8)} isUnread={true} />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for a collapsed edited group', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for an expanded edited group', async () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} />,
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('NotificationGroupItem - Mobile Snapshots', () => {
+  beforeEach(() => {
+    setMobileViewport();
+  });
+
+  afterEach(() => {
+    resetViewport();
+  });
+
+  it('matches snapshot on mobile viewport', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostDeleted, 8)} isUnread isMobile />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for an always-expanded edited group on mobile viewport', () => {
+    const { container } = render(
+      <NotificationGroupItem notifications={buildGroup(NotificationType.PostEdited, 3)} isUnread={false} isMobile />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.test.tsx.snap
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.test.tsx.snap
@@ -1,0 +1,599 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NotificationGroupItem - Mobile Snapshots > matches snapshot for an always-expanded edited group on mobile viewport 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-1"
+  data-cy="notification-group"
+  data-testid="container"
+>
+  <div
+    class="flex w-full min-w-0 items-center justify-between gap-2"
+    data-cy="notification-group-header"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-2"
+      data-testid="container"
+    >
+      <a
+        class="shrink-0 transition-opacity hover:opacity-80"
+        href="/profile/oliver"
+      >
+        <div
+          data-name="Oliver"
+          data-testid="avatar-with-fallback"
+        />
+      </a>
+      <p
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+        data-testid="typography"
+      >
+        <a
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+          href="/profile/oliver"
+        >
+          Oliver
+        </a>
+         
+        <span
+          class="text-foreground lg:shrink-0"
+        >
+          edited 3 posts you interacted with
+        </span>
+      </p>
+    </div>
+    <div
+      class="flex items-center gap-2 shrink-0"
+      data-testid="container"
+    >
+      <span
+        class="text-xs font-medium tracking-widest text-muted-foreground"
+        data-testid="typography"
+      >
+        37m
+      </span>
+      <div
+        class="relative shrink-0"
+        data-testid="container"
+        style="width: 24px; height: 24px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sticky-note text-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+          />
+          <path
+            d="M15 3v5a1 1 0 0 0 1 1h5"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="flex min-w-0 flex-col items-start gap-2 pl-8 lg:pl-10"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full min-w-0 flex-col gap-2"
+      data-testid="container"
+    >
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266580000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266520000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266460000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NotificationGroupItem - Mobile Snapshots > matches snapshot on mobile viewport 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-1"
+  data-cy="notification-group"
+  data-testid="container"
+>
+  <div
+    class="flex w-full min-w-0 items-center justify-between gap-2"
+    data-cy="notification-group-header"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-2"
+      data-testid="container"
+    >
+      <a
+        class="shrink-0 transition-opacity hover:opacity-80"
+        href="/profile/oliver"
+      >
+        <div
+          data-name="Oliver"
+          data-testid="avatar-with-fallback"
+        />
+      </a>
+      <p
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+        data-testid="typography"
+      >
+        <a
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+          href="/profile/oliver"
+        >
+          Oliver
+        </a>
+         
+        <span
+          class="text-foreground lg:shrink-0"
+        >
+          deleted 8 posts you interacted with
+        </span>
+      </p>
+    </div>
+    <div
+      class="flex items-center gap-2 shrink-0"
+      data-testid="container"
+    >
+      <span
+        class="text-xs font-medium tracking-widest text-muted-foreground"
+        data-testid="typography"
+      >
+        37m
+      </span>
+      <div
+        class="relative shrink-0"
+        data-testid="container"
+        style="width: 24px; height: 24px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-trash2 lucide-trash-2 text-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 11v6"
+          />
+          <path
+            d="M14 11v6"
+          />
+          <path
+            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"
+          />
+          <path
+            d="M3 6h18"
+          />
+          <path
+            d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+          />
+        </svg>
+        <div
+          class="absolute right-0 bottom-0 rounded-full bg-brand"
+          data-cy="notification-unread-dot"
+          data-testid="container"
+          style="width: 11px; height: 11px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NotificationGroupItem - Snapshots > matches snapshot for a collapsed edited group 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-1"
+  data-cy="notification-group"
+  data-slot="collapsible"
+  data-state="closed"
+  data-testid="collapsible"
+>
+  <div
+    class="flex w-full min-w-0 items-center justify-between gap-2"
+    data-cy="notification-group-header"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-2"
+      data-testid="container"
+    >
+      <a
+        class="shrink-0 transition-opacity hover:opacity-80"
+        href="/profile/oliver"
+      >
+        <div
+          data-name="Oliver"
+          data-testid="avatar-with-fallback"
+        />
+      </a>
+      <p
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+        data-testid="typography"
+      >
+        <a
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+          href="/profile/oliver"
+        >
+          Oliver
+        </a>
+         
+        <span
+          class="text-foreground lg:shrink-0"
+        >
+          edited 3 posts you interacted with
+        </span>
+      </p>
+      <button
+        aria-controls="radix-normalized"
+        aria-expanded="false"
+        aria-label="Show the 3 posts edited by Oliver"
+        class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 order-last shrink-0"
+        data-cy="notification-group-toggle"
+        data-size="sm"
+        data-slot="collapsible-trigger"
+        data-state="closed"
+        data-testid="collapsible-trigger"
+        data-variant="secondary"
+        type="button"
+      >
+        Show
+      </button>
+    </div>
+    <div
+      class="flex items-center gap-2 shrink-0"
+      data-testid="container"
+    >
+      <span
+        class=""
+        data-state="closed"
+      >
+        <span
+          class="text-xs font-medium tracking-widest text-muted-foreground"
+          data-testid="typography"
+        >
+          37m
+        </span>
+      </span>
+      <div
+        class="relative shrink-0"
+        data-testid="container"
+        style="width: 24px; height: 24px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sticky-note text-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+          />
+          <path
+            d="M15 3v5a1 1 0 0 0 1 1h5"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="min-w-0 flex-col items-start gap-2 pl-8 lg:pl-10 hidden"
+    data-testid="container"
+  >
+    <div
+      class="flex w-full min-w-0 flex-col gap-2"
+      data-slot="collapsible-content"
+      data-state="closed"
+      data-testid="collapsible-content"
+      hidden=""
+      id="radix-normalized"
+      style=""
+    />
+  </div>
+</div>
+`;
+
+exports[`NotificationGroupItem - Snapshots > matches snapshot for a deleted group 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-1"
+  data-cy="notification-group"
+  data-testid="container"
+>
+  <div
+    class="flex w-full min-w-0 items-center justify-between gap-2"
+    data-cy="notification-group-header"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-2"
+      data-testid="container"
+    >
+      <a
+        class="shrink-0 transition-opacity hover:opacity-80"
+        href="/profile/oliver"
+      >
+        <div
+          data-name="Oliver"
+          data-testid="avatar-with-fallback"
+        />
+      </a>
+      <p
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+        data-testid="typography"
+      >
+        <a
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+          href="/profile/oliver"
+        >
+          Oliver
+        </a>
+         
+        <span
+          class="text-foreground lg:shrink-0"
+        >
+          deleted 8 posts you interacted with
+        </span>
+      </p>
+    </div>
+    <div
+      class="flex items-center gap-2 shrink-0"
+      data-testid="container"
+    >
+      <span
+        class=""
+        data-state="closed"
+      >
+        <span
+          class="text-xs font-medium tracking-widest text-muted-foreground"
+          data-testid="typography"
+        >
+          37m
+        </span>
+      </span>
+      <div
+        class="relative shrink-0"
+        data-testid="container"
+        style="width: 24px; height: 24px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-trash2 lucide-trash-2 text-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 11v6"
+          />
+          <path
+            d="M14 11v6"
+          />
+          <path
+            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"
+          />
+          <path
+            d="M3 6h18"
+          />
+          <path
+            d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+          />
+        </svg>
+        <div
+          class="absolute right-0 bottom-0 rounded-full bg-brand"
+          data-cy="notification-unread-dot"
+          data-testid="container"
+          style="width: 11px; height: 11px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NotificationGroupItem - Snapshots > matches snapshot for an expanded edited group 1`] = `
+<div
+  class="flex w-full min-w-0 flex-col gap-1"
+  data-cy="notification-group"
+  data-slot="collapsible"
+  data-state="open"
+  data-testid="collapsible"
+>
+  <div
+    class="flex w-full min-w-0 items-center justify-between gap-2"
+    data-cy="notification-group-header"
+    data-testid="container"
+  >
+    <div
+      class="flex min-w-0 flex-1 items-center gap-2"
+      data-testid="container"
+    >
+      <a
+        class="shrink-0 transition-opacity hover:opacity-80"
+        href="/profile/oliver"
+      >
+        <div
+          data-name="Oliver"
+          data-testid="avatar-with-fallback"
+        />
+      </a>
+      <p
+        class="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
+        data-testid="typography"
+      >
+        <a
+          class="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
+          href="/profile/oliver"
+        >
+          Oliver
+        </a>
+         
+        <span
+          class="text-foreground lg:shrink-0"
+        >
+          edited 3 posts you interacted with
+        </span>
+      </p>
+    </div>
+    <div
+      class="flex items-center gap-2 shrink-0"
+      data-testid="container"
+    >
+      <span
+        class=""
+        data-state="closed"
+      >
+        <span
+          class="text-xs font-medium tracking-widest text-muted-foreground"
+          data-testid="typography"
+        >
+          37m
+        </span>
+      </span>
+      <div
+        class="relative shrink-0"
+        data-testid="container"
+        style="width: 24px; height: 24px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sticky-note text-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 9a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 15 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2z"
+          />
+          <path
+            d="M15 3v5a1 1 0 0 0 1 1h5"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="flex min-w-0 flex-col items-start gap-2 pl-8 lg:pl-10"
+    data-testid="container"
+  >
+    <button
+      aria-controls="radix-normalized"
+      aria-expanded="true"
+      aria-label="Hide the posts edited by Oliver"
+      class="inline-flex items-center justify-center whitespace-nowrap text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\\"size-\\"])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-semibold cursor-pointer rounded-full border shadow-xs bg-secondary text-secondary-foreground hover:bg-accent h-8 gap-1.5 px-3 has-[>svg]:px-3.5 order-last shrink-0"
+      data-cy="notification-group-toggle"
+      data-size="sm"
+      data-slot="collapsible-trigger"
+      data-state="open"
+      data-testid="collapsible-trigger"
+      data-variant="secondary"
+      type="button"
+    >
+      Hide
+    </button>
+    <div
+      class="flex w-full min-w-0 flex-col gap-2"
+      data-slot="collapsible-content"
+      data-state="open"
+      data-testid="collapsible-content"
+      id="radix-normalized"
+      style=""
+    >
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266580000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266520000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+      <div
+        class="min-w-0"
+        data-cy="notification-group-item"
+      >
+        <a
+          class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+          href="/post/oliver/post-1767266460000"
+        >
+          "Apple releases the new iPhone"
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.tsx
@@ -17,8 +17,8 @@ import {
   getNotificationKindBucket,
   getUserIdFromNotification,
   getUserProfileLink,
-} from '@/organisms/NotificationItem/NotificationItem.utils';
-import type { GroupableNotification } from '@/organisms/NotificationsList/NotificationsList.types';
+} from '../NotificationItem/NotificationItem.utils';
+import type { GroupableNotification } from '../NotificationsList/NotificationsList.types';
 import { getGroupedActionText, getGroupToggleHideLabel, getGroupToggleShowLabel } from './NotificationGroupItem.utils';
 import { NotificationGroupPostTitle } from './NotificationGroupPostTitle';
 
@@ -32,6 +32,14 @@ interface NotificationGroupItemProps {
    * Supplied by the list so rows do not each subscribe to viewport changes.
    */
   isMobile?: boolean;
+  /**
+   * Disclosure state owned by the list. A run's members change as pages load and
+   * refreshes arrive, which can change the row's key and remount it — holding the state
+   * here would silently collapse the group the user is reading. Omitted when the row is
+   * rendered on its own, where it keeps its own state.
+   */
+  isExpanded?: boolean;
+  onExpandedChange?: (isExpanded: boolean) => void;
 }
 
 /**
@@ -42,8 +50,20 @@ interface NotificationGroupItemProps {
  * title list: collapsed behind a disclosure toggle on desktop, always expanded on
  * mobile where the list stacks vertically anyway.
  */
-export function NotificationGroupItem({ notifications, isUnread, isMobile = false }: NotificationGroupItemProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+export function NotificationGroupItem({
+  notifications,
+  isUnread,
+  isMobile = false,
+  isExpanded: expandedProp,
+  onExpandedChange,
+}: NotificationGroupItemProps) {
+  const [ownExpanded, setOwnExpanded] = useState(false);
+  const isExpanded = expandedProp ?? ownExpanded;
+
+  const handleExpandedChange = (next: boolean) => {
+    setOwnExpanded(next);
+    onExpandedChange?.(next);
+  };
 
   const toggleRef = useRef<HTMLButtonElement>(null);
   // On desktop the toggle relocates between the header and the disclosure block, which
@@ -191,7 +211,7 @@ export function NotificationGroupItem({ notifications, isUnread, isMobile = fals
   if (!isDisclosable) return row;
 
   return (
-    <Collapsible asChild={true} open={isExpanded} onOpenChange={setIsExpanded}>
+    <Collapsible asChild={true} open={isExpanded} onOpenChange={handleExpandedChange}>
       {row}
     </Collapsible>
   );

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button, ButtonVariant } from '@/atoms/Button/Button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/atoms/Collapsible/Collapsible';
+import { Container } from '@/atoms/Container/Container';
+import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
+import { cn } from '@/libs/utils/utils';
+import { getBusinessKey } from '@/models/notification/notification.helpers';
+import { NotificationType } from '@/models/notification/notification.types';
+import {
+  NotificationActorAvatar,
+  NotificationActorHeading,
+  NotificationTimestampAndIcon,
+} from '@/molecules/NotificationRowChrome/NotificationRowChrome';
+import {
+  getNotificationKindBucket,
+  getUserIdFromNotification,
+  getUserProfileLink,
+} from '@/organisms/NotificationItem/NotificationItem.utils';
+import type { GroupableNotification } from '@/organisms/NotificationsList/NotificationsList.types';
+import { getGroupedActionText, getGroupToggleHideLabel, getGroupToggleShowLabel } from './NotificationGroupItem.utils';
+import { NotificationGroupPostTitle } from './NotificationGroupPostTitle';
+
+interface NotificationGroupItemProps {
+  /** The run of notifications collapsed into this row, newest first. */
+  notifications: GroupableNotification[];
+  /** Whether any member of the run is unread. */
+  isUnread: boolean;
+  /**
+   * Whether the notification list is being viewed below the desktop breakpoint.
+   * Supplied by the list so rows do not each subscribe to viewport changes.
+   */
+  isMobile?: boolean;
+}
+
+/**
+ * A run of repeated delete/edit notifications rendered as one row.
+ *
+ * Deleted groups are a single flat line by design — the total is the story, and the
+ * design keeps them unlinked. Edited groups keep direct access to every post through a
+ * title list: collapsed behind a disclosure toggle on desktop, always expanded on
+ * mobile where the list stacks vertically anyway.
+ */
+export function NotificationGroupItem({ notifications, isUnread, isMobile = false }: NotificationGroupItemProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  // On desktop the toggle relocates between the header and the disclosure block, which
+  // remounts it and would drop keyboard focus on <body>.
+  const shouldRestoreFocusRef = useRef(false);
+
+  // The list is newest-first, so the head carries the timestamp to show. Every member
+  // shares the type, actor and kind bucket — that is what the run was grouped on.
+  const head: GroupableNotification | undefined = notifications[0];
+  const count = notifications.length;
+  const actorId = head ? getUserIdFromNotification(head) : '';
+
+  const { profile } = useUserProfile(actorId);
+
+  useEffect(() => {
+    if (!shouldRestoreFocusRef.current) return;
+    shouldRestoreFocusRef.current = false;
+    // preventScroll: browsers center a focused element, which would scroll the header
+    // and the first titles out of view; nearest-edge keeps everything just revealed
+    // visible while the control still receives focus (scrollIntoView is absent in
+    // jsdom, hence the optional call).
+    toggleRef.current?.focus({ preventScroll: true });
+    toggleRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [isExpanded]);
+
+  if (!head) return null;
+
+  const kindBucket = getNotificationKindBucket(head);
+  const userName = profile?.name || 'User';
+  const userProfileLink = actorId ? getUserProfileLink(actorId) : null;
+
+  const timestampDate = new Date(head.timestamp);
+
+  const isEditedGroup = head.type === NotificationType.PostEdited;
+  // Mobile renders the title list permanently without a toggle, so the disclosure
+  // mechanics exist only on desktop.
+  const isDisclosable = isEditedGroup && !isMobile;
+  // Collapsed the toggle sits inline in the header row; expanded it moves below the list.
+  const showToggleInHeader = isDisclosable && !isExpanded;
+
+  // A run groups by kind bucket, so members can mix media kinds (image, video, link…).
+  // When every member shares one raw kind the icon keeps it, matching what the same
+  // notifications would show as single rows; mixed runs fall back to the bucket.
+  const uniformPostKind = notifications.every((notification) => notification.post_kind === head.post_kind)
+    ? head.post_kind
+    : undefined;
+
+  const titleList = isEditedGroup
+    ? notifications.map((notification) => (
+        <NotificationGroupPostTitle key={getBusinessKey(notification)} notification={notification} />
+      ))
+    : null;
+
+  const toggle = (
+    <CollapsibleTrigger asChild>
+      <Button
+        ref={toggleRef}
+        variant={ButtonVariant.SECONDARY}
+        size="sm"
+        type="button"
+        // order-last keeps the pill rendered below the expanded list while the DOM
+        // places it before the titles, so Tab moves from the toggle into the links it
+        // just revealed. In the header cluster it is the last child anyway.
+        className="order-last shrink-0"
+        data-cy="notification-group-toggle"
+        // The visible label repeats across rows, so name the control for screen
+        // readers by the group it belongs to.
+        aria-label={
+          isExpanded
+            ? getGroupToggleHideLabel(head.type, kindBucket, userName)
+            : getGroupToggleShowLabel(head.type, kindBucket, count, userName)
+        }
+        // Only restore focus when the control was actually focused (keyboard, most
+        // mouse flows); Safari mouse clicks leave it unfocused and must stay that way.
+        onClick={(event) => {
+          shouldRestoreFocusRef.current = document.activeElement === event.currentTarget;
+        }}
+      >
+        {isExpanded ? 'Hide' : 'Show'}
+      </Button>
+    </CollapsibleTrigger>
+  );
+
+  const row = (
+    <Container overrideDefaults={true} className="flex w-full min-w-0 flex-col gap-1" data-cy="notification-group">
+      <Container
+        overrideDefaults={true}
+        className="flex w-full min-w-0 items-center justify-between gap-2"
+        data-cy="notification-group-header"
+      >
+        <Container overrideDefaults={true} className="flex min-w-0 flex-1 items-center gap-2">
+          <NotificationActorAvatar
+            avatarUrl={profile?.avatarUrl}
+            userName={userName}
+            fallbackSeed={actorId}
+            userProfileLink={userProfileLink}
+          />
+
+          <NotificationActorHeading
+            userName={userName}
+            userProfileLink={userProfileLink}
+            actionText={getGroupedActionText(head.type, kindBucket, count)}
+          />
+
+          {showToggleInHeader && toggle}
+        </Container>
+
+        <NotificationTimestampAndIcon
+          timestampDate={timestampDate}
+          isMobile={isMobile}
+          type={head.type}
+          postKind={uniformPostKind ?? kindBucket}
+          showBadge={isUnread}
+          className="shrink-0"
+        />
+      </Container>
+
+      {isEditedGroup && (
+        // Indented to the text column: avatar (size-6, size-8 on lg) plus the gap-2.
+        // Stays mounted even when the toggle lives in the header, so force-mounted
+        // titles survive collapsing; `hidden` then removes its stray flex gap.
+        <Container
+          overrideDefaults={true}
+          className={cn('flex min-w-0 flex-col items-start gap-2 pl-8 lg:pl-10', showToggleInHeader && 'hidden')}
+        >
+          {isDisclosable ? (
+            <>
+              {!showToggleInHeader && toggle}
+
+              {/* Titles unmount while closed, so their post fetches stay lazy — the
+                  local-first cache makes a re-expand a cheap local re-read, and members
+                  appended to the run later never fetch until actually revealed. */}
+              <CollapsibleContent className="flex w-full min-w-0 flex-col gap-2">{titleList}</CollapsibleContent>
+            </>
+          ) : (
+            <Container overrideDefaults={true} className="flex w-full min-w-0 flex-col gap-2">
+              {titleList}
+            </Container>
+          )}
+        </Container>
+      )}
+    </Container>
+  );
+
+  if (!isDisclosable) return row;
+
+  return (
+    <Collapsible asChild={true} open={isExpanded} onOpenChange={setIsExpanded}>
+      {row}
+    </Collapsible>
+  );
+}

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.test.ts
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatGroupedPostTitle, GROUP_POST_TITLE_MAX_LENGTH } from './NotificationGroupItem.utils';
+
+describe('formatGroupedPostTitle', () => {
+  it('wraps a short title in double quotes without truncating', () => {
+    expect(formatGroupedPostTitle('Based Bitcoin')).toBe('"Based Bitcoin"');
+  });
+
+  it('keeps a title of exactly the maximum length intact', () => {
+    const title = 'a'.repeat(GROUP_POST_TITLE_MAX_LENGTH);
+
+    expect(formatGroupedPostTitle(title)).toBe(`"${title}"`);
+  });
+
+  it('truncates a longer title with an ellipsis', () => {
+    const title = 'a'.repeat(GROUP_POST_TITLE_MAX_LENGTH + 10);
+
+    expect(formatGroupedPostTitle(title)).toBe(`"${'a'.repeat(GROUP_POST_TITLE_MAX_LENGTH)}..."`);
+  });
+
+  it('never splits an emoji at the cut, truncating by grapheme instead of code unit', () => {
+    // 39 chars + 🚀 (2 code units) would slice mid-surrogate with a char-based cut.
+    const title = `${'a'.repeat(GROUP_POST_TITLE_MAX_LENGTH - 1)}🚀 and more`;
+
+    expect(formatGroupedPostTitle(title)).toBe(`"${'a'.repeat(GROUP_POST_TITLE_MAX_LENGTH - 1)}🚀..."`);
+  });
+});

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.ts
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.ts
@@ -1,0 +1,76 @@
+import { truncateByGraphemes } from '@/libs/utils/truncate';
+import { NotificationType } from '@/models/notification/notification.types';
+import type { NotificationKindBucket } from '@/organisms/NotificationItem/NotificationItem.utils';
+import type { GroupableNotificationType } from '@/organisms/NotificationsList/NotificationsList.types';
+
+/**
+ * Grouped post titles get more room than the single-row preview (20 chars) because they
+ * sit on their own line rather than sharing one with the action text.
+ */
+export const GROUP_POST_TITLE_MAX_LENGTH = 40;
+
+/**
+ * Formats an edited post's title for the grouped list.
+ * Double quotes and a longer limit set it apart from the single-row preview.
+ * Grapheme-based truncation keeps emoji and combined characters whole at the cut.
+ */
+export function formatGroupedPostTitle(title: string): string {
+  return `"${truncateByGraphemes(title, GROUP_POST_TITLE_MAX_LENGTH)}"`;
+}
+
+/**
+ * Copy vocabulary for grouped rows, one record per (type × kind bucket). The row text
+ * and both of the toggle's accessible labels derive from the same record, so the verbs
+ * and nouns cannot drift apart.
+ */
+const GROUPED_COPY: Record<
+  GroupableNotificationType,
+  Record<NotificationKindBucket, { verb: string; noun: string; suffix?: string }>
+> = {
+  [NotificationType.PostDeleted]: {
+    post: { verb: 'deleted', noun: 'posts', suffix: ' you interacted with' },
+    collection: { verb: 'deleted', noun: 'collections', suffix: ' you interacted with' },
+    long: { verb: 'deleted', noun: 'articles', suffix: ' you interacted with' },
+  },
+  [NotificationType.PostEdited]: {
+    post: { verb: 'edited', noun: 'posts', suffix: ' you interacted with' },
+    collection: { verb: 'updated', noun: 'collections' },
+    long: { verb: 'updated', noun: 'articles' },
+  },
+};
+
+/**
+ * Action text for a group's row (rendered after the actor's username).
+ */
+export function getGroupedActionText(
+  type: GroupableNotificationType,
+  kindBucket: NotificationKindBucket,
+  count: number,
+): string {
+  const { verb, noun, suffix } = GROUPED_COPY[type][kindBucket];
+  return `${verb} ${count} ${noun}${suffix ?? ''}`;
+}
+
+/**
+ * Accessible name for the disclosure toggle while collapsed. The visible label is just
+ * "Show", so the control is named by its kind, count and actor.
+ */
+export function getGroupToggleShowLabel(
+  type: GroupableNotificationType,
+  kindBucket: NotificationKindBucket,
+  count: number,
+  name: string,
+): string {
+  const { verb, noun } = GROUPED_COPY[type][kindBucket];
+  return `Show the ${count} ${noun} ${verb} by ${name}`;
+}
+
+/** Accessible name for the disclosure toggle while expanded. */
+export function getGroupToggleHideLabel(
+  type: GroupableNotificationType,
+  kindBucket: NotificationKindBucket,
+  name: string,
+): string {
+  const { verb, noun } = GROUPED_COPY[type][kindBucket];
+  return `Hide the ${noun} ${verb} by ${name}`;
+}

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.ts
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupItem.utils.ts
@@ -1,7 +1,7 @@
 import { truncateByGraphemes } from '@/libs/utils/truncate';
 import { NotificationType } from '@/models/notification/notification.types';
-import type { NotificationKindBucket } from '@/organisms/NotificationItem/NotificationItem.utils';
-import type { GroupableNotificationType } from '@/organisms/NotificationsList/NotificationsList.types';
+import type { NotificationKindBucket } from '../NotificationItem/NotificationItem.utils';
+import type { GroupableNotificationType } from '../NotificationsList/NotificationsList.types';
 
 /**
  * Grouped post titles get more room than the single-row preview (20 chars) because they

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.test.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationType, PostChangedSource } from '@/models/notification/notification.types';
+import type { GroupableNotification } from '@/organisms/NotificationsList/NotificationsList.types';
+import { NotificationGroupPostTitle } from './NotificationGroupPostTitle';
+
+type PostContentResult = { content: string | null; isDeleted: boolean; isMissing: boolean; isResolving: boolean };
+
+const mockUseNotificationPostContent = vi.hoisted(() =>
+  vi.fn<(options: { compositeId: string | null }) => PostContentResult>(() => ({
+    content: 'Apple releases the new iPhone',
+    isDeleted: false,
+    isMissing: false,
+    isResolving: false,
+  })),
+);
+
+const postContent = (overrides: Partial<PostContentResult>): PostContentResult => ({
+  content: null,
+  isDeleted: false,
+  isMissing: false,
+  isResolving: false,
+  ...overrides,
+});
+
+vi.mock('@/hooks/useNotificationPostContent/useNotificationPostContent', () => ({
+  useNotificationPostContent: mockUseNotificationPostContent,
+}));
+
+const TIMESTAMP = new Date('2026-01-01T12:00:00Z').getTime();
+
+function editedNotification(editedUri?: string): GroupableNotification {
+  return {
+    id: `post_edited:${TIMESTAMP}:oliver`,
+    type: NotificationType.PostEdited,
+    timestamp: TIMESTAMP,
+    edit_source: PostChangedSource.Reply,
+    edited_by: 'oliver',
+    edited_uri: editedUri ?? 'pubky://oliver/pub/pubky.app/posts/post123',
+    linked_uri: 'pubky://viewer/pub/pubky.app/posts/linked123',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseNotificationPostContent.mockReturnValue(postContent({ content: 'Apple releases the new iPhone' }));
+});
+
+describe('NotificationGroupPostTitle', () => {
+  it('renders the resolved title in double quotes, linking to the post', () => {
+    render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('"Apple releases the new iPhone"');
+    expect(link).toHaveAttribute('href', '/post/oliver/post123');
+  });
+
+  it('truncates a long title at 40 characters', () => {
+    mockUseNotificationPostContent.mockReturnValue(
+      postContent({ content: 'Apple releases the new iPhone and everybody rushes to buy it' }),
+    );
+
+    render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    expect(screen.getByRole('link')).toHaveTextContent('"Apple releases the new iPhone and everyb..."');
+  });
+
+  it('asks the post-content hook for the edited post', () => {
+    render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    expect(mockUseNotificationPostContent).toHaveBeenCalledWith(
+      expect.objectContaining({ compositeId: 'oliver:post123', notifyOnCollectionParseError: false }),
+    );
+  });
+
+  it('shows a skeleton while the title is still resolving', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({ isResolving: true }));
+
+    const { container } = render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    expect(container.querySelector('[data-slot="skeleton"]')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder once the title settles with nothing', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({}));
+
+    const { container } = render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    expect(screen.getByText('Untitled post')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeInTheDocument();
+    // The post still exists (only its label failed to derive), so navigation stays valid.
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/post/oliver/post123');
+  });
+
+  it('drops the link when the post itself is gone', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({ isMissing: true }));
+
+    render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    expect(screen.getByText('Untitled post')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a deleted member as a plain unlinked notice, not a quoted title', () => {
+    mockUseNotificationPostContent.mockReturnValue(
+      postContent({ content: 'This post has been deleted by its author.', isDeleted: true }),
+    );
+
+    render(<NotificationGroupPostTitle notification={editedNotification()} />);
+
+    // The notice renders verbatim: no quotes, no 40-char cut, and nothing to click.
+    expect(screen.getByText('This post has been deleted by its author.')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders plain text when the post URI cannot be resolved to a route', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({}));
+
+    render(<NotificationGroupPostTitle notification={editedNotification('not-a-pubky-uri')} />);
+
+    expect(screen.getByText('Untitled post')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});
+
+describe('NotificationGroupPostTitle - Snapshots', () => {
+  it('matches snapshot with a resolved title', () => {
+    const { container } = render(<NotificationGroupPostTitle notification={editedNotification()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot while resolving', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({ isResolving: true }));
+
+    const { container } = render(<NotificationGroupPostTitle notification={editedNotification()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with an unresolvable post', () => {
+    mockUseNotificationPostContent.mockReturnValue(postContent({}));
+
+    const { container } = render(<NotificationGroupPostTitle notification={editedNotification('not-a-pubky-uri')} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.test.tsx.snap
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.test.tsx.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NotificationGroupPostTitle - Snapshots > matches snapshot while resolving 1`] = `
+<div
+  data-cy="notification-group-item"
+>
+  <div
+    class="animate-pulse rounded-md bg-muted h-4 w-48 max-w-full"
+    data-slot="skeleton"
+  />
+</div>
+`;
+
+exports[`NotificationGroupPostTitle - Snapshots > matches snapshot with a resolved title 1`] = `
+<div
+  class="min-w-0"
+  data-cy="notification-group-item"
+>
+  <a
+    class="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+    href="/post/oliver/post123"
+  >
+    "Apple releases the new iPhone"
+  </a>
+</div>
+`;
+
+exports[`NotificationGroupPostTitle - Snapshots > matches snapshot with an unresolvable post 1`] = `
+<div
+  class="min-w-0"
+  data-cy="notification-group-item"
+>
+  <p
+    class="block truncate text-sm font-medium text-muted-foreground lg:text-base"
+    data-testid="typography"
+  >
+    Untitled post
+  </p>
+</div>
+`;

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton } from '@/atoms/Skeleton/Skeleton';
+import { Typography } from '@/atoms/Typography/Typography';
+import { useNotificationPostContent } from '@/hooks/useNotificationPostContent/useNotificationPostContent';
+import type { FlatNotification } from '@/models/notification/notification.types';
+import {
+  getNotificationLink,
+  getPostUriFromNotification,
+  pubkyUriToCompositeId,
+} from '@/organisms/NotificationItem/NotificationItem.utils';
+import { formatGroupedPostTitle } from './NotificationGroupItem.utils';
+
+interface NotificationGroupPostTitleProps {
+  notification: FlatNotification;
+}
+
+/**
+ * One edited post inside a grouped notification row: its title, linking to the post.
+ *
+ * Each title owns its own fetch, so collapsing the group also collapses the request
+ * count — only the titles actually rendered are resolved.
+ */
+export function NotificationGroupPostTitle({ notification }: NotificationGroupPostTitleProps) {
+  const postUri = getPostUriFromNotification(notification);
+  const compositeId = postUri ? pubkyUriToCompositeId(postUri) : null;
+
+  const { content, isDeleted, isMissing, isResolving } = useNotificationPostContent({
+    compositeId,
+    notifyOnCollectionParseError: false,
+  });
+  const { notificationLink } = getNotificationLink(notification);
+
+  if (isResolving) {
+    return (
+      <div data-cy="notification-group-item">
+        <Skeleton className="h-4 w-48 max-w-full" />
+      </div>
+    );
+  }
+
+  // A member deleted after its edits has no destination and no title — state the notice
+  // plainly instead of dressing it up as a quoted, truncated, clickable title.
+  if (isDeleted) {
+    return (
+      <div data-cy="notification-group-item" className="min-w-0">
+        <Typography as="p" className="block truncate text-sm font-medium text-muted-foreground lg:text-base">
+          {content}
+        </Typography>
+      </div>
+    );
+  }
+
+  // A post that never resolves still gets a row, so the header count, the pill count and
+  // the rendered rows always agree. A missing post drops its link (the destination shows
+  // nothing); an existing post whose label merely failed to derive keeps it.
+  const title = content ? formatGroupedPostTitle(content) : 'Untitled post';
+  const link = isMissing ? null : notificationLink;
+
+  return (
+    <div data-cy="notification-group-item" className="min-w-0">
+      {link ? (
+        <Link
+          href={link}
+          className="block truncate text-sm font-medium text-muted-foreground hover:underline lg:text-base"
+        >
+          {title}
+        </Link>
+      ) : (
+        <Typography as="p" className="block truncate text-sm font-medium text-muted-foreground lg:text-base">
+          {title}
+        </Typography>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.tsx
+++ b/src/components/organisms/NotificationGroupItem/NotificationGroupPostTitle.tsx
@@ -9,7 +9,7 @@ import {
   getNotificationLink,
   getPostUriFromNotification,
   pubkyUriToCompositeId,
-} from '@/organisms/NotificationItem/NotificationItem.utils';
+} from '../NotificationItem/NotificationItem.utils';
 import { formatGroupedPostTitle } from './NotificationGroupItem.utils';
 
 interface NotificationGroupPostTitleProps {

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -92,7 +92,8 @@ vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => {
 });
 
 // Mock molecules
-const mockToast = vi.fn();
+// Hoisted so the module-level `toast` export can be mocked with it directly.
+const mockToast = vi.hoisted(() => vi.fn());
 /** The post the mocked live query currently reports; null models "not found". */
 const mockPostDetails = { value: null as { kind: string; content: string } | null };
 const mockUsePostDetails = vi.fn((compositeId: string | null) => ({
@@ -142,6 +143,7 @@ vi.mock('@/molecules/PostTag/PostTag', () => {
 
 vi.mock('@/molecules/Toaster/use-toast', () => {
   return {
+    toast: mockToast,
     useToast: () => ({ toast: mockToast }),
   };
 });

--- a/src/components/organisms/NotificationItem/NotificationItem.test.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -58,12 +58,8 @@ vi.mock('@/services/local/post/post', () => ({
     readPostDetails: vi.fn(() => Promise.resolve(null)),
   },
 }));
-vi.mock('@/controllers/post/post', () => ({
-  PostController: {
-    get getOrFetch() {
-      return mockGetOrFetch;
-    },
-  },
+vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
+  usePostDetails: (compositeId: string | null) => mockUsePostDetails(compositeId),
 }));
 vi.mock('@/controllers/file/file', () => ({
   FileController: {
@@ -97,7 +93,12 @@ vi.mock('@/organisms/AvatarWithFallback/AvatarWithFallback', () => {
 
 // Mock molecules
 const mockToast = vi.fn();
-const mockGetOrFetch = vi.fn<() => Promise<{ kind: string; content: string } | null>>(() => Promise.resolve(null));
+/** The post the mocked live query currently reports; null models "not found". */
+const mockPostDetails = { value: null as { kind: string; content: string } | null };
+const mockUsePostDetails = vi.fn((compositeId: string | null) => ({
+  postDetails: compositeId ? mockPostDetails.value : null,
+  isLoading: false,
+}));
 vi.mock('@/molecules/NotificationIcon/NotificationIcon', () => {
   return {
     NotificationIcon: ({
@@ -186,8 +187,8 @@ describe('NotificationItem', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToast.mockClear();
-    mockGetOrFetch.mockClear();
-    mockGetOrFetch.mockResolvedValue(null);
+    mockUsePostDetails.mockClear();
+    mockPostDetails.value = null;
     vi.mocked(useUserProfile).mockReturnValue({
       profile: { name: 'User', avatarUrl: undefined },
       isLoading: false,
@@ -417,10 +418,10 @@ describe('NotificationItem', () => {
       body: '## Introduction\n\nArticle body content here in **Markdown** format.',
     });
 
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'long',
       content: articleContent,
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -442,10 +443,10 @@ describe('NotificationItem', () => {
   it('falls back to raw content without toast when article JSON parsing fails', async () => {
     const invalidJson = 'not valid json content';
 
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'long',
       content: invalidJson,
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -470,10 +471,10 @@ describe('NotificationItem', () => {
       items: ['user1:post1'],
     });
 
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'collection',
       content: collectionContent,
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -493,10 +494,10 @@ describe('NotificationItem', () => {
   it('falls back to raw content and shows toast when collection JSON parsing fails', async () => {
     const invalidJson = 'not valid json content';
 
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'collection',
       content: invalidJson,
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -517,10 +518,10 @@ describe('NotificationItem', () => {
   });
 
   it('uses content directly for short posts', async () => {
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'short',
       content: 'This is a short post content',
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -540,10 +541,10 @@ describe('NotificationItem', () => {
   });
 
   it('shows deleted message when post is deleted', async () => {
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'short',
       content: '[DELETED]',
-    });
+    };
 
     const mentionNotification = {
       id: 'mention:123:user1',
@@ -561,6 +562,26 @@ describe('NotificationItem', () => {
     await vi.waitFor(() => {
       expect(screen.getByText("'This post has been d...'")).toBeInTheDocument();
     });
+  });
+
+  it('renders a deleted notification without any post link', () => {
+    // Design decision on PR #2314: the deleted post has no destination, so the row is
+    // informational — only the avatar and username may link (to the actor's profile).
+    const deletedNotification = {
+      id: 'post_deleted:123:user1',
+      type: NotificationType.PostDeleted,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      delete_source: PostChangedSource.Repost,
+      deleted_by: 'user1',
+      deleted_uri: 'pubky://user1/pub/pubky.app/posts/post123',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/linked123',
+    } as FlatNotification;
+
+    const { container } = render(<NotificationItem notification={deletedNotification} isUnread={false} />);
+
+    expect(screen.getByText('deleted a post').closest('a')).toBeNull();
+    const hrefs = [...container.querySelectorAll('a')].map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs).toEqual(['/profile/user1', '/profile/user1']);
   });
 
   it('links to parent post (not the reply) for Reply notifications', () => {
@@ -617,10 +638,10 @@ describe('NotificationItem', () => {
     vi.setSystemTime(new Date('2026-07-16T12:00:00Z'));
 
     try {
-      mockGetOrFetch.mockResolvedValue({
+      mockPostDetails.value = {
         kind: 'collection',
         content: JSON.stringify({ name: 'Based Bitcoin', description: '', items: [] }),
-      });
+      };
 
       const collectionNotification = {
         id: 'post_edited:123:collection-owner',
@@ -639,10 +660,7 @@ describe('NotificationItem', () => {
         const preview = screen.getByText("'Based Bitcoin'");
         expect(preview).toHaveClass('hidden', 'sm:block', 'text-muted-foreground');
       });
-      expect(mockGetOrFetch).toHaveBeenCalledWith({
-        compositeId: 'collection-owner:collection-id',
-        viewerId: 'test-user-pubky',
-      });
+      expect(mockUsePostDetails).toHaveBeenCalledWith('collection-owner:collection-id');
     } finally {
       vi.useRealTimers();
     }
@@ -788,7 +806,7 @@ describe('NotificationItem', () => {
 describe('NotificationItem - Snapshots', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetOrFetch.mockResolvedValue(null);
+    mockPostDetails.value = null;
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-16T12:00:00Z'));
   });
@@ -834,10 +852,10 @@ describe('NotificationItem - Snapshots', () => {
   });
 
   it('matches snapshot for an edited collection with a title preview', async () => {
-    mockGetOrFetch.mockResolvedValue({
+    mockPostDetails.value = {
       kind: 'collection',
       content: JSON.stringify({ name: 'Based Bitcoin', description: '', items: [] }),
-    });
+    };
     const notification = {
       id: 'post_edited:123:collection-owner',
       type: NotificationType.PostEdited,
@@ -850,10 +868,8 @@ describe('NotificationItem - Snapshots', () => {
     } satisfies FlatNotification;
 
     render(<NotificationItem notification={notification} isUnread={false} />);
-    await act(async () => {
-      await mockGetOrFetch.mock.results[0]?.value;
-    });
 
+    // Collection names derive synchronously from the live query's value.
     expect(screen.getByText("'Based Bitcoin'")).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/NotificationItem/NotificationItem.tsx
+++ b/src/components/organisms/NotificationItem/NotificationItem.tsx
@@ -1,26 +1,19 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Container } from '@/atoms/Container/Container';
 import { Typography } from '@/atoms/Typography/Typography';
-import { PostController } from '@/controllers/post/post';
-import { useRelativeTime } from '@/hooks/useRelativeTime/useRelativeTime';
+import { useNotificationPostContent } from '@/hooks/useNotificationPostContent/useNotificationPostContent';
 import { buildSearchUrl } from '@/hooks/useTagSearch/useTagSearch.utils';
 import { useUserProfile } from '@/hooks/useUserProfile/useUserProfile';
-import { Logger } from '@/libs/logger/logger';
-import { parseArticleContent } from '@/libs/post/articleContent';
-import { parseCollectionContent } from '@/libs/post/collectionContent';
-import { isPostDeleted } from '@/libs/utils/utils';
 import { NotificationType } from '@/models/notification/notification.types';
-import { NotificationIcon } from '@/molecules/NotificationIcon/NotificationIcon';
+import {
+  NotificationActorAvatar,
+  NotificationActorHeading,
+  NotificationTimestampAndIcon,
+} from '@/molecules/NotificationRowChrome/NotificationRowChrome';
 import { PostTag } from '@/molecules/PostTag/PostTag';
-import { RelativeTimestamp } from '@/molecules/RelativeTimestamp/RelativeTimestamp';
-import { useToast } from '@/molecules/Toaster/use-toast';
-import { useAuthStore } from '@/stores/auth/auth.store';
-import { AvatarWithFallback } from '../AvatarWithFallback/AvatarWithFallback';
-import { resolvePubkyToNames } from './NotificationItem.helpers';
 import type { NotificationItemProps } from './NotificationItem.types';
 import {
   formatPreviewText,
@@ -34,73 +27,20 @@ import {
 
 export function NotificationItem({ notification, isUnread, isMobile = false }: NotificationItemProps) {
   const router = useRouter();
-  const { toast } = useToast();
-  const { formatRelativeTime } = useRelativeTime();
 
   // Extract the user ID from the notification (the actor who triggered it)
   const actorUserId = getUserIdFromNotification(notification);
   const postKind = 'post_kind' in notification ? notification.post_kind : undefined;
+  const showsPostPreview = hasPostPreview(notification.type, postKind);
 
-  // Extract post composite ID for notifications with post content (memoized to avoid recalculation)
-  const postCompositeId = useMemo(() => {
-    const postUri = getPostUriFromNotification(notification);
-    return postUri ? pubkyUriToCompositeId(postUri) : null;
-  }, [notification]);
-
-  // State for post content (fetched via controller)
-  const [postContent, setPostContent] = useState<string | null>(null);
+  // Types that never render a preview stay null so they do not trigger a pointless fetch.
+  const postUri = showsPostPreview ? getPostUriFromNotification(notification) : null;
+  const postCompositeId = postUri ? pubkyUriToCompositeId(postUri) : null;
 
   // Use existing hook for user profile data
   const { profile } = useUserProfile(actorUserId || '');
 
-  // Fetch post content via controller (handles caching internally)
-  useEffect(() => {
-    if (!postCompositeId) return;
-
-    const viewerId = useAuthStore.getState().currentUserPubky;
-    if (!viewerId) return;
-
-    let isCancelled = false;
-
-    // PostController.getOrFetch handles the caching strategy:
-    // 1. Check local DB first
-    // 2. If missing, fetch from Nexus
-    // 3. Write to local DB
-    PostController.getOrFetch({ compositeId: postCompositeId, viewerId })
-      .then(async (post) => {
-        if (!isCancelled && post?.content) {
-          if (isPostDeleted(post.content)) {
-            setPostContent('This post has been deleted by its author.');
-          } else if (post.kind === 'long') {
-            setPostContent(parseArticleContent(post.content)?.title || post.content);
-          } else if (post.kind === 'collection') {
-            const parsed = parseCollectionContent(post.content);
-            if (parsed) {
-              setPostContent(parsed.name);
-            } else {
-              setPostContent(post.content);
-              toast({
-                variant: 'error',
-                description: 'Could not parse collection content',
-              });
-            }
-          } else {
-            const content = await resolvePubkyToNames(post.content);
-            if (!isCancelled) setPostContent(content);
-          }
-        }
-      })
-      .catch((error) => {
-        if (!isCancelled) {
-          Logger.warn('Failed to fetch notification post:', { postCompositeId, error });
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast is an external side-effect, not a dependency
-  }, [postCompositeId]);
+  const { content: postContent } = useNotificationPostContent({ compositeId: postCompositeId });
 
   // Get user name and avatar from profile hook
   const userName = profile?.name || 'User';
@@ -110,17 +50,9 @@ export function NotificationItem({ notification, isUnread, isMobile = false }: N
   const actionText = getNotificationActionText(notification);
 
   // Get post preview text
-  const previewText = hasPostPreview(notification.type, postKind) ? formatPreviewText(postContent) : null;
+  const previewText = showsPostPreview ? formatPreviewText(postContent) : null;
 
   const timestampDate = new Date(notification.timestamp);
-  const timestampElement = (
-    <RelativeTimestamp
-      timeAgo={formatRelativeTime(timestampDate)}
-      date={timestampDate}
-      isMobile={isMobile}
-      className="text-xs font-medium tracking-widest text-muted-foreground"
-    />
-  );
 
   // Calculate notification links (business logic separated in pure function)
   const { notificationLink, userProfileLink } = getNotificationLink(notification);
@@ -148,52 +80,20 @@ export function NotificationItem({ notification, isUnread, isMobile = false }: N
       onClick={handleRowClick}
     >
       <Container overrideDefaults={true} className="flex min-w-0 flex-1 items-center gap-2">
-        {/* Avatar - links to user profile */}
-        {userProfileLink ? (
-          <Link href={userProfileLink} className="shrink-0 transition-opacity hover:opacity-80">
-            <AvatarWithFallback
-              avatarUrl={avatarUrl}
-              name={userName}
-              fallbackSeed={actorUserId || userName}
-              size="sm"
-              className="lg:size-8"
-            />
-          </Link>
-        ) : (
-          <AvatarWithFallback
-            avatarUrl={avatarUrl}
-            name={userName}
-            fallbackSeed={actorUserId || userName}
-            size="sm"
-            className="shrink-0 lg:size-8"
-          />
-        )}
+        <NotificationActorAvatar
+          avatarUrl={avatarUrl}
+          userName={userName}
+          fallbackSeed={actorUserId || userName}
+          userProfileLink={userProfileLink}
+        />
 
         <Container overrideDefaults={true} className="flex min-w-0 flex-1 items-center gap-2">
-          <Typography
-            as="p"
-            className="min-w-0 shrink text-sm leading-normal font-medium whitespace-normal text-foreground lg:flex lg:items-baseline lg:gap-1 lg:text-base lg:whitespace-nowrap"
-          >
-            {/* Username - truncated independently so long names do not overlap timestamp/icon */}
-            {userProfileLink ? (
-              <Link
-                href={userProfileLink}
-                className="inline-block max-w-full min-w-0 truncate align-bottom no-underline hover:no-underline"
-              >
-                {userName}
-              </Link>
-            ) : (
-              <span className="inline-block max-w-full min-w-0 truncate align-bottom">{userName}</span>
-            )}{' '}
-            {/* Action text - links to notification target (post or profile) */}
-            {notificationLink ? (
-              <Link href={notificationLink} className="text-foreground hover:underline lg:shrink-0">
-                {actionText}
-              </Link>
-            ) : (
-              <span className="text-foreground lg:shrink-0">{actionText}</span>
-            )}
-          </Typography>
+          <NotificationActorHeading
+            userName={userName}
+            userProfileLink={userProfileLink}
+            actionText={actionText}
+            actionLink={notificationLink}
+          />
 
           {/* Post preview text - dynamically fetched from database */}
           {previewText &&
@@ -234,19 +134,14 @@ export function NotificationItem({ notification, isUnread, isMobile = false }: N
       </Container>
 
       {/* Timestamp and icon - links to notification target */}
-      {notificationLink ? (
-        <Link href={notificationLink} className="flex shrink-0 items-center gap-2 transition-opacity hover:opacity-80">
-          {timestampElement}
-
-          <NotificationIcon type={notification.type} postKind={postKind} showBadge={isUnread} />
-        </Link>
-      ) : (
-        <Container overrideDefaults={true} className="flex items-center gap-2">
-          {timestampElement}
-
-          <NotificationIcon type={notification.type} postKind={postKind} showBadge={isUnread} />
-        </Container>
-      )}
+      <NotificationTimestampAndIcon
+        timestampDate={timestampDate}
+        isMobile={isMobile}
+        type={notification.type}
+        postKind={postKind}
+        showBadge={isUnread}
+        link={notificationLink}
+      />
     </Container>
   );
 }

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.test.ts
@@ -117,17 +117,6 @@ describe('NotificationItem utilities', () => {
         repost_uri: 'pubky://actor/pub/pubky.app/posts/repost-id',
       },
     },
-    {
-      label: 'deleted collection',
-      expected: '/post/viewer/linked-id',
-      notification: {
-        type: NotificationType.PostDeleted,
-        delete_source: PostChangedSource.Repost,
-        deleted_by: 'owner',
-        deleted_uri: 'pubky://owner/pub/pubky.app/posts/collection-id',
-        linked_uri: 'pubky://viewer/pub/pubky.app/posts/linked-id',
-      },
-    },
   ])('keeps the existing live post target for a $label notification', ({ notification, expected }) => {
     const flatNotification = {
       id: `${notification.type}:123:actor`,
@@ -137,5 +126,25 @@ describe('NotificationItem utilities', () => {
     } as FlatNotification;
 
     expect(getNotificationLink(flatNotification).notificationLink).toBe(expected);
+  });
+
+  it('gives a deleted notification no post target, keeping the row informational', () => {
+    // Design decision on PR #2314: the deleted post has no destination, so the row
+    // must not navigate anywhere (the viewer's linked post is deliberately not used).
+    const notification = {
+      id: 'post_deleted:123:owner',
+      type: NotificationType.PostDeleted,
+      timestamp: 123,
+      delete_source: PostChangedSource.Repost,
+      deleted_by: 'owner',
+      deleted_uri: 'pubky://owner/pub/pubky.app/posts/collection-id',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/linked-id',
+      post_kind: 'collection',
+    } satisfies FlatNotification;
+
+    const { notificationLink, userProfileLink } = getNotificationLink(notification);
+
+    expect(notificationLink).toBeNull();
+    expect(userProfileLink).toBe('/profile/owner');
   });
 });

--- a/src/components/organisms/NotificationItem/NotificationItem.utils.ts
+++ b/src/components/organisms/NotificationItem/NotificationItem.utils.ts
@@ -26,6 +26,10 @@ const NOTIFICATION_ACTION_TEXT: Record<NotificationType, string> = {
 };
 
 type SpecificPostKind = 'collection' | 'long';
+
+/** The three post-kind variants the notification copy distinguishes. */
+export type NotificationKindBucket = SpecificPostKind | 'post';
+
 type KindSpecificNotificationAction = Partial<Record<NotificationType, Record<SpecificPostKind, string>>>;
 
 const KIND_SPECIFIC_NOTIFICATION_ACTION_TEXT: KindSpecificNotificationAction = {
@@ -38,15 +42,23 @@ const KIND_SPECIFIC_NOTIFICATION_ACTION_TEXT: KindSpecificNotificationAction = {
 };
 
 /**
+ * Buckets a notification's post kind into the three variants the copy distinguishes.
+ * Anything Nexus sends that is not a collection or an article reads as a plain post.
+ */
+export function getNotificationKindBucket(notification: FlatNotification): NotificationKindBucket {
+  const postKind = 'post_kind' in notification ? notification.post_kind : undefined;
+  if (postKind === 'collection' || postKind === 'long') return postKind;
+  return 'post';
+}
+
+/**
  * Get notification action text (without the username) based on type
  */
 export function getNotificationActionText(notification: FlatNotification): string {
-  if ('post_kind' in notification) {
-    const postKind = notification.post_kind;
-    if (postKind === 'collection' || postKind === 'long') {
-      const actionText = KIND_SPECIFIC_NOTIFICATION_ACTION_TEXT[notification.type]?.[postKind];
-      if (actionText) return actionText;
-    }
+  const kindBucket = getNotificationKindBucket(notification);
+  if (kindBucket !== 'post') {
+    const actionText = KIND_SPECIFIC_NOTIFICATION_ACTION_TEXT[notification.type]?.[kindBucket];
+    if (actionText) return actionText;
   }
 
   return NOTIFICATION_ACTION_TEXT[notification.type] ?? 'New notification';
@@ -145,8 +157,9 @@ function getPostLink(notification: FlatNotification): string | null {
       break;
 
     case NotificationType.PostDeleted:
-      uri = notification.linked_uri;
-      break;
+      // Deleted-post rows are informational by design — the deleted post has no
+      // destination, so the row offers no post link (matching the flat grouped row).
+      return null;
 
     case NotificationType.PostEdited:
       uri = notification.edited_uri;
@@ -179,7 +192,7 @@ function getPostLink(notification: FlatNotification): string | null {
 /**
  * Get the user profile link for the notification actor
  */
-function getUserProfileLink(userId: string): string {
+export function getUserProfileLink(userId: string): string {
   return `${APP_ROUTES.PROFILE}/${userId}`;
 }
 

--- a/src/components/organisms/NotificationsContainer/NotificationsContainer.test.tsx
+++ b/src/components/organisms/NotificationsContainer/NotificationsContainer.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNotifications } from '@/hooks/useNotifications/useNotifications';
-import { NotificationType } from '@/models/notification/notification.types';
+import { type FlatNotification, NotificationType, PostChangedSource } from '@/models/notification/notification.types';
 import { NotificationsContainer } from './NotificationsContainer';
 
 const authStoreState = vi.hoisted(() => ({ session: {} as unknown }));
@@ -36,10 +37,25 @@ vi.mock('@/hooks/useNotifications/useNotifications', () => ({
   })),
 }));
 
+// Captures the options the container hands the scroll sentinel, so tests can inspect
+// the wiring; the budget behaviour itself lives in (and is tested with) the hook.
+const infiniteScrollOptions = vi.hoisted(() => ({
+  current: null as {
+    onLoadMore: () => void;
+    hasMore: boolean;
+    isLoading: boolean;
+    itemCount?: number;
+    maxUnproductiveLoads?: number;
+  } | null,
+}));
+const infiniteScrollState = vi.hoisted(() => ({ isStalled: false }));
+const mockResumeAutoLoad = vi.hoisted(() => vi.fn());
+
 vi.mock('@/hooks/useInfiniteScroll/useInfiniteScroll', () => ({
-  useInfiniteScroll: vi.fn(() => ({
-    sentinelRef: vi.fn(),
-  })),
+  useInfiniteScroll: vi.fn((options: { onLoadMore: () => void; hasMore: boolean; isLoading: boolean }) => {
+    infiniteScrollOptions.current = options;
+    return { sentinelRef: vi.fn(), isStalled: infiniteScrollState.isStalled, resumeAutoLoad: mockResumeAutoLoad };
+  }),
 }));
 
 // Mock atoms
@@ -90,8 +106,8 @@ vi.mock('@/molecules/NotificationsEmpty/NotificationsEmpty', () => {
 
 // Mock organisms (NotificationsList is now in organisms)
 vi.mock('@/organisms/NotificationsList/NotificationsList', () => ({
-  NotificationsList: ({ notifications }: { notifications: unknown[] }) => (
-    <div data-testid="notifications-list">{notifications.length} notifications</div>
+  NotificationsList: ({ entries }: { entries: unknown[] }) => (
+    <div data-testid="notifications-list">{entries.length} notifications</div>
   ),
 }));
 
@@ -155,7 +171,8 @@ describe('NotificationsContainer', () => {
     expect(screen.getByText(/No notifications yet/i)).toBeInTheDocument();
   });
 
-  it('shows error state', () => {
+  it('owns the page with a retry when a failure leaves nothing loaded', async () => {
+    const refresh = vi.fn();
     vi.mocked(useNotifications).mockReturnValueOnce({
       notifications: [],
       unreadNotifications: [],
@@ -166,12 +183,53 @@ describe('NotificationsContainer', () => {
       hasMore: false,
       error: 'Failed to load notifications',
       loadMore: vi.fn(),
-      refresh: vi.fn(),
+      refresh,
       markAllAsRead: vi.fn(),
       isNotificationUnread: vi.fn(() => false),
     });
     render(<NotificationsContainer />);
+
     expect(screen.getByText(/Failed to load notifications/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('notifications-list')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the loaded rows and renders the failure inline with a retry', async () => {
+    const refresh = vi.fn();
+    vi.mocked(useNotifications).mockReturnValueOnce({
+      notifications: [
+        {
+          id: 'follow:123:user1',
+          type: NotificationType.Follow,
+          timestamp: Date.now() - 1000 * 60 * 30,
+          followed_by: 'user1',
+        } as FlatNotification,
+      ],
+      unreadNotifications: [],
+      count: 1,
+      unreadCount: 0,
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: true,
+      error: 'Failed to load more notifications',
+      loadMore: vi.fn(),
+      refresh,
+      markAllAsRead: vi.fn(),
+      isNotificationUnread: vi.fn(() => false),
+    });
+    const { container } = render(<NotificationsContainer />);
+
+    // The accumulated list survives the failure; the error renders below it instead.
+    expect(screen.getByTestId('notifications-list')).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load more notifications/i)).toBeInTheDocument();
+    // The sentinel unmounts so the observer cannot loop retries against a failing
+    // network — recovery goes through the button.
+    expect(container.querySelector('[data-cy="notifications-sentinel"]')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it('shows loading more indicator when paginating', () => {
@@ -262,5 +320,154 @@ describe('NotificationsContainer', () => {
   it('matches snapshot', () => {
     const { container } = render(<NotificationsContainer />);
     expect(container).toMatchSnapshot();
+  });
+});
+
+function buildNotificationsResult({
+  notifications,
+  loadMore = vi.fn(),
+  hasMore = true,
+}: {
+  notifications: FlatNotification[];
+  loadMore?: () => Promise<void>;
+  hasMore?: boolean;
+}): ReturnType<typeof useNotifications> {
+  return {
+    notifications,
+    unreadNotifications: [],
+    count: notifications.length,
+    unreadCount: 0,
+    isLoading: false,
+    isLoadingMore: false,
+    hasMore,
+    error: null,
+    loadMore,
+    refresh: vi.fn(),
+    markAllAsRead: vi.fn(),
+    isNotificationUnread: vi.fn(() => false),
+  };
+}
+
+describe('NotificationsContainer - grouping', () => {
+  beforeEach(() => {
+    authStoreState.session = {};
+  });
+
+  it('collapses consecutive deletions by the same actor into one row', () => {
+    const deletion = (timestamp: number): FlatNotification => ({
+      id: `post_deleted:${timestamp}:alice`,
+      type: NotificationType.PostDeleted,
+      timestamp,
+      delete_source: PostChangedSource.Reply,
+      deleted_by: 'alice',
+      deleted_uri: `pubky://alice/pub/pubky.app/posts/deleted-${timestamp}`,
+      linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
+    });
+
+    vi.mocked(useNotifications).mockReturnValue(
+      buildNotificationsResult({ notifications: [deletion(3000), deletion(2000), deletion(1000)] }),
+    );
+
+    render(<NotificationsContainer />);
+
+    // The mocked list renders its entry count, so three notifications becoming one row
+    // proves the container grouped them before handing them over.
+    expect(screen.getByTestId('notifications-list')).toHaveTextContent('1 notifications');
+  });
+});
+
+describe('NotificationsContainer - auto-load guard', () => {
+  // Grouping can collapse a page into a handful of rows, leaving the sentinel on screen
+  // and re-triggering loads. The budget lives in useInfiniteScroll (tested there); these
+  // tests pin the container's wiring: the options it passes and the stall button.
+  const loadMore = vi.fn();
+
+  const followNotification = (actor: string): FlatNotification => ({
+    id: `follow:${actor}`,
+    type: NotificationType.Follow,
+    timestamp: Date.now(),
+    followed_by: actor,
+  });
+
+  /** The button carries a Cypress hook, not a testing-library one. */
+  const loadMoreButton = () => document.querySelector<HTMLButtonElement>('[data-cy="notifications-load-more"]');
+
+  const mockShortList = (hasMore = true) =>
+    vi
+      .mocked(useNotifications)
+      .mockReturnValue(buildNotificationsResult({ notifications: [followNotification('user1')], loadMore, hasMore }));
+
+  beforeEach(() => {
+    authStoreState.session = {};
+    loadMore.mockClear();
+    mockResumeAutoLoad.mockClear();
+    infiniteScrollState.isStalled = false;
+    infiniteScrollOptions.current = null;
+    mockShortList();
+  });
+
+  it('hands the sentinel the rendered row count and the unproductive-load budget', () => {
+    render(<NotificationsContainer />);
+
+    expect(infiniteScrollOptions.current).toMatchObject({
+      hasMore: true,
+      isLoading: false,
+      itemCount: 1,
+      maxUnproductiveLoads: 3,
+    });
+    // loadMore goes through unwrapped — the hook owns the budget accounting.
+    expect(infiniteScrollOptions.current?.onLoadMore).toBe(loadMore);
+  });
+
+  it('reports rendered rows, not raw notifications, as the productivity signal', () => {
+    const deletion = (timestamp: number): FlatNotification => ({
+      id: `post_deleted:${timestamp}:alice`,
+      type: NotificationType.PostDeleted,
+      timestamp,
+      delete_source: PostChangedSource.Reply,
+      deleted_by: 'alice',
+      deleted_uri: `pubky://alice/pub/pubky.app/posts/deleted-${timestamp}`,
+      linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
+    });
+    vi.mocked(useNotifications).mockReturnValue(
+      buildNotificationsResult({ notifications: [deletion(3000), deletion(2000), deletion(1000)], loadMore }),
+    );
+
+    render(<NotificationsContainer />);
+
+    // Three notifications grouped into one row must count as one item.
+    expect(infiniteScrollOptions.current?.itemCount).toBe(1);
+  });
+
+  it('offers the manual button while auto-loading is stalled', () => {
+    infiniteScrollState.isStalled = true;
+
+    render(<NotificationsContainer />);
+
+    expect(loadMoreButton()).toBeInTheDocument();
+  });
+
+  it('hides the manual button while auto-loading is running normally', () => {
+    render(<NotificationsContainer />);
+
+    expect(loadMoreButton()).toBeNull();
+  });
+
+  it('resumes auto-loading when the user asks for more', async () => {
+    infiniteScrollState.isStalled = true;
+
+    render(<NotificationsContainer />);
+    await userEvent.click(loadMoreButton()!);
+
+    expect(mockResumeAutoLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('never offers the manual button once there is nothing left to load', () => {
+    infiniteScrollState.isStalled = true;
+    mockShortList(false);
+
+    render(<NotificationsContainer />);
+
+    expect(loadMoreButton()).toBeNull();
   });
 });

--- a/src/components/organisms/NotificationsContainer/NotificationsContainer.test.tsx.snap
+++ b/src/components/organisms/NotificationsContainer/NotificationsContainer.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`NotificationsContainer > matches snapshot 1`] = `
   </div>
   <div
     class="h-10"
+    data-cy="notifications-sentinel"
   />
 </div>
 `;

--- a/src/components/organisms/NotificationsContainer/NotificationsContainer.tsx
+++ b/src/components/organisms/NotificationsContainer/NotificationsContainer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { Button, ButtonVariant } from '@/atoms/Button/Button';
 import { Container } from '@/atoms/Container/Container';
 import { Heading } from '@/atoms/Heading/Heading';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll';
@@ -8,7 +9,11 @@ import { useNotifications } from '@/hooks/useNotifications/useNotifications';
 import { NotificationsEmpty } from '@/molecules/NotificationsEmpty/NotificationsEmpty';
 import { useAuthStore } from '@/stores/auth/auth.store';
 import { NotificationsList } from '../NotificationsList/NotificationsList';
+import { groupNotifications } from '../NotificationsList/NotificationsList.utils';
 import { NotificationsContainerSkeleton, NotificationsLoadMoreSkeleton } from './NotificationsContainer.skeleton';
+
+/** Consecutive automatic loads allowed without the rendered list getting any longer. */
+const MAX_UNPRODUCTIVE_AUTO_LOADS = 3;
 
 /**
  * Organism that handles all notification business logic:
@@ -18,14 +23,31 @@ import { NotificationsContainerSkeleton, NotificationsLoadMoreSkeleton } from '.
  * - Loading/error/empty states
  */
 export function NotificationsContainer() {
-  const { notifications, unreadNotifications, isLoading, isLoadingMore, hasMore, error, loadMore, markAllAsRead } =
-    useNotifications();
+  const {
+    notifications,
+    unreadNotifications,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    markAllAsRead,
+  } = useNotifications();
 
-  // Infinite scroll sentinel
-  const { sentinelRef } = useInfiniteScroll({
+  const entries = groupNotifications(notifications);
+
+  // Grouping collapses many notifications into few rows, so a page can leave the scroll
+  // sentinel on screen and immediately trigger the next one. A page that merges entirely
+  // into existing groups adds no rows at all, which would loop to the end of the user's
+  // history. The hook budgets the loads that fail to make the list longer, then hands
+  // the decision back to the user via the manual button below.
+  const { sentinelRef, isStalled, resumeAutoLoad } = useInfiniteScroll({
     onLoadMore: loadMore,
     hasMore,
     isLoading: isLoadingMore,
+    itemCount: entries.length,
+    maxUnproductiveLoads: MAX_UNPRODUCTIVE_AUTO_LOADS,
   });
 
   // Re-run once the session is restored, since the write needs an authenticated session.
@@ -42,11 +64,15 @@ export function NotificationsContainer() {
     return <NotificationsContainerSkeleton />;
   }
 
-  // Error state
-  if (error) {
+  // A failure with nothing loaded yet is a dead end, so it owns the page. A failure
+  // with rows on screen must not throw them away — it renders inline below the list.
+  if (error && notifications.length === 0) {
     return (
       <Container overrideDefaults={true} className="flex flex-col items-center justify-center gap-4 py-12">
         <p className="text-muted-foreground">{error}</p>
+        <Button variant={ButtonVariant.SECONDARY} type="button" onClick={refresh} data-cy="notifications-retry">
+          {'Try again'}
+        </Button>
       </Container>
     );
   }
@@ -61,12 +87,36 @@ export function NotificationsContainer() {
       <Heading level={5} size="lg" className="leading-normal font-light text-muted-foreground lg:hidden">
         Notifications {unreadNotifications.length > 0 && `(${unreadNotifications.length})`}
       </Heading>
-      <NotificationsList notifications={notifications} unreadNotifications={unreadNotifications} />
+      <NotificationsList entries={entries} unreadNotifications={unreadNotifications} />
 
-      {/* Infinite scroll sentinel - triggers loadMore when visible */}
-      <div ref={sentinelRef} className="h-10" />
+      {/* Infinite scroll sentinel - triggers loadMore when visible. Unmounted while an
+          error shows so the observer cannot loop retries against a failing network;
+          recovery goes through the Try again button instead. */}
+      {!error && <div ref={sentinelRef} className="h-10" data-cy="notifications-sentinel" />}
+
+      {error && (
+        <Container overrideDefaults={true} className="flex flex-col items-center gap-2 py-4">
+          <p className="text-muted-foreground">{error}</p>
+          <Button variant={ButtonVariant.SECONDARY} type="button" onClick={refresh} data-cy="notifications-retry">
+            {'Try again'}
+          </Button>
+        </Container>
+      )}
 
       {isLoadingMore && <NotificationsLoadMoreSkeleton />}
+
+      {hasMore && isStalled && !isLoadingMore && (
+        <Container overrideDefaults={true} className="flex justify-center py-2">
+          <Button
+            variant={ButtonVariant.SECONDARY}
+            type="button"
+            onClick={resumeAutoLoad}
+            data-cy="notifications-load-more"
+          >
+            {'Load more'}
+          </Button>
+        </Container>
+      )}
     </>
   );
 }

--- a/src/components/organisms/NotificationsList/NotificationsList.test.tsx
+++ b/src/components/organisms/NotificationsList/NotificationsList.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type FlatNotification, NotificationType } from '@/models/notification/notification.types';
+import { type FlatNotification, NotificationType, PostChangedSource } from '@/models/notification/notification.types';
 import { NotificationsList } from './NotificationsList';
+import type { GroupableNotification, NotificationListEntry } from './NotificationsList.types';
 
 const mockUseIsMobile = vi.hoisted(() => vi.fn(() => false));
 
@@ -11,9 +12,44 @@ vi.mock('@/hooks/useIsMobile/useIsMobile', () => ({
 
 // Mock NotificationItem
 vi.mock('@/organisms/NotificationItem/NotificationItem', () => ({
-  NotificationItem: ({ notification, isMobile }: { notification: FlatNotification; isMobile: boolean }) => (
-    <div data-testid="notification-item" data-type={notification.type} data-mobile={isMobile ? 'true' : undefined}>
+  NotificationItem: ({
+    notification,
+    isUnread,
+    isMobile,
+  }: {
+    notification: FlatNotification;
+    isUnread: boolean;
+    isMobile: boolean;
+  }) => (
+    <div
+      data-testid="notification-item"
+      data-type={notification.type}
+      data-unread={isUnread ? 'true' : 'false'}
+      data-mobile={isMobile ? 'true' : undefined}
+    >
       {notification.type}
+    </div>
+  ),
+}));
+
+vi.mock('@/organisms/NotificationGroupItem/NotificationGroupItem', () => ({
+  NotificationGroupItem: ({
+    notifications,
+    isUnread,
+    isMobile,
+  }: {
+    notifications: GroupableNotification[];
+    isUnread: boolean;
+    isMobile: boolean;
+  }) => (
+    <div
+      data-testid="notification-group-item"
+      data-type={notifications[0].type}
+      data-count={notifications.length}
+      data-unread={isUnread ? 'true' : 'false'}
+      data-mobile={isMobile ? 'true' : undefined}
+    >
+      {notifications[0].type}
     </div>
   ),
 }));
@@ -27,6 +63,20 @@ vi.mock('@/atoms/Container/Container', () => {
       </div>
     ),
   };
+});
+
+const toSingle = (notification: FlatNotification): NotificationListEntry => ({ kind: 'single', notification });
+
+const toGroup = (notifications: GroupableNotification[]): NotificationListEntry => ({ kind: 'group', notifications });
+
+const deletedBy = (deleter: string, timestamp: number): GroupableNotification => ({
+  id: `post_deleted:${timestamp}:${deleter}`,
+  type: NotificationType.PostDeleted,
+  timestamp,
+  delete_source: PostChangedSource.Reply,
+  deleted_by: deleter,
+  deleted_uri: `pubky://${deleter}/pub/pubky.app/posts/deleted-${timestamp}`,
+  linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
 });
 
 beforeEach(() => {
@@ -60,20 +110,22 @@ describe('NotificationsList', () => {
     } as FlatNotification,
   ];
 
+  const mockEntries = mockNotifications.map(toSingle);
+
   it('renders list of notifications', () => {
-    render(<NotificationsList notifications={mockNotifications} unreadNotifications={[]} />);
+    render(<NotificationsList entries={mockEntries} unreadNotifications={[]} />);
     const items = screen.getAllByTestId('notification-item');
     expect(items).toHaveLength(3);
   });
 
   it('renders empty list when no notifications', () => {
-    render(<NotificationsList notifications={[]} unreadNotifications={[]} />);
+    render(<NotificationsList entries={[]} unreadNotifications={[]} />);
     const items = screen.queryAllByTestId('notification-item');
     expect(items).toHaveLength(0);
   });
 
   it('renders notifications in correct order', () => {
-    render(<NotificationsList notifications={mockNotifications} unreadNotifications={[]} />);
+    render(<NotificationsList entries={mockEntries} unreadNotifications={[]} />);
     const items = screen.getAllByTestId('notification-item');
     expect(items[0]).toHaveAttribute('data-type', NotificationType.Follow);
     expect(items[1]).toHaveAttribute('data-type', NotificationType.Reply);
@@ -83,10 +135,58 @@ describe('NotificationsList', () => {
   it('detects the viewport once and shares the result with every notification', () => {
     mockUseIsMobile.mockReturnValue(true);
 
-    render(<NotificationsList notifications={mockNotifications} unreadNotifications={[]} />);
+    render(<NotificationsList entries={mockEntries} unreadNotifications={[]} />);
 
     expect(mockUseIsMobile).toHaveBeenCalledTimes(1);
     expect(screen.getAllByTestId('notification-item').every((item) => item.dataset.mobile === 'true')).toBe(true);
+  });
+
+  it('renders a group entry as a single grouped row', () => {
+    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+
+    render(<NotificationsList entries={[toGroup(grouped)]} unreadNotifications={[]} />);
+
+    expect(screen.getAllByTestId('notification-group-item')).toHaveLength(1);
+    expect(screen.queryAllByTestId('notification-item')).toHaveLength(0);
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-count', '2');
+  });
+
+  it('interleaves grouped and single rows in entry order', () => {
+    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+    const entries = [toGroup(grouped), toSingle(mockNotifications[0])];
+
+    const { container } = render(<NotificationsList entries={entries} unreadNotifications={[]} />);
+
+    const rendered = container.querySelectorAll(
+      '[data-testid="notification-group-item"], [data-testid="notification-item"]',
+    );
+    expect(rendered[0]).toHaveAttribute('data-testid', 'notification-group-item');
+    expect(rendered[1]).toHaveAttribute('data-testid', 'notification-item');
+  });
+
+  it('marks a single row unread when its notification is unread', () => {
+    render(<NotificationsList entries={mockEntries} unreadNotifications={[mockNotifications[0]]} />);
+
+    const items = screen.getAllByTestId('notification-item');
+    expect(items[0]).toHaveAttribute('data-unread', 'true');
+    expect(items[1]).toHaveAttribute('data-unread', 'false');
+  });
+
+  it('marks a group unread when only a trailing member is unread', () => {
+    const newest = deletedBy('deleter', 3000);
+    const oldest = deletedBy('deleter', 2000);
+
+    render(<NotificationsList entries={[toGroup([newest, oldest])]} unreadNotifications={[oldest]} />);
+
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-unread', 'true');
+  });
+
+  it('marks a group read when none of its members are unread', () => {
+    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+
+    render(<NotificationsList entries={[toGroup(grouped)]} unreadNotifications={[]} />);
+
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-unread', 'false');
   });
 });
 
@@ -108,12 +208,34 @@ describe('NotificationsList - Snapshots', () => {
         reply_uri: 'user2:reply456',
       } as FlatNotification,
     ];
-    const { container } = render(<NotificationsList notifications={notifications} unreadNotifications={[]} />);
+    const { container } = render(<NotificationsList entries={notifications.map(toSingle)} unreadNotifications={[]} />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('matches snapshot with empty list', () => {
-    const { container } = render(<NotificationsList notifications={[]} unreadNotifications={[]} />);
+    const { container } = render(<NotificationsList entries={[]} unreadNotifications={[]} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('NotificationsList - Mobile Snapshots', () => {
+  beforeEach(() => {
+    mockUseIsMobile.mockReturnValue(true);
+  });
+
+  it('matches snapshot with a group and a single on mobile viewport', () => {
+    const single: FlatNotification = {
+      id: 'follow:123:user1',
+      type: NotificationType.Follow,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      followed_by: 'user1',
+    } as FlatNotification;
+    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+
+    const { container } = render(
+      <NotificationsList entries={[toGroup(grouped), toSingle(single)]} unreadNotifications={[]} />,
+    );
+
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/NotificationsList/NotificationsList.test.tsx
+++ b/src/components/organisms/NotificationsList/NotificationsList.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type FlatNotification, NotificationType, PostChangedSource } from '@/models/notification/notification.types';
+import { resetViewport, setMobileViewport } from '@/test-utils/viewport';
 import { NotificationsList } from './NotificationsList';
 import type { GroupableNotification, NotificationListEntry } from './NotificationsList.types';
 
@@ -37,10 +39,14 @@ vi.mock('@/organisms/NotificationGroupItem/NotificationGroupItem', () => ({
     notifications,
     isUnread,
     isMobile,
+    isExpanded,
+    onExpandedChange,
   }: {
     notifications: GroupableNotification[];
     isUnread: boolean;
     isMobile: boolean;
+    isExpanded?: boolean;
+    onExpandedChange?: (expanded: boolean) => void;
   }) => (
     <div
       data-testid="notification-group-item"
@@ -48,7 +54,11 @@ vi.mock('@/organisms/NotificationGroupItem/NotificationGroupItem', () => ({
       data-count={notifications.length}
       data-unread={isUnread ? 'true' : 'false'}
       data-mobile={isMobile ? 'true' : undefined}
+      data-expanded={isExpanded ? 'true' : 'false'}
     >
+      <button type="button" onClick={() => onExpandedChange?.(!isExpanded)}>
+        toggle
+      </button>
       {notifications[0].type}
     </div>
   ),
@@ -181,6 +191,34 @@ describe('NotificationsList', () => {
     expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-unread', 'true');
   });
 
+  it('keeps a group expanded when its members change and the row remounts', async () => {
+    const newest = deletedBy('deleter', 4000);
+    const middle = deletedBy('deleter', 3000);
+    const oldest = deletedBy('deleter', 2000);
+
+    const { rerender } = render(<NotificationsList entries={[toGroup([middle, oldest])]} unreadNotifications={[]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-expanded', 'true');
+
+    // A refresh prepends a newer member, which changes the row's key and remounts it;
+    // the disclosure state lives here, so the group the user is reading stays open.
+    rerender(<NotificationsList entries={[toGroup([newest, middle, oldest])]} unreadNotifications={[]} />);
+
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('collapses a group again once the row reports it closed', async () => {
+    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+
+    render(<NotificationsList entries={[toGroup(grouped)]} unreadNotifications={[]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    await userEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    expect(screen.getByTestId('notification-group-item')).toHaveAttribute('data-expanded', 'false');
+  });
+
   it('marks a group read when none of its members are unread', () => {
     const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
 
@@ -190,25 +228,31 @@ describe('NotificationsList', () => {
   });
 });
 
+/** Shared by the desktop and mobile snapshots, which must render the same input. */
+const renderSnapshotList = () => {
+  const notifications: FlatNotification[] = [
+    {
+      id: 'follow:123:user1',
+      type: NotificationType.Follow,
+      timestamp: Date.now() - 1000 * 60 * 30,
+      followed_by: 'user1',
+    } as FlatNotification,
+    {
+      id: 'reply:123:user2',
+      type: NotificationType.Reply,
+      timestamp: Date.now() - 1000 * 60 * 60,
+      replied_by: 'user2',
+      parent_post_uri: 'user1:post123',
+      reply_uri: 'user2:reply456',
+    } as FlatNotification,
+  ];
+
+  return render(<NotificationsList entries={notifications.map(toSingle)} unreadNotifications={[]} />);
+};
+
 describe('NotificationsList - Snapshots', () => {
   it('matches snapshot with notifications', () => {
-    const notifications: FlatNotification[] = [
-      {
-        id: 'follow:123:user1',
-        type: NotificationType.Follow,
-        timestamp: Date.now() - 1000 * 60 * 30,
-        followed_by: 'user1',
-      } as FlatNotification,
-      {
-        id: 'reply:123:user2',
-        type: NotificationType.Reply,
-        timestamp: Date.now() - 1000 * 60 * 60,
-        replied_by: 'user2',
-        parent_post_uri: 'user1:post123',
-        reply_uri: 'user2:reply456',
-      } as FlatNotification,
-    ];
-    const { container } = render(<NotificationsList entries={notifications.map(toSingle)} unreadNotifications={[]} />);
+    const { container } = renderSnapshotList();
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -220,22 +264,16 @@ describe('NotificationsList - Snapshots', () => {
 
 describe('NotificationsList - Mobile Snapshots', () => {
   beforeEach(() => {
+    setMobileViewport();
     mockUseIsMobile.mockReturnValue(true);
   });
 
-  it('matches snapshot with a group and a single on mobile viewport', () => {
-    const single: FlatNotification = {
-      id: 'follow:123:user1',
-      type: NotificationType.Follow,
-      timestamp: Date.now() - 1000 * 60 * 30,
-      followed_by: 'user1',
-    } as FlatNotification;
-    const grouped = [deletedBy('deleter', 3000), deletedBy('deleter', 2000)];
+  afterEach(() => {
+    resetViewport();
+  });
 
-    const { container } = render(
-      <NotificationsList entries={[toGroup(grouped), toSingle(single)]} unreadNotifications={[]} />,
-    );
-
+  it('matches snapshot on mobile viewport', () => {
+    const { container } = renderSnapshotList();
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
+++ b/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
@@ -1,5 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`NotificationsList - Mobile Snapshots > matches snapshot with a group and a single on mobile viewport 1`] = `
+<div
+  class="gap-3 rounded-md bg-card p-6"
+  data-testid="container"
+>
+  <div
+    data-count="2"
+    data-mobile="true"
+    data-testid="notification-group-item"
+    data-type="post_deleted"
+    data-unread="false"
+  >
+    post_deleted
+  </div>
+  <div
+    data-mobile="true"
+    data-testid="notification-item"
+    data-type="follow"
+    data-unread="false"
+  >
+    follow
+  </div>
+</div>
+`;
+
 exports[`NotificationsList - Snapshots > matches snapshot with empty list 1`] = `
 <div
   class="gap-3 rounded-md bg-card p-6"
@@ -15,12 +40,14 @@ exports[`NotificationsList - Snapshots > matches snapshot with notifications 1`]
   <div
     data-testid="notification-item"
     data-type="follow"
+    data-unread="false"
   >
     follow
   </div>
   <div
     data-testid="notification-item"
     data-type="reply"
+    data-unread="false"
   >
     reply
   </div>

--- a/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
+++ b/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
@@ -24,31 +24,6 @@ exports[`NotificationsList - Mobile Snapshots > matches snapshot on mobile viewp
 </div>
 `;
 
-exports[`NotificationsList - Mobile Snapshots > matches snapshot with a group and a single on mobile viewport 1`] = `
-<div
-  class="gap-3 rounded-md bg-card p-6"
-  data-testid="container"
->
-  <div
-    data-count="2"
-    data-mobile="true"
-    data-testid="notification-group-item"
-    data-type="post_deleted"
-    data-unread="false"
-  >
-    post_deleted
-  </div>
-  <div
-    data-mobile="true"
-    data-testid="notification-item"
-    data-type="follow"
-    data-unread="false"
-  >
-    follow
-  </div>
-</div>
-`;
-
 exports[`NotificationsList - Snapshots > matches snapshot with empty list 1`] = `
 <div
   class="gap-3 rounded-md bg-card p-6"

--- a/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
+++ b/src/components/organisms/NotificationsList/NotificationsList.test.tsx.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`NotificationsList - Mobile Snapshots > matches snapshot on mobile viewport 1`] = `
+<div
+  class="gap-3 rounded-md bg-card p-6"
+  data-testid="container"
+>
+  <div
+    data-mobile="true"
+    data-testid="notification-item"
+    data-type="follow"
+    data-unread="false"
+  >
+    follow
+  </div>
+  <div
+    data-mobile="true"
+    data-testid="notification-item"
+    data-type="reply"
+    data-unread="false"
+  >
+    reply
+  </div>
+</div>
+`;
+
 exports[`NotificationsList - Mobile Snapshots > matches snapshot with a group and a single on mobile viewport 1`] = `
 <div
   class="gap-3 rounded-md bg-card p-6"

--- a/src/components/organisms/NotificationsList/NotificationsList.tsx
+++ b/src/components/organisms/NotificationsList/NotificationsList.tsx
@@ -1,31 +1,48 @@
 'use client';
 
-import { useMemo } from 'react';
 import { Container } from '@/atoms/Container/Container';
 import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
 import { getBusinessKey } from '@/models/notification/notification.helpers';
+import { NotificationGroupItem } from '../NotificationGroupItem/NotificationGroupItem';
 import { NotificationItem } from '../NotificationItem/NotificationItem';
 import type { NotificationsListProps } from './NotificationsList.types';
 
-export function NotificationsList({ notifications, unreadNotifications }: NotificationsListProps) {
+export function NotificationsList({ entries, unreadNotifications }: NotificationsListProps) {
   const isMobile = useIsMobile();
 
-  // Create a Set of unread notification business keys for O(1) lookup
-  // Early return optimization for empty unread list
-  const unreadKeys = useMemo(() => {
-    if (unreadNotifications.length === 0) return new Set<string>();
-    return new Set(unreadNotifications.map(getBusinessKey));
-  }, [unreadNotifications]);
+  // Set of unread notification business keys for O(1) lookup
+  const unreadKeys = new Set(unreadNotifications.map(getBusinessKey));
 
   return (
     <Container data-cy="notifications-list" className="gap-3 rounded-md bg-card p-6">
-      {notifications.map((notification) => {
-        // Use business key for unread lookup (to match unreadNotifications)
-        const businessKey = getBusinessKey(notification);
-        const isUnread = unreadKeys.has(businessKey);
+      {entries.map((entry) => {
+        if (entry.kind === 'group') {
+          // A group is unread while any of its collapsed members still is.
+          const isUnread = entry.notifications.some((notification) => unreadKeys.has(getBusinessKey(notification)));
+
+          return (
+            <NotificationGroupItem
+              // Keyed on the oldest member: a poll refresh prepends newer members to the
+              // run the user may be reading (the head moves), while pagination extends
+              // only the off-screen frontier run at its tail — so the tail is the stabler
+              // identity. The prefix keeps group and single keys from ever colliding.
+              key={`group:${getBusinessKey(entry.notifications[entry.notifications.length - 1])}`}
+              notifications={entry.notifications}
+              isUnread={isUnread}
+              isMobile={isMobile}
+            />
+          );
+        }
+
+        const businessKey = getBusinessKey(entry.notification);
 
         return (
-          <NotificationItem key={businessKey} notification={notification} isUnread={isUnread} isMobile={isMobile} />
+          <NotificationItem
+            key={businessKey}
+            notification={entry.notification}
+            isUnread={unreadKeys.has(businessKey)}
+            isMobile={isMobile}
+          />
         );
       })}
     </Container>

--- a/src/components/organisms/NotificationsList/NotificationsList.tsx
+++ b/src/components/organisms/NotificationsList/NotificationsList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Container } from '@/atoms/Container/Container';
 import { useIsMobile } from '@/hooks/useIsMobile/useIsMobile';
 import { getBusinessKey } from '@/models/notification/notification.helpers';
@@ -10,6 +11,11 @@ import type { NotificationsListProps } from './NotificationsList.types';
 export function NotificationsList({ entries, unreadNotifications }: NotificationsListProps) {
   const isMobile = useIsMobile();
 
+  // Which groups are expanded, tracked by their members rather than by row identity: a
+  // run gains members as pages load and refreshes arrive, so any single member can stop
+  // being the row's key — but the run stays the same run as long as one member matches.
+  const [expandedMemberKeys, setExpandedMemberKeys] = useState<ReadonlySet<string>>(() => new Set());
+
   // Set of unread notification business keys for O(1) lookup
   const unreadKeys = new Set(unreadNotifications.map(getBusinessKey));
 
@@ -17,19 +23,33 @@ export function NotificationsList({ entries, unreadNotifications }: Notification
     <Container data-cy="notifications-list" className="gap-3 rounded-md bg-card p-6">
       {entries.map((entry) => {
         if (entry.kind === 'group') {
+          const memberKeys = entry.notifications.map(getBusinessKey);
           // A group is unread while any of its collapsed members still is.
-          const isUnread = entry.notifications.some((notification) => unreadKeys.has(getBusinessKey(notification)));
+          const isUnread = memberKeys.some((key) => unreadKeys.has(key));
+          const isExpanded = memberKeys.some((key) => expandedMemberKeys.has(key));
+
+          const handleExpandedChange = (expanded: boolean) =>
+            setExpandedMemberKeys((previous) => {
+              const next = new Set(previous);
+              for (const key of memberKeys) {
+                if (expanded) next.add(key);
+                else next.delete(key);
+              }
+              return next;
+            });
 
           return (
             <NotificationGroupItem
-              // Keyed on the oldest member: a poll refresh prepends newer members to the
-              // run the user may be reading (the head moves), while pagination extends
-              // only the off-screen frontier run at its tail — so the tail is the stabler
-              // identity. The prefix keeps group and single keys from ever colliding.
-              key={`group:${getBusinessKey(entry.notifications[entry.notifications.length - 1])}`}
+              // Keyed on the head because pagination appends older notifications, so a
+              // growing run grows at its tail and the head stays put. The prefix keeps
+              // group and single keys from ever colliding. A remount is survivable
+              // either way: the disclosure state lives here, not in the row.
+              key={`group:${memberKeys[0]}`}
               notifications={entry.notifications}
               isUnread={isUnread}
               isMobile={isMobile}
+              isExpanded={isExpanded}
+              onExpandedChange={handleExpandedChange}
             />
           );
         }

--- a/src/components/organisms/NotificationsList/NotificationsList.types.ts
+++ b/src/components/organisms/NotificationsList/NotificationsList.types.ts
@@ -1,16 +1,22 @@
-import type { FlatNotification } from '@/models/notification/notification.types';
+import type { FlatNotification, NotificationType } from '@/models/notification/notification.types';
+
+/** Notification types whose repeats collapse into a grouped row. */
+export type GroupableNotificationType = NotificationType.PostDeleted | NotificationType.PostEdited;
+
+export type GroupableNotification = Extract<FlatNotification, { type: GroupableNotificationType }>;
 
 /**
- * Props for the NotificationsList component
+ * One rendered row: either a lone notification or a run of consecutive ones that share a
+ * type, an actor and a post kind. Grouped runs hold at least MIN_NOTIFICATION_GROUP_SIZE
+ * members, newest first (mirroring the source order).
  */
-export interface NotificationsListProps {
-  /**
-   * Array of all notifications to display
-   */
-  notifications: FlatNotification[];
+export type NotificationListEntry =
+  | { kind: 'single'; notification: FlatNotification }
+  | { kind: 'group'; notifications: GroupableNotification[] };
 
-  /**
-   * Array of unread notifications (used to determine which notifications should show the unread badge)
-   */
+export interface NotificationsListProps {
+  /** Rows to display, already grouped by `groupNotifications`. */
+  entries: NotificationListEntry[];
+  /** Used to decide which rows show the unread badge. */
   unreadNotifications: FlatNotification[];
 }

--- a/src/components/organisms/NotificationsList/NotificationsList.utils.test.ts
+++ b/src/components/organisms/NotificationsList/NotificationsList.utils.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import { type FlatNotification, NotificationType, PostChangedSource } from '@/models/notification/notification.types';
+import { getNotificationKindBucket } from '@/organisms/NotificationItem/NotificationItem.utils';
+import type { GroupableNotification } from './NotificationsList.types';
+import { groupNotifications } from './NotificationsList.utils';
+
+let nextTimestamp = 100_000;
+
+/** Timestamps only need to be distinct; grouping never reads them. */
+const uniqueTimestamp = () => (nextTimestamp -= 1000);
+
+function deleted(actor: string, postKind?: string, deletedUri?: string): GroupableNotification {
+  const timestamp = uniqueTimestamp();
+  return {
+    id: `post_deleted:${timestamp}:${actor}`,
+    type: NotificationType.PostDeleted,
+    timestamp,
+    delete_source: PostChangedSource.Reply,
+    deleted_by: actor,
+    deleted_uri: deletedUri ?? `pubky://${actor}/pub/pubky.app/posts/deleted-${timestamp}`,
+    linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
+    post_kind: postKind,
+  };
+}
+
+function edited(actor: string, postKind?: string, editedUri?: string): GroupableNotification {
+  const timestamp = uniqueTimestamp();
+  return {
+    id: `post_edited:${timestamp}:${actor}`,
+    type: NotificationType.PostEdited,
+    timestamp,
+    edit_source: PostChangedSource.Reply,
+    edited_by: actor,
+    edited_uri: editedUri ?? `pubky://${actor}/pub/pubky.app/posts/edited-${timestamp}`,
+    linked_uri: `pubky://viewer/pub/pubky.app/posts/linked-${timestamp}`,
+    post_kind: postKind,
+  };
+}
+
+function follow(actor: string): FlatNotification {
+  const timestamp = uniqueTimestamp();
+  return {
+    id: `follow:${timestamp}:${actor}`,
+    type: NotificationType.Follow,
+    timestamp,
+    followed_by: actor,
+  };
+}
+
+function reply(actor: string): FlatNotification {
+  const timestamp = uniqueTimestamp();
+  return {
+    id: `reply:${timestamp}:${actor}`,
+    type: NotificationType.Reply,
+    timestamp,
+    replied_by: actor,
+    parent_post_uri: `pubky://viewer/pub/pubky.app/posts/parent-${timestamp}`,
+    reply_uri: `pubky://${actor}/pub/pubky.app/posts/reply-${timestamp}`,
+  };
+}
+
+/** Flattens entries back to their notifications, in render order. */
+const flatten = (entries: ReturnType<typeof groupNotifications>): FlatNotification[] =>
+  entries.flatMap((entry) => (entry.kind === 'group' ? entry.notifications : [entry.notification]));
+
+describe('groupNotifications', () => {
+  it('returns no entries for an empty list', () => {
+    expect(groupNotifications([])).toEqual([]);
+  });
+
+  it.each([2, 3, 8])('collapses a run of %i deletions into one group', (size) => {
+    const run = Array.from({ length: size }, () => deleted('deleter'));
+
+    const entries = groupNotifications(run);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe('group');
+    expect(entries[0].kind === 'group' && entries[0].notifications).toHaveLength(size);
+  });
+
+  it('leaves a lone deletion as a single with its unchanged business key', () => {
+    const only = deleted('deleter');
+
+    const entries = groupNotifications([only]);
+
+    expect(entries).toEqual([{ kind: 'single', notification: only }]);
+  });
+
+  it('never merges runs from different actors', () => {
+    const entries = groupNotifications([deleted('alice'), deleted('bob')]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(['single', 'single']);
+  });
+
+  it('never merges different post kinds, so the copy stays accurate', () => {
+    const entries = groupNotifications([
+      deleted('alice', 'short'),
+      deleted('alice', 'short'),
+      deleted('alice', 'collection'),
+      deleted('alice', 'collection'),
+    ]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind === 'group' && getNotificationKindBucket(entries[0].notifications[0])).toBe('post');
+    expect(entries[1].kind === 'group' && getNotificationKindBucket(entries[1].notifications[0])).toBe('collection');
+  });
+
+  it('splits a deleted run from an edited run by the same actor', () => {
+    const entries = groupNotifications([deleted('alice'), deleted('alice'), edited('alice'), edited('alice')]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind === 'group' && entries[0].notifications[0].type).toBe(NotificationType.PostDeleted);
+    expect(entries[1].kind === 'group' && entries[1].notifications[0].type).toBe(NotificationType.PostEdited);
+  });
+
+  it.each([
+    ['follow', follow],
+    ['reply', reply],
+  ])('never groups consecutive %s notifications from the same actor', (_label, build) => {
+    const entries = groupNotifications([build('alice'), build('alice'), build('alice')]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(['single', 'single', 'single']);
+  });
+
+  it('splits a run interrupted by an unrelated notification', () => {
+    const entries = groupNotifications([deleted('alice'), follow('bob'), deleted('alice'), deleted('alice')]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(['single', 'single', 'group']);
+  });
+
+  it('keeps a run split when interrupted mid-burst, preserving chronological order', () => {
+    const first = deleted('alice');
+    const second = deleted('alice');
+    const interruption = reply('bob');
+    const third = deleted('alice');
+    const fourth = deleted('alice');
+
+    const entries = groupNotifications([first, second, interruption, third, fourth]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(['group', 'single', 'group']);
+    expect(flatten(entries)).toEqual([first, second, interruption, third, fourth]);
+  });
+
+  it('preserves order and emits every notification exactly once when all posts are distinct', () => {
+    // Same-post repeats within a run are the one exception: they collapse to their
+    // newest occurrence (covered by the dedup tests below).
+    const input = [deleted('alice'), deleted('alice'), follow('bob'), edited('carol'), reply('dave'), deleted('alice')];
+
+    expect(flatten(groupNotifications(input))).toEqual(input);
+  });
+
+  it('keeps the group key stable when a later page extends the run', () => {
+    const pageOne = [follow('bob'), deleted('alice'), deleted('alice')];
+    const pageTwo = [deleted('alice'), deleted('alice'), deleted('alice')];
+
+    const beforePaging = groupNotifications(pageOne);
+    const afterPaging = groupNotifications([...pageOne, ...pageTwo]);
+
+    const groupBefore = beforePaging.find((entry) => entry.kind === 'group');
+    const groupAfter = afterPaging.find((entry) => entry.kind === 'group');
+
+    // The run only ever grows at its tail during pagination, so the head stays put and
+    // the oldest member (NotificationsList's row key) is appended, never moved.
+    expect(groupBefore?.kind === 'group' && groupBefore.notifications[0]).toBe(
+      groupAfter?.kind === 'group' && groupAfter.notifications[0],
+    );
+    expect(groupBefore?.kind === 'group' && groupBefore.notifications).toHaveLength(2);
+    expect(groupAfter?.kind === 'group' && groupAfter.notifications).toHaveLength(5);
+  });
+
+  it('promotes a trailing single to a group once the next page arrives', () => {
+    const pageOne = [follow('bob'), deleted('alice')];
+    const pageTwo = [deleted('alice')];
+
+    expect(groupNotifications(pageOne).map((entry) => entry.kind)).toEqual(['single', 'single']);
+    expect(groupNotifications([...pageOne, ...pageTwo]).map((entry) => entry.kind)).toEqual(['single', 'group']);
+  });
+
+  it('collapses repeated edits of the same post into its newest notification', () => {
+    const uri = 'pubky://alice/pub/pubky.app/posts/same-post';
+    const newest = edited('alice', undefined, uri);
+    const input = [newest, edited('alice', undefined, uri), edited('alice', undefined, uri)];
+
+    const entries = groupNotifications(input);
+
+    expect(entries).toEqual([{ kind: 'single', notification: newest }]);
+  });
+
+  it('keeps one notification per post when a run mixes repeats and distinct posts', () => {
+    const uri = 'pubky://alice/pub/pubky.app/posts/same-post';
+    const newestOfRepeated = edited('alice', undefined, uri);
+    const distinct = edited('alice');
+
+    const entries = groupNotifications([newestOfRepeated, distinct, edited('alice', undefined, uri)]);
+
+    expect(entries).toEqual([{ kind: 'group', notifications: [newestOfRepeated, distinct] }]);
+  });
+
+  it('collapses one deletion reported once per interaction into a single row', () => {
+    const uri = 'pubky://alice/pub/pubky.app/posts/gone-post';
+    const newest = deleted('alice', undefined, uri);
+
+    const entries = groupNotifications([newest, deleted('alice', undefined, uri)]);
+
+    expect(entries).toEqual([{ kind: 'single', notification: newest }]);
+  });
+
+  it('does not deduplicate the same post across separate runs', () => {
+    const uri = 'pubky://alice/pub/pubky.app/posts/same-post';
+
+    const entries = groupNotifications([
+      edited('alice', undefined, uri),
+      follow('bob'),
+      edited('alice', undefined, uri),
+    ]);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(['single', 'single', 'single']);
+  });
+
+  it('stays well-formed when the input is not sorted by timestamp', () => {
+    const older = deleted('alice');
+    const newer = deleted('alice');
+    // Deliberately ascending, the opposite of the list's usual newest-first order.
+    const input = [older, newer];
+
+    const entries = groupNotifications(input);
+
+    expect(entries).toHaveLength(1);
+    expect(flatten(entries)).toEqual(input);
+    // The head is whatever came first in the input; grouping never reorders.
+    expect(entries[0].kind === 'group' && entries[0].notifications[0]).toBe(older);
+  });
+});

--- a/src/components/organisms/NotificationsList/NotificationsList.utils.ts
+++ b/src/components/organisms/NotificationsList/NotificationsList.utils.ts
@@ -1,0 +1,82 @@
+import { type FlatNotification, NotificationType } from '@/models/notification/notification.types';
+import {
+  getNotificationKindBucket,
+  getUserIdFromNotification,
+} from '@/organisms/NotificationItem/NotificationItem.utils';
+import type { GroupableNotification, NotificationListEntry } from './NotificationsList.types';
+
+/** A run shorter than this renders as ungrouped NotificationItem rows. */
+const MIN_NOTIFICATION_GROUP_SIZE = 2;
+
+/** Deleted and edited notifications arrive one per affected post, so bursts flood the list. */
+function isGroupable(notification: FlatNotification): notification is GroupableNotification {
+  return notification.type === NotificationType.PostDeleted || notification.type === NotificationType.PostEdited;
+}
+
+/**
+ * Whether `notification` continues the run headed by `head`.
+ *
+ * Kept separate from the walk below so the rule can change — a time window, say — without
+ * touching the traversal.
+ */
+function continuesRun(head: GroupableNotification, notification: GroupableNotification): boolean {
+  return (
+    head.type === notification.type &&
+    getUserIdFromNotification(head) === getUserIdFromNotification(notification) &&
+    getNotificationKindBucket(head) === getNotificationKindBucket(notification)
+  );
+}
+
+/**
+ * URI of the post whose change the notification reports — the identity repeated
+ * notifications about the same post share.
+ */
+function getChangedPostUri(notification: GroupableNotification): string {
+  return notification.type === NotificationType.PostDeleted ? notification.deleted_uri : notification.edited_uri;
+}
+
+/**
+ * Collapses consecutive runs of deleted/edited notifications that share an actor and a
+ * post kind into single rows.
+ *
+ * Within a run, repeats about the same post (the same post edited several times, or one
+ * deletion reported once per interaction) keep only their newest occurrence, so the row
+ * count and the title list reflect distinct posts. Order is otherwise preserved, and runs
+ * shorter than MIN_NOTIFICATION_GROUP_SIZE come back as individual `single` entries.
+ */
+export function groupNotifications(notifications: FlatNotification[]): NotificationListEntry[] {
+  const entries: NotificationListEntry[] = [];
+  let run: GroupableNotification[] = [];
+  let runPostUris = new Set<string>();
+
+  const flush = () => {
+    if (run.length >= MIN_NOTIFICATION_GROUP_SIZE) {
+      entries.push({ kind: 'group', notifications: run });
+    } else {
+      entries.push(...run.map((notification) => ({ kind: 'single' as const, notification })));
+    }
+    run = [];
+    runPostUris = new Set();
+  };
+
+  for (const notification of notifications) {
+    if (!isGroupable(notification)) {
+      flush();
+      entries.push({ kind: 'single', notification });
+      continue;
+    }
+
+    if (run.length > 0 && !continuesRun(run[0], notification)) flush();
+
+    // The list is newest-first, so the occurrence already in the run is the newer one.
+    const postUri = getChangedPostUri(notification);
+    if (runPostUris.has(postUri)) continue;
+    runPostUris.add(postUri);
+
+    run.push(notification);
+  }
+
+  flush();
+
+  return entries;
+}

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ProfilePageHeader - Mobile Snapshots > matches snapshot on mobile viewp
       data-testid="container"
     >
       <h1
-        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-8 text-white sm:max-w-xl lg:max-w-full lg:text-6xl lg:leading-none"
+        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
         data-cy="profile-username-header"
         data-testid="typography"
       >
@@ -333,7 +333,7 @@ exports[`ProfilePageHeader - Snapshots > matches snapshot 1`] = `
       data-testid="container"
     >
       <h1
-        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-8 text-white sm:max-w-xl lg:max-w-full lg:text-6xl lg:leading-none"
+        class="font-bold max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
         data-cy="profile-username-header"
         data-testid="typography"
       >

--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -151,7 +151,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
             data-cy="profile-username-header"
             as="h1"
             size="lg"
-            className="max-width-profile-page-header w-full truncate text-2xl leading-8 text-white sm:max-w-xl lg:max-w-full lg:text-6xl lg:leading-none"
+            className="max-width-profile-page-header w-full truncate text-2xl leading-normal text-white sm:max-w-xl lg:max-w-full lg:text-6xl"
           >
             {name}
           </Typography>

--- a/src/components/organisms/ProfileReplies/RepliesWithParent.test.tsx
+++ b/src/components/organisms/ProfileReplies/RepliesWithParent.test.tsx
@@ -148,6 +148,8 @@ describe('RepliesWithParent', () => {
     // Mock useInfiniteScroll
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
 
     // Mock useLiveQuery

--- a/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
+++ b/src/components/organisms/Timeline/Feed/TimelineFeed/VisualTimelinePosts.test.tsx
@@ -281,6 +281,8 @@ describe('VisualTimelinePosts', () => {
     });
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
     mockUseVisualFeedTiles.mockReturnValue({
       rows: createRows(),
@@ -1204,6 +1206,8 @@ describe('VisualTimelinePosts - Snapshots', () => {
     mockUseIsTouchDevice.mockReturnValue(false);
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
     mockUseVisualFeedTiles.mockReturnValue({
       rows: createRows(),

--- a/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.test.tsx
+++ b/src/components/organisms/Timeline/Posts/GridPosts/GridPosts.test.tsx
@@ -119,6 +119,8 @@ describe('TimelineGridPosts', () => {
 
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
 
     // Mock useLiveQuery to return no replies by default
@@ -458,6 +460,8 @@ describe('TimelineGridPosts', () => {
     it('should render sentinel element for infinite scroll', async () => {
       mockUseInfiniteScroll.mockReturnValue({
         sentinelRef: vi.fn(),
+        isStalled: false,
+        resumeAutoLoad: vi.fn(),
       });
 
       const { container } = render(
@@ -522,6 +526,8 @@ describe('TimelineGridPosts - Snapshots', () => {
 
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
 
     // Mock useLiveQuery

--- a/src/components/organisms/Timeline/Posts/Posts.test.tsx
+++ b/src/components/organisms/Timeline/Posts/Posts.test.tsx
@@ -119,6 +119,8 @@ describe('TimelinePosts', () => {
 
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
 
     // Mock useLiveQuery to return no replies by default
@@ -563,6 +565,8 @@ describe('TimelinePosts', () => {
     it('should render sentinel element for infinite scroll', async () => {
       mockUseInfiniteScroll.mockReturnValue({
         sentinelRef: vi.fn(),
+        isStalled: false,
+        resumeAutoLoad: vi.fn(),
       });
 
       const { container } = render(
@@ -636,6 +640,8 @@ describe('TimelinePosts - Snapshots', () => {
 
     mockUseInfiniteScroll.mockReturnValue({
       sentinelRef: vi.fn(),
+      isStalled: false,
+      resumeAutoLoad: vi.fn(),
     });
 
     // Mock useLiveQuery

--- a/src/core/application/notification/notification.test.ts
+++ b/src/core/application/notification/notification.test.ts
@@ -652,6 +652,38 @@ describe('NotificationApplication.fetchMissingEntities', () => {
     expect(fetchPostsSpy).not.toHaveBeenCalled();
     expect(fetchUsersSpy).not.toHaveBeenCalled();
   });
+
+  it('refetches edited posts even on a cache hit, so rows never show pre-edit content', async () => {
+    // The cached copy predates the edit by definition — the notification is the proof —
+    // and the local-first read path never revalidates a cache hit on its own.
+    const notifications = [createNexus(1000)];
+    const editedFlat = {
+      id: 'post_edited:1000:author',
+      type: NotificationType.PostEdited,
+      timestamp: 1000,
+      edited_by: 'author',
+      edited_uri: 'pubky://author/pub/pubky.app/posts/edited-post',
+      linked_uri: 'pubky://viewer/pub/pubky.app/posts/linked-post',
+    } as FlatNotification;
+
+    vi.spyOn(NotificationNormalizer, 'toFlatNotification').mockReturnValue(editedFlat);
+    vi.spyOn(LocalNotificationService, 'parseNotifications').mockReturnValue({
+      relatedPostIds: ['author:edited-post'],
+      relatedUserIds: [],
+    });
+    // The edited post is already cached — nothing is "missing".
+    vi.spyOn(LocalStreamPostsService, 'getNotPersistedPostsInCache').mockResolvedValue([]);
+    vi.spyOn(LocalStreamUsersService, 'getNotPersistedUsersInCache').mockResolvedValue([]);
+    const fetchPostsSpy = vi.spyOn(PostStreamApplication, 'fetchMissingPostsFromNexus').mockResolvedValue(undefined);
+    vi.spyOn(UserStreamApplication, 'fetchMissingUsersFromNexus').mockResolvedValue(undefined);
+
+    await NotificationApplication.fetchMissingEntities({ notifications, viewerId });
+
+    expect(fetchPostsSpy).toHaveBeenCalledWith({
+      cacheMissPostIds: ['author:edited-post'],
+      viewerId,
+    });
+  });
 });
 
 describe('NotificationApplication.getAllFromCache', () => {

--- a/src/core/application/notification/notification.ts
+++ b/src/core/application/notification/notification.ts
@@ -13,7 +13,8 @@ import { PostStreamApplication } from '@/application/stream/posts/post';
 import { UserStreamApplication } from '@/application/stream/users/users';
 import { HttpMethod } from '@/libs/http/http.types';
 import { Logger } from '@/libs/logger/logger';
-import type { Pubky } from '@/models/models.types';
+import { CompositeIdDomain, type Pubky } from '@/models/models.types';
+import { buildCompositeIdFromPubkyUri } from '@/models/models.utils';
 import { type FlatNotification, NotificationType } from '@/models/notification/notification.types';
 import { NotificationNormalizer } from '@/pipes/notification/notification.normalizer';
 import { HomeserverService } from '@/services/homeserver/homeserver';
@@ -300,6 +301,10 @@ export class NotificationApplication {
   /**
    * Fetches posts and users referenced in notifications that are not yet persisted in cache.
    *
+   * Edited posts are refetched even on a cache hit: the notification itself proves the
+   * cached copy predates the edit, and the local-first read path never revalidates a
+   * cached post, so without this the notification row would render the pre-edit content.
+   *
    * @param notifications - Array of flat notifications to extract post and user references from
    */
   static async fetchMissingEntities({
@@ -313,9 +318,17 @@ export class NotificationApplication {
     const notPersistedPostIds = await LocalStreamPostsService.getNotPersistedPostsInCache(relatedPostIds);
     const notPersistedUserIds = await LocalStreamUsersService.getNotPersistedUsersInCache(relatedUserIds);
 
-    if (notPersistedPostIds.length > 0) {
+    const editedPostIds = flatNotifications.flatMap((n) =>
+      n.type === NotificationType.PostEdited
+        ? (buildCompositeIdFromPubkyUri({ uri: n.edited_uri, domain: CompositeIdDomain.POSTS }) ?? [])
+        : [],
+    );
+
+    const postIdsToFetch = [...new Set([...notPersistedPostIds, ...editedPostIds])];
+
+    if (postIdsToFetch.length > 0) {
       await PostStreamApplication.fetchMissingPostsFromNexus({
-        cacheMissPostIds: notPersistedPostIds,
+        cacheMissPostIds: postIdsToFetch,
         viewerId,
       });
     }

--- a/src/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
+++ b/src/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asOpaque } from '@/test-utils/type-assertions';
 import { useInfiniteScroll } from './useInfiniteScroll';
 
 // Mock IntersectionObserver
@@ -7,11 +8,14 @@ const mockObserve = vi.fn();
 const mockUnobserve = vi.fn();
 const mockDisconnect = vi.fn();
 
-const mockIntersectionObserver = vi.fn().mockImplementation(() => ({
-  observe: mockObserve,
-  unobserve: mockUnobserve,
-  disconnect: mockDisconnect,
-}));
+// A plain function so `new IntersectionObserver(...)` can construct it.
+const mockIntersectionObserver = vi.fn(function () {
+  return {
+    observe: mockObserve,
+    unobserve: mockUnobserve,
+    disconnect: mockDisconnect,
+  };
+});
 
 // Make it available globally
 Object.defineProperty(window, 'IntersectionObserver', {
@@ -115,5 +119,120 @@ describe('useInfiniteScroll', () => {
         }),
       );
     }).not.toThrow();
+  });
+});
+
+describe('useInfiniteScroll - unproductive-load budget', () => {
+  const DEBOUNCE_MS = 300;
+  let mockOnLoadMore: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockOnLoadMore = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Renders the hook with a mounted sentinel so the intersection observer is live. */
+  function renderWithSentinel(initialItemCount?: number, maxUnproductiveLoads?: number) {
+    const rendered = renderHook(
+      ({ itemCount }: { itemCount?: number }) =>
+        useInfiniteScroll({
+          onLoadMore: mockOnLoadMore,
+          hasMore: true,
+          isLoading: false,
+          debounceMs: DEBOUNCE_MS,
+          itemCount,
+          maxUnproductiveLoads,
+        }),
+      { initialProps: { itemCount: initialItemCount } },
+    );
+
+    act(() => rendered.result.current.sentinelRef(document.createElement('div')));
+
+    return rendered;
+  }
+
+  /** Fires the latest observer callback and lets the debounce elapse. */
+  const intersect = () => {
+    const observerCalls = asOpaque<Array<[(entries: Array<{ isIntersecting: boolean }>) => void]>>(
+      mockIntersectionObserver.mock.calls,
+    );
+    const observerCallback = observerCalls.at(-1)![0];
+    act(() => {
+      observerCallback([{ isIntersecting: true }]);
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+  };
+
+  it('stalls instead of loading once the consecutive unproductive loads exceed the budget', () => {
+    const { result } = renderWithSentinel(1, 3);
+
+    intersect();
+    intersect();
+    intersect();
+    expect(result.current.isStalled).toBe(false);
+
+    intersect();
+
+    // The fourth round is refused rather than paged.
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(3);
+    expect(result.current.isStalled).toBe(true);
+  });
+
+  it('refills the budget whenever a load actually grows the item count', () => {
+    const { result, rerender } = renderWithSentinel(1, 3);
+
+    // Six rounds — well past the cap — each one growing the list.
+    for (let round = 1; round <= 6; round += 1) {
+      intersect();
+      rerender({ itemCount: 1 + round });
+    }
+
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(6);
+    expect(result.current.isStalled).toBe(false);
+  });
+
+  it('resumeAutoLoad clears the stall and loads the next page immediately', () => {
+    const { result } = renderWithSentinel(1, 3);
+
+    for (let i = 0; i < 4; i += 1) intersect();
+    expect(result.current.isStalled).toBe(true);
+
+    act(() => result.current.resumeAutoLoad());
+
+    expect(result.current.isStalled).toBe(false);
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(4);
+  });
+
+  it('resets the budget and clears the stall when the list shrinks, as on a refresh', () => {
+    const { result, rerender } = renderWithSentinel(8, 3);
+
+    for (let i = 0; i < 4; i += 1) intersect();
+    expect(result.current.isStalled).toBe(true);
+
+    // A polling refresh replaces the accumulated pages with page one.
+    rerender({ itemCount: 2 });
+    expect(result.current.isStalled).toBe(false);
+
+    // The fresh, shorter list gets a full budget again: productive rounds keep loading.
+    for (let round = 1; round <= 4; round += 1) {
+      intersect();
+      rerender({ itemCount: 2 + round });
+    }
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(3 + 4);
+    expect(result.current.isStalled).toBe(false);
+  });
+
+  it('never stalls when no budget is configured', () => {
+    const { result } = renderWithSentinel(undefined, undefined);
+
+    for (let i = 0; i < 10; i += 1) intersect();
+
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(10);
+    expect(result.current.isStalled).toBe(false);
   });
 });

--- a/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
@@ -8,6 +8,19 @@ interface UseInfiniteScrollOptions {
   isLoading: boolean;
   threshold?: number; // Distance from bottom to trigger load (in pixels)
   debounceMs?: number; // Debounce time to prevent rapid calls
+  /**
+   * Current rendered item count. Together with `maxUnproductiveLoads`, enables the
+   * unproductive-load budget: consecutive automatic loads that fail to grow this count
+   * are budgeted, and when the budget runs out auto-loading stalls (`isStalled`) until
+   * the consumer calls `resumeAutoLoad` — typically from a manual "Load more" button.
+   *
+   * Needed when items collapse or filter after fetching (grouping, muting): a page that
+   * merges entirely into existing rows keeps the sentinel on screen and would otherwise
+   * chain loads to the end of the stream.
+   */
+  itemCount?: number;
+  /** Consecutive automatic loads allowed without `itemCount` growing. */
+  maxUnproductiveLoads?: number;
 }
 
 export const useInfiniteScroll = ({
@@ -16,16 +29,42 @@ export const useInfiniteScroll = ({
   isLoading,
   threshold = 200,
   debounceMs = 300,
+  itemCount,
+  maxUnproductiveLoads,
 }: UseInfiniteScrollOptions) => {
   // Use state to track sentinel element - this ensures useEffect re-runs when sentinel mounts
   const [sentinel, setSentinel] = useState<HTMLDivElement | null>(null);
+  const [isStalled, setIsStalled] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const onLoadMoreRef = useRef(onLoadMore);
+
+  const budgetEnabled = itemCount !== undefined && maxUnproductiveLoads !== undefined;
+  // The debounced trigger fires from a timeout, so it reads the budget through refs to
+  // avoid stale closures — same reason onLoadMore lives in a ref.
+  const budgetRef = useRef({ itemCount, maxUnproductiveLoads, enabled: budgetEnabled });
+  const highWaterRef = useRef(itemCount ?? 0);
+  const unproductiveLoadsRef = useRef(0);
 
   // Keep onLoadMore ref updated to avoid stale closures
   useEffect(() => {
     onLoadMoreRef.current = onLoadMore;
   }, [onLoadMore]);
+
+  useEffect(() => {
+    budgetRef.current = { itemCount, maxUnproductiveLoads, enabled: budgetEnabled };
+  }, [itemCount, maxUnproductiveLoads, budgetEnabled]);
+
+  // A refresh can replace the list with a shorter one while the consumer stays mounted.
+  // The stale high-water mark would then miscount every productive load as unproductive,
+  // so shrinkage resets the budget and re-arms auto-loading.
+  useEffect(() => {
+    if (!budgetEnabled || itemCount === undefined) return;
+    if (itemCount < highWaterRef.current) {
+      highWaterRef.current = itemCount;
+      unproductiveLoadsRef.current = 0;
+      setIsStalled(false);
+    }
+  }, [budgetEnabled, itemCount]);
 
   // Callback ref - called when element mounts/unmounts
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
@@ -37,12 +76,34 @@ export const useInfiniteScroll = ({
       clearTimeout(timeoutRef.current);
     }
     timeoutRef.current = setTimeout(() => {
+      const budget = budgetRef.current;
+      if (budget.enabled) {
+        const count = budget.itemCount ?? 0;
+        if (count > highWaterRef.current) {
+          highWaterRef.current = count;
+          unproductiveLoadsRef.current = 0;
+        }
+
+        unproductiveLoadsRef.current += 1;
+        if (unproductiveLoadsRef.current > (budget.maxUnproductiveLoads ?? Infinity)) {
+          setIsStalled(true);
+          return;
+        }
+      }
+
       onLoadMoreRef.current();
     }, debounceMs);
   }, [debounceMs]);
 
+  /** Clears a stall and immediately loads the next page. Wire to a manual load button. */
+  const resumeAutoLoad = () => {
+    unproductiveLoadsRef.current = 0;
+    setIsStalled(false);
+    onLoadMoreRef.current();
+  };
+
   useEffect(() => {
-    if (!sentinel || !hasMore || isLoading) return;
+    if (!sentinel || !hasMore || isLoading || isStalled) return;
 
     const handleIntersection = (entries: IntersectionObserverEntry[]) => {
       const target = entries[0];
@@ -66,7 +127,7 @@ export const useInfiniteScroll = ({
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [sentinel, hasMore, isLoading, threshold, debouncedLoadMore]);
+  }, [sentinel, hasMore, isLoading, isStalled, threshold, debouncedLoadMore]);
 
-  return { sentinelRef };
+  return { sentinelRef, isStalled, resumeAutoLoad };
 };

--- a/src/hooks/useNotificationPostContent/useNotificationPostContent.test.tsx
+++ b/src/hooks/useNotificationPostContent/useNotificationPostContent.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
 }));
 
 vi.mock('@/molecules/Toaster/use-toast', () => ({
-  useToast: () => ({ toast: mockToast }),
+  toast: mockToast,
 }));
 
 vi.mock('@/libs/logger/logger', () => ({

--- a/src/hooks/useNotificationPostContent/useNotificationPostContent.test.tsx
+++ b/src/hooks/useNotificationPostContent/useNotificationPostContent.test.tsx
@@ -1,0 +1,185 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNotificationPostContent } from './useNotificationPostContent';
+
+type PostDetails = { kind: string; content: string } | null | undefined;
+
+const mockUsePostDetails = vi.hoisted(() =>
+  vi.fn<(compositeId: string | null) => { postDetails: PostDetails; isLoading: boolean }>(() => ({
+    postDetails: null,
+    isLoading: false,
+  })),
+);
+const mockToast = vi.hoisted(() => vi.fn());
+const mockWarn = vi.hoisted(() => vi.fn());
+const mockResolvePubkyToNames = vi.hoisted(() =>
+  vi.fn<(content: string) => Promise<string>>((content) => Promise.resolve(content.replace('pk:abc', '@Alice'))),
+);
+
+// The local-first fetch pattern is usePostDetails' contract, covered by its own tests;
+// here it is a seam so these tests focus on label derivation.
+vi.mock('@/hooks/usePostDetails/usePostDetails', () => ({
+  usePostDetails: mockUsePostDetails,
+}));
+
+vi.mock('@/molecules/Toaster/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock('@/libs/logger/logger', () => ({
+  Logger: { warn: mockWarn, error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Real implementation would resolve `pk:` mentions through UserController; stub the
+// network hop but keep the pass-through behaviour.
+vi.mock('@/organisms/NotificationItem/NotificationItem.helpers', () => ({
+  resolvePubkyToNames: mockResolvePubkyToNames,
+}));
+
+const COMPOSITE_ID = 'author:post123';
+
+/** The post the mocked live query currently reports; undefined models "still loading". */
+const setPost = (postDetails: PostDetails, isLoading = postDetails === undefined) =>
+  mockUsePostDetails.mockReturnValue({ postDetails, isLoading });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolvePubkyToNames.mockImplementation((content) => Promise.resolve(content.replace('pk:abc', '@Alice')));
+  setPost(null);
+});
+
+describe('useNotificationPostContent', () => {
+  it('stays idle and resolves nothing without a composite id', () => {
+    setPost(undefined, true);
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: null }));
+
+    expect(result.current).toEqual({ content: null, isDeleted: false, isMissing: false, isResolving: false });
+  });
+
+  it('reports resolving while the post is still loading', () => {
+    setPost(undefined, true);
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    expect(result.current.isResolving).toBe(true);
+    expect(result.current.content).toBeNull();
+  });
+
+  it('resolves pubky mentions in a short post', async () => {
+    setPost({ kind: 'short', content: 'Hey pk:abc' });
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    // Mention resolution is async, so the hook keeps resolving until it lands.
+    expect(result.current.isResolving).toBe(true);
+
+    await waitFor(() => expect(result.current.content).toBe('Hey @Alice'));
+    expect(result.current.isResolving).toBe(false);
+  });
+
+  it('uses the article title for a long post', () => {
+    setPost({ kind: 'long', content: JSON.stringify({ title: 'On Bitcoin', body: 'Long body' }) });
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    expect(result.current.content).toBe('On Bitcoin');
+    expect(result.current.isResolving).toBe(false);
+  });
+
+  it('uses the collection name for a collection post', () => {
+    setPost({ kind: 'collection', content: JSON.stringify({ name: 'Based Bitcoin', posts: [] }) });
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    expect(result.current.content).toBe('Based Bitcoin');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('falls back to raw content and warns the user when collection content will not parse', () => {
+    setPost({ kind: 'collection', content: 'not-json' });
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    expect(result.current.content).toBe('not-json');
+    expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'error' }));
+  });
+
+  it('stays silent about an unparseable collection when the caller opts out', () => {
+    // Grouped rows render many titles at once and must not fire a toast per member.
+    setPost({ kind: 'collection', content: 'not-json' });
+
+    const { result } = renderHook(() =>
+      useNotificationPostContent({ compositeId: COMPOSITE_ID, notifyOnCollectionParseError: false }),
+    );
+
+    expect(result.current.content).toBe('not-json');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('reports a deleted post with the dedicated copy and the isDeleted flag', () => {
+    setPost({ kind: 'short', content: '[DELETED]' });
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    expect(result.current.content).toBe('This post has been deleted by its author.');
+    expect(result.current.isDeleted).toBe(true);
+    expect(result.current.isMissing).toBe(false);
+  });
+
+  it('settles with no content when the post cannot be found', () => {
+    setPost(null);
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    // isMissing distinguishes a post that is gone from content that failed to derive.
+    expect(result.current).toEqual({ content: null, isDeleted: false, isMissing: true, isResolving: false });
+  });
+
+  it('settles and logs when mention resolution rejects, rather than resolving forever', async () => {
+    setPost({ kind: 'short', content: 'Hey pk:abc' });
+    mockResolvePubkyToNames.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    await waitFor(() => expect(result.current.isResolving).toBe(false));
+    expect(result.current.content).toBeNull();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('re-renders with the new title when the post is edited while mounted', async () => {
+    // The live local-first read is the point of building on usePostDetails (ADR-0011):
+    // a Dexie write re-fires the query, and the label must follow.
+    setPost({ kind: 'short', content: 'First title' });
+
+    const { result, rerender } = renderHook(() => useNotificationPostContent({ compositeId: COMPOSITE_ID }));
+
+    await waitFor(() => expect(result.current.content).toBe('First title'));
+
+    setPost({ kind: 'short', content: 'Second title' });
+    rerender();
+
+    await waitFor(() => expect(result.current.content).toBe('Second title'));
+  });
+
+  it('never shows the previous post while a new composite id resolves', async () => {
+    setPost({ kind: 'short', content: 'Old post' });
+
+    const { result, rerender } = renderHook(({ id }) => useNotificationPostContent({ compositeId: id }), {
+      initialProps: { id: COMPOSITE_ID },
+    });
+
+    await waitFor(() => expect(result.current.content).toBe('Old post'));
+
+    // The new id is still loading; the old content must not leak into this window.
+    setPost(undefined, true);
+    rerender({ id: 'author:post456' });
+
+    expect(result.current).toEqual({ content: null, isDeleted: false, isMissing: false, isResolving: true });
+
+    setPost({ kind: 'short', content: 'New post' });
+    rerender({ id: 'author:post456' });
+
+    await waitFor(() => expect(result.current.content).toBe('New post'));
+  });
+});

--- a/src/hooks/useNotificationPostContent/useNotificationPostContent.tsx
+++ b/src/hooks/useNotificationPostContent/useNotificationPostContent.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePostDetails } from '@/hooks/usePostDetails/usePostDetails';
+import { Logger } from '@/libs/logger/logger';
+import { parseCollectionContent } from '@/libs/post/collectionContent';
+import { deriveTextPreview } from '@/libs/post/postPreview';
+import { isPostDeleted } from '@/libs/utils/utils';
+import { useToast } from '@/molecules/Toaster/use-toast';
+import { resolvePubkyToNames } from '@/organisms/NotificationItem/NotificationItem.helpers';
+
+interface UseNotificationPostContentOptions {
+  /** Composite post id (`author:postId`), or null when the notification has no post to preview. */
+  compositeId: string | null;
+  /**
+   * Surface a toast when collection content fails to parse. Grouped rows pass false so a
+   * group of N unparseable collections does not fire N toasts.
+   * @default true
+   */
+  notifyOnCollectionParseError?: boolean;
+}
+
+/**
+ * Resolves the display text for the post a notification refers to.
+ *
+ * Reads live and local-first through `usePostDetails` (ADR-0011) — a post edited while
+ * the row is mounted re-renders with the new title — then picks the best label for the
+ * post kind: the article title, the collection name, or the raw content with pubky
+ * mentions resolved to display names.
+ */
+export function useNotificationPostContent({
+  compositeId,
+  notifyOnCollectionParseError = true,
+}: UseNotificationPostContentOptions): {
+  content: string | null;
+  isDeleted: boolean;
+  isMissing: boolean;
+  isResolving: boolean;
+} {
+  const { toast } = useToast();
+  const { postDetails, isLoading } = usePostDetails(compositeId);
+
+  const rawContent = postDetails?.content ?? null;
+  const kind = postDetails?.kind;
+
+  const isDeleted = rawContent !== null && isPostDeleted(rawContent);
+  // The post is gone entirely (never resolvable), as opposed to content that merely
+  // failed to derive a label while the post itself exists.
+  const isMissing = compositeId !== null && !isLoading && postDetails === null;
+
+  // Mention resolution is async, so plain posts settle through this state; it is keyed
+  // by the content it resolved, which makes a stale value (old post, or pre-edit
+  // content) detectable and never rendered.
+  const [mentionResolution, setMentionResolution] = useState<{ source: string; content: string | null } | null>(null);
+
+  const needsMentionResolution = rawContent !== null && !isDeleted && kind !== 'long' && kind !== 'collection';
+
+  useEffect(() => {
+    if (!needsMentionResolution || rawContent === null) return;
+
+    let isCancelled = false;
+
+    resolvePubkyToNames(rawContent)
+      .then((resolved) => {
+        if (!isCancelled) setMentionResolution({ source: rawContent, content: resolved });
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          Logger.warn('Failed to resolve notification post mentions:', { postCompositeId: compositeId, error });
+          setMentionResolution({ source: rawContent, content: null });
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [needsMentionResolution, rawContent, compositeId]);
+
+  const collectionParseFailed =
+    rawContent !== null && kind === 'collection' && !isDeleted && !parseCollectionContent(rawContent);
+
+  useEffect(() => {
+    if (collectionParseFailed && notifyOnCollectionParseError) {
+      toast({
+        variant: 'error',
+        description: 'Could not parse collection content',
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast is an external side-effect, not a dependency
+  }, [collectionParseFailed, notifyOnCollectionParseError, rawContent]);
+
+  // Derive the label for the current post. Because this reads the live query's value
+  // directly, a compositeId change can never leak the previous post's text.
+  let content: string | null = null;
+  let isResolvingMentions = false;
+
+  if (rawContent !== null) {
+    if (!needsMentionResolution) {
+      // Deleted notices, article titles and collection names follow the app-wide
+      // preview policy, kept in postPreview so the surfaces never drift apart.
+      content = deriveTextPreview({ content: rawContent, kind: kind ?? '' });
+    } else if (mentionResolution?.source === rawContent) {
+      content = mentionResolution.content;
+    } else {
+      isResolvingMentions = true;
+    }
+  }
+
+  return {
+    content,
+    isDeleted,
+    isMissing,
+    // A null compositeId settles immediately — there is nothing to resolve.
+    isResolving: compositeId !== null && (isLoading || isResolvingMentions),
+  };
+}

--- a/src/hooks/useNotificationPostContent/useNotificationPostContent.tsx
+++ b/src/hooks/useNotificationPostContent/useNotificationPostContent.tsx
@@ -6,7 +6,7 @@ import { Logger } from '@/libs/logger/logger';
 import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { deriveTextPreview } from '@/libs/post/postPreview';
 import { isPostDeleted } from '@/libs/utils/utils';
-import { useToast } from '@/molecules/Toaster/use-toast';
+import { toast } from '@/molecules/Toaster/use-toast';
 import { resolvePubkyToNames } from '@/organisms/NotificationItem/NotificationItem.helpers';
 
 interface UseNotificationPostContentOptions {
@@ -37,7 +37,6 @@ export function useNotificationPostContent({
   isMissing: boolean;
   isResolving: boolean;
 } {
-  const { toast } = useToast();
   const { postDetails, isLoading } = usePostDetails(compositeId);
 
   const rawContent = postDetails?.content ?? null;
@@ -86,7 +85,6 @@ export function useNotificationPostContent({
         description: 'Could not parse collection content',
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast is an external side-effect, not a dependency
   }, [collectionParseFailed, notifyOnCollectionParseError, rawContent]);
 
   // Derive the label for the current post. Because this reads the live query's value

--- a/src/hooks/useNotifications/useNotifications.test.tsx
+++ b/src/hooks/useNotifications/useNotifications.test.tsx
@@ -414,6 +414,68 @@ describe('useNotifications', () => {
     expect(NotificationController.getOrFetchNotifications).toHaveBeenNthCalledWith(3, { olderThan: 3999 });
   });
 
+  it('restores pagination when refresh stands in for a failed initial load', async () => {
+    // The retry button calls refresh(); without establishing the cursor the first
+    // loadMore would see an undefined olderThan and switch pagination off for good.
+    const firstPage = [
+      { id: 'test-1', type: NotificationType.Follow, timestamp: 2000, followed_by: 'user1' },
+    ] as FlatNotification[];
+    const secondPage = [
+      { id: 'test-2', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user2' },
+    ] as FlatNotification[];
+
+    vi.mocked(NotificationController.getOrFetchNotifications)
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ flatNotifications: firstPage, olderThan: 1999 })
+      .mockResolvedValueOnce({ flatNotifications: secondPage, olderThan: 999 });
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to load notifications');
+    });
+    expect(result.current.notifications).toEqual([]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.notifications).toEqual(firstPage);
+    expect(result.current.hasMore).toBe(true);
+
+    // Pagination still works: the cursor from the retry is used for the next page.
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(NotificationController.getOrFetchNotifications).toHaveBeenNthCalledWith(3, { olderThan: 1999 });
+    expect(result.current.notifications).toEqual([...firstPage, ...secondPage]);
+  });
+
+  it('keeps the loaded list when a refreshed page is filtered down to nothing', async () => {
+    // Everyone on the newest page is muted, so the filtered page is empty — that says
+    // nothing about overlap and must not be mistaken for a gap that replaces the list.
+    const initialNotifications = [
+      { id: 'test-1', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user1' },
+    ] as FlatNotification[];
+
+    vi.mocked(NotificationController.getOrFetchNotifications)
+      .mockResolvedValueOnce({ flatNotifications: initialNotifications, olderThan: 999 })
+      .mockResolvedValueOnce({ flatNotifications: [], olderThan: undefined });
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.notifications).toEqual(initialNotifications);
+  });
+
   it('should reset pagination and refetch first page when notification filter changes', async () => {
     // Regression intent:
     // - User may already be paginated into older items (cursor has advanced).

--- a/src/hooks/useNotifications/useNotifications.test.tsx
+++ b/src/hooks/useNotifications/useNotifications.test.tsx
@@ -339,6 +339,81 @@ describe('useNotifications', () => {
     expect(NotificationController.getOrFetchNotifications).toHaveBeenCalledTimes(2);
   });
 
+  it('refreshes silently, without swapping the mounted list for a loading state', async () => {
+    const initialNotifications = [
+      { id: 'test-1', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user1' },
+    ] as FlatNotification[];
+    const refreshedNotifications = [
+      { id: 'test-2', type: NotificationType.Follow, timestamp: 2000, followed_by: 'user2' },
+      { id: 'test-1', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user1' },
+    ] as FlatNotification[];
+
+    let resolveRefresh!: (value: { flatNotifications: FlatNotification[]; olderThan: number }) => void;
+    vi.mocked(NotificationController.getOrFetchNotifications)
+      .mockResolvedValueOnce({ flatNotifications: initialNotifications, olderThan: 999 })
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveRefresh = resolve)));
+
+    const { result, rerender } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      setMockUnreadCount(2);
+      rerender();
+    });
+
+    // The refresh is in flight — the already loaded list must stay mounted, so the
+    // container's skeleton gate (isLoading) must not flip and collapse expanded rows.
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.notifications).toEqual(initialNotifications);
+
+    await act(async () => {
+      resolveRefresh({ flatNotifications: refreshedNotifications, olderThan: 999 });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.notifications).toEqual(refreshedNotifications);
+  });
+
+  it('falls back to replacing the list when the refreshed page does not overlap it', async () => {
+    // More than a page arrived at once: prepending would leave an invisible gap between
+    // the fresh page and the previously loaded items, so the refresh starts over.
+    const initialNotifications = [
+      { id: 'test-1', type: NotificationType.Follow, timestamp: 1000, followed_by: 'user1' },
+    ] as FlatNotification[];
+    const freshPage = [
+      { id: 'test-3', type: NotificationType.Follow, timestamp: 5000, followed_by: 'user3' },
+      { id: 'test-2', type: NotificationType.Follow, timestamp: 4000, followed_by: 'user2' },
+    ] as FlatNotification[];
+
+    vi.mocked(NotificationController.getOrFetchNotifications)
+      .mockResolvedValueOnce({ flatNotifications: initialNotifications, olderThan: 999 })
+      .mockResolvedValueOnce({ flatNotifications: freshPage, olderThan: 3999 });
+
+    const { result, rerender } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      setMockUnreadCount(2);
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(result.current.notifications).toEqual(freshPage);
+    });
+
+    // Pagination restarts from the fresh page's cursor, not the stale pre-refresh one.
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(NotificationController.getOrFetchNotifications).toHaveBeenNthCalledWith(3, { olderThan: 3999 });
+  });
+
   it('should reset pagination and refetch first page when notification filter changes', async () => {
     // Regression intent:
     // - User may already be paginated into older items (cursor has advanced).

--- a/src/hooks/useNotifications/useNotifications.tsx
+++ b/src/hooks/useNotifications/useNotifications.tsx
@@ -23,6 +23,13 @@ export function useNotifications(): UseNotificationsResult {
 
   const olderThanRef = useRef<number | undefined>(undefined);
   const loadingRef = useRef(false);
+  // Mirrors `notifications` so `refresh` can diff against the loaded list without
+  // subscribing to it (its identity changes on every merge).
+  const notificationsRef = useRef<FlatNotification[]>([]);
+
+  useEffect(() => {
+    notificationsRef.current = notifications;
+  }, [notifications]);
 
   const { currentUserPubky } = useAuthStore();
   const notificationPreferences = useSettingsStore((s) => s.notifications);
@@ -160,28 +167,41 @@ export function useNotifications(): UseNotificationsResult {
   }, [hasMore, currentUserPubky, filterMutedNotifications]);
 
   /**
-   * Refresh notifications - resets pagination and fetches from start
+   * Refresh notifications - fetches the newest page and merges it in place.
+   *
+   * Runs silently (no `isLoading` flip): the poll fires it whenever anything new
+   * arrives, and swapping the mounted list for a skeleton would collapse expanded
+   * group rows and throw away scroll position every few seconds on active accounts.
+   * New notifications are prepended onto what is already loaded; only when the fresh
+   * page does not overlap the loaded list at all (more than a page arrived at once,
+   * so prepending would leave a gap) does it fall back to replacing the list and
+   * resetting pagination, like the initial load.
    */
   const refresh = useCallback(async () => {
     if (!currentUserPubky || loadingRef.current) return;
 
     loadingRef.current = true;
-    setIsLoading(true);
     setError(null);
-    olderThanRef.current = undefined;
-    setHasMore(true);
 
     try {
-      const { flatNotifications: notifications, olderThan } = await NotificationController.getOrFetchNotifications({});
+      const { flatNotifications: fetched, olderThan } = await NotificationController.getOrFetchNotifications({});
 
-      setNotifications(filterMutedNotifications(notifications));
-      olderThanRef.current = olderThan;
-      setHasMore(olderThan !== undefined);
+      const fresh = filterMutedNotifications(fetched);
+      const existingIds = new Set(notificationsRef.current.map((n) => n.id));
+      const newNotifications = fresh.filter((n) => !existingIds.has(n.id));
+
+      const hasGap = notificationsRef.current.length > 0 && newNotifications.length === fresh.length;
+      if (hasGap) {
+        setNotifications(fresh);
+        olderThanRef.current = olderThan;
+        setHasMore(olderThan !== undefined);
+      } else if (newNotifications.length > 0) {
+        setNotifications((prev) => [...newNotifications, ...prev]);
+      }
     } catch {
       setError('Failed to refresh notifications');
     } finally {
       loadingRef.current = false;
-      setIsLoading(false);
     }
   }, [currentUserPubky, filterMutedNotifications]);
 
@@ -218,6 +238,8 @@ export function useNotifications(): UseNotificationsResult {
    * Reset pagination when notification filter preferences change.
    * Preference changes create a new query context, so we must restart from
    * the first page instead of continuing with the previous olderThan cursor.
+   * This is a full reload (not the silent merge `refresh`), because the already
+   * loaded list was built under the old filter and cannot be patched in place.
    */
   useEffect(() => {
     if (!currentUserPubky) return;
@@ -227,8 +249,8 @@ export function useNotifications(): UseNotificationsResult {
 
     if (!hasPreferencesChanged) return;
 
-    refresh();
-  }, [currentUserPubky, notificationPreferences, refresh]);
+    performInitialLoad();
+  }, [currentUserPubky, notificationPreferences, performInitialLoad]);
 
   /**
    * Reactively filter notifications when mute state changes.

--- a/src/hooks/useNotifications/useNotifications.tsx
+++ b/src/hooks/useNotifications/useNotifications.tsx
@@ -172,10 +172,10 @@ export function useNotifications(): UseNotificationsResult {
    * Runs silently (no `isLoading` flip): the poll fires it whenever anything new
    * arrives, and swapping the mounted list for a skeleton would collapse expanded
    * group rows and throw away scroll position every few seconds on active accounts.
-   * New notifications are prepended onto what is already loaded; only when the fresh
-   * page does not overlap the loaded list at all (more than a page arrived at once,
-   * so prepending would leave a gap) does it fall back to replacing the list and
-   * resetting pagination, like the initial load.
+   * New notifications are prepended onto what is already loaded; the list is replaced
+   * (and pagination restarted) only when there is nothing to prepend onto, or when the
+   * fresh page shares nothing with the loaded list — more than a page arrived at once,
+   * so prepending would leave an invisible gap.
    */
   const refresh = useCallback(async () => {
     if (!currentUserPubky || loadingRef.current) return;
@@ -190,8 +190,14 @@ export function useNotifications(): UseNotificationsResult {
       const existingIds = new Set(notificationsRef.current.map((n) => n.id));
       const newNotifications = fresh.filter((n) => !existingIds.has(n.id));
 
-      const hasGap = notificationsRef.current.length > 0 && newNotifications.length === fresh.length;
-      if (hasGap) {
+      // Nothing loaded yet — the first load failed and the user retried, so this call
+      // stands in for it and has to establish the pagination cursor too.
+      const isEmptyList = notificationsRef.current.length === 0;
+      // An empty page proves nothing about overlap (every actor on it may be muted), so
+      // it must never be mistaken for a gap and wipe the loaded list.
+      const hasGap = !isEmptyList && fresh.length > 0 && newNotifications.length === fresh.length;
+
+      if (isEmptyList || hasGap) {
         setNotifications(fresh);
         olderThanRef.current = olderThan;
         setHasMore(olderThan !== undefined);


### PR DESCRIPTION
Closes #1570

Bursts of post-change notifications (an author editing or deleting many posts you interacted with) flooded the list with one row per post. This groups them.

## What changed

- **Grouping** — consecutive deleted/edited notifications from the same actor and content kind collapse into one row; repeated notifications about the same post keep only the newest occurrence.
- **Deleted groups** render as a flat summary (`John deleted 8 posts you interacted with`) with no post links; single deleted rows are informational too — the deleted post has no destination.
- **Edited groups** list every affected post title behind a `Show`/`Hide` disclosure on desktop (pill inline in the row while collapsed, under the list when expanded) and render permanently expanded on mobile, per the [Figma design](https://www.figma.com/design/01ZvjSPZnKTNmaEWz0yJsq/Pubky-SHADCN?node-id=44799-221063).
- **Titles** resolve live and local-first (article title / collection name / content with mentions resolved), quoted and truncated at 40 graphemes; a member deleted after its edits renders a plain unlinked notice, and a post that no longer exists drops its link.
- **Freshness** — edited posts are refetched when their notification arrives, so rows show post-edit content even when the post was already cached.
- **Refresh** — poll-driven refreshes merge new notifications in place instead of swapping the list for a skeleton, so expanded groups, scroll position and loaded pages survive.
- **Pagination** — grouping can make a fetched page add zero rows, so auto-loading budgets unproductive loads and hands control back via a manual `Load more` button; a failed load keeps the accumulated rows and offers an inline `Try again`.
- **Shared chrome** — avatar, heading and timestamp/icon extracted into `NotificationRowChrome`, used by both single and grouped rows.

## Tests

Unit coverage across grouping rules, the group row (disclosure, focus, icons, lazy fetches), title resolution, the silent refresh and the load budget. The two e2e "…that you reposted" scenarios now create two posts each and assert the grouped row — including the Show/Hide disclosure on desktop and the permanently expanded list on the mobile config.
<img width="1213" height="756" alt="image" src="https://github.com/user-attachments/assets/bbcc60f3-4f45-4f96-a3c1-75ebee785138" />
<img width="824" height="595" alt="image" src="https://github.com/user-attachments/assets/83516106-3e30-4613-897e-2221944e55c1" />
<img width="412" height="878" alt="image" src="https://github.com/user-attachments/assets/568140a5-94c4-4166-b1a8-63173589b8fb" />

Edit: Also closes #2287 
