### PR TITLE
fix(posts): skip optimistic feed prepend on WoT-sourced streams

### DIFF
--- a/src/components/organisms/Timeline/Feed/NewPostsSection/NewPostsSection.tsx
+++ b/src/components/organisms/Timeline/Feed/NewPostsSection/NewPostsSection.tsx
@@ -69,6 +69,8 @@ export function NewPostsSection({
         Gate optimistic prepend by content kind (e.g. do not show a `short` post
         after "New posts" on `timeline:…:collection`). `!kind` keeps cache misses
         so a not-yet-indexed post can still appear; mirrors `usePostInput`.
+        Intentionally NOT gated by WoT source (unlike `usePostInput`, #2308):
+        unread ids come from polling this exact stream, so they belong in it.
       */
       if (postsToAdd.length > 0) {
         const details = await PostController.getDetailsByIds({ compositeIds: postsToAdd });

--- a/src/core/models/stream/post/postStream.types.test.ts
+++ b/src/core/models/stream/post/postStream.types.test.ts
@@ -13,7 +13,9 @@ import {
   isAuthorStreamSkippingMuteFilter,
   isCollectionItemsStream,
   isSkipPaginatedStream,
+  isViewerExcludedWotStream,
   isWotDomainStream,
+  isWotStream,
 } from '@/models/stream/post/postStream.types';
 import { StreamSorting } from '@/services/nexus/nexus.types';
 import { StreamKind, StreamSource } from '@/services/nexus/stream/posts/postStream.types';
@@ -171,6 +173,32 @@ describe('isCollectionItemsStream', () => {
     expect(isCollectionItemsStream(buildCollectionItemsStreamId(TEST_PUBKY, TEST_POST_ID))).toBe(true);
     expect(isCollectionItemsStream(buildAuthorCollectionsStreamId(TEST_PUBKY))).toBe(false);
     expect(isCollectionItemsStream('timeline:bookmarks:collection')).toBe(false);
+  });
+});
+
+describe('isWotStream', () => {
+  it('returns true only for wot-sourced stream ids', () => {
+    expect(isWotStream('timeline:wot:all')).toBe(true);
+    expect(isWotStream('total_engagement:wot:image')).toBe(true);
+    expect(isWotStream('timeline:wot_domain:2:all:bitcoin')).toBe(false);
+    expect(isWotStream('timeline:following:all')).toBe(false);
+    expect(isWotStream(`timeline:author:${TEST_PUBKY}:all`)).toBe(false);
+    expect(isWotStream(`author:${TEST_PUBKY}`)).toBe(false);
+  });
+});
+
+describe('isViewerExcludedWotStream', () => {
+  it('returns true for wot (My network) and wot_domain (Tagged as) streams', () => {
+    expect(isViewerExcludedWotStream('timeline:wot:all')).toBe(true);
+    expect(isViewerExcludedWotStream(buildWotDomainStreamId(StreamSorting.TIMELINE, 2, 'all', ['bitcoin']))).toBe(true);
+  });
+
+  it('returns false for streams that carry the viewer own posts', () => {
+    expect(isViewerExcludedWotStream('timeline:all:all')).toBe(false);
+    expect(isViewerExcludedWotStream('timeline:following:all')).toBe(false);
+    expect(isViewerExcludedWotStream('timeline:friends:short')).toBe(false);
+    expect(isViewerExcludedWotStream(buildSortedAuthorStreamId(StreamSorting.TIMELINE, TEST_PUBKY, 'all'))).toBe(false);
+    expect(isViewerExcludedWotStream(`author:${TEST_PUBKY}`)).toBe(false);
   });
 });
 

--- a/src/core/models/stream/post/postStream.types.ts
+++ b/src/core/models/stream/post/postStream.types.ts
@@ -202,6 +202,21 @@ export function isWotDomainStream(streamId: string): streamId is WotDomainStream
   return streamId.split(':')[1] === StreamSource.WOT_DOMAIN;
 }
 
+export function isWotStream(streamId: string): streamId is WotStreamId {
+  return streamId.split(':')[1] === StreamSource.WOT;
+}
+
+/**
+ * Web-of-Trust-sourced streams ('My network' `wot`, 'Tagged as' `wot_domain`)
+ * never contain the viewer's own posts: Nexus filters them out server-side
+ * (`author.id <> observer_id`) and the local create path never writes into
+ * these streams. Consumers must not optimistically insert the viewer's own
+ * new posts into them (#2308).
+ */
+export function isViewerExcludedWotStream(streamId: string): boolean {
+  return isWotStream(streamId) || isWotDomainStream(streamId);
+}
+
 const POST_STREAM_KIND_SEGMENTS: ReadonlySet<string> = new Set(['all', ...Object.values<string>(StreamKind)]);
 
 function toPostStreamKindSegment(segment: string | undefined): PostStreamKindSegment | undefined {

--- a/src/hooks/usePostInput/usePostInput.test.ts
+++ b/src/hooks/usePostInput/usePostInput.test.ts
@@ -724,16 +724,22 @@ describe('usePostInput', () => {
       expect(mockOnSuccess).toHaveBeenCalledWith('created-post-id');
     });
 
-    it('does not prependPosts when the created post kind does not match a wot_domain stream kind', async () => {
+    /*
+      WoT-sourced streams are gated before the kind lookup (#2308), which also
+      covers the former kind-mismatch case on `timeline:wot_domain:…:image`.
+    */
+    it.each([
+      ['wot (My network)', 'timeline:wot:all'],
+      ['wot_domain (Tagged as)', 'timeline:wot_domain:2:all:bitcoin'],
+    ])('does not prependPosts on a %s stream even when the kind matches (#2308)', async (_label, streamId) => {
       mockContent = 'Test content';
       mockPost.mockImplementation(async ({ onSuccess }) => {
         onSuccess('created-post-id');
       });
       vi.mocked(useTimelineFeedContext).mockReturnValue({
         ...mockTimelineFeedContext,
-        streamId: 'timeline:wot_domain:2:image:bitcoin' as PostStreamId,
+        streamId: streamId as PostStreamId,
       });
-      vi.mocked(PostController.getDetails).mockResolvedValue({ kind: 'short' } as never);
 
       const mockOnSuccess = vi.fn();
       const { result } = renderHook(() =>
@@ -748,10 +754,73 @@ describe('usePostInput', () => {
       });
 
       await waitFor(() => {
-        expect(PostController.getDetails).toHaveBeenCalledWith({ compositeId: 'created-post-id' });
+        expect(mockOnSuccess).toHaveBeenCalledWith('created-post-id');
+      });
+      // The gate short-circuits before the kind lookup
+      expect(PostController.getDetails).not.toHaveBeenCalled();
+      expect(mockPrependPosts).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['following', PostStreamTypes.TIMELINE_FOLLOWING_ALL as string],
+      ['Me (sorted author)', 'timeline:author:test-user-pubky:all'],
+    ])('still prependPosts on the %s stream', async (_label, streamId) => {
+      mockContent = 'Test content';
+      mockPost.mockImplementation(async ({ onSuccess }) => {
+        onSuccess('created-post-id');
+      });
+      vi.mocked(useTimelineFeedContext).mockReturnValue({
+        ...mockTimelineFeedContext,
+        streamId: streamId as PostStreamId,
+      });
+
+      const mockOnSuccess = vi.fn();
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+          onSuccess: mockOnSuccess,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      await waitFor(() => {
+        expect(mockPrependPosts).toHaveBeenCalledWith('created-post-id');
+      });
+      expect(mockOnSuccess).toHaveBeenCalledWith('created-post-id');
+    });
+
+    it('collapses PostInput when prepend is skipped on a WoT stream', async () => {
+      mockContent = 'Test content';
+      mockPost.mockImplementation(async ({ onSuccess }) => {
+        onSuccess('created-post-id');
+      });
+      vi.mocked(useTimelineFeedContext).mockReturnValue({
+        ...mockTimelineFeedContext,
+        streamId: 'timeline:wot:all' as PostStreamId,
+      });
+
+      const { result } = renderHook(() =>
+        usePostInput({
+          variant: 'post',
+        }),
+      );
+
+      act(() => {
+        result.current.handleExpand();
+      });
+      expect(result.current.isExpanded).toBe(true);
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isExpanded).toBe(false);
       });
       expect(mockPrependPosts).not.toHaveBeenCalled();
-      expect(mockOnSuccess).toHaveBeenCalledWith('created-post-id');
     });
 
     it('collapses PostInput when the created post kind does not match the stream content filter', async () => {

--- a/src/hooks/usePostInput/usePostInput.ts
+++ b/src/hooks/usePostInput/usePostInput.ts
@@ -25,6 +25,7 @@ import { getContentWithMention } from '@/hooks/useMentionAutocomplete/useMention
 import { usePost } from '@/hooks/usePost/usePost';
 import { useUserDetails } from '@/hooks/useUserDetails/useUserDetails';
 import { Logger } from '@/libs/logger/logger';
+import { isViewerExcludedWotStream } from '@/models/stream/post/postStream.types';
 import { useToast } from '@/molecules/Toaster/use-toast';
 import { POST_INPUT_PLACEHOLDER, POST_INPUT_VARIANT } from '@/organisms/PostInput/PostInput.constants';
 import { useTimelineFeedContext } from '@/organisms/Timeline/Feed/TimelineFeed/TimelineFeedContext';
@@ -228,6 +229,18 @@ export function usePostInput({
             const streamId = timelineFeed?.streamId;
             if (!streamId) {
               await timelineFeed?.prependPosts(createdPostId);
+              return;
+            }
+
+            /*
+              WoT-sourced streams ('My network', 'Tagged as') never contain the
+              viewer's own posts (Nexus excludes them and the local create path
+              never writes into them), so prepending would flash the post and
+              lose it on the next stream reset (#2308). Unlike the kind gate
+              below, this check is NOT mirrored in `NewPostsSection`: unread ids
+              there come from polling the WoT stream itself, so they belong.
+            */
+            if (isViewerExcludedWotStream(streamId)) {
               return;
             }
 


### PR DESCRIPTION
## Summary
- fix #2308
- A newly created post flashed at the top of the feed with the 'My network' or 'Tagged as' Reach filter active, then vanished after toggling filters — the optimistic prepend gate only checked content kind, never the stream source.
- WoT-sourced streams (`wot`, `wot_domain`) never contain the viewer's own posts: Nexus excludes them server-side (`author.id <> observer_id`) and the local create path never writes into those streams, so the optimistic entry was guaranteed inconsistent.

## Changes
- `postStream.types.ts`: add `isWotStream` (symmetric with `isWotDomainStream`) and `isViewerExcludedWotStream`, documenting why WoT streams never carry the viewer's own posts.
- `usePostInput.ts`: skip the optimistic prepend when the active stream is WoT-sourced, before the kind lookup; composer collapse and `onSuccess` behavior unchanged. Covers both POST and REPOST variants.
- `NewPostsSection.tsx`: comment-only — note the intentional divergence (unread ids come from polling the WoT stream itself, so they belong and are not source-gated).
- Tests: `isWotStream`/`isViewerExcludedWotStream` cases; `usePostInput` no longer prepends on `timeline:wot:all` / `timeline:wot_domain:2:all:bitcoin` even when the kind matches, still prepends on All/Following/Me streams, and still collapses when skipped. Removed the old wot_domain kind-mismatch test, superseded by the stronger source gate.

https://github.com/user-attachments/assets/b2c58779-3626-4ef0-89c2-ca6db42f508d

## Test plan
- [ ] Manual: apply 'Tagged as' (or 'My network') Reach, create a post from the quick post area — post must NOT appear at top of feed; switch to All/Following/Me — post appears

## Notes
- Own posts still show optimistically on All, Following, Friends, and Me — Following/Friends are persisted into local streams by `LocalPostService.updatePostStream`, so they are self-consistent. Whether own posts *should* appear on Following/Friends at all is a separate product question worth its own issue.