### PR TITLE
fix (Bug): Add tag focus lost when moving mouse cursor #2291

### DIFF
--- a/src/components/atoms/Popover/Popover.tsx
+++ b/src/components/atoms/Popover/Popover.tsx
@@ -40,15 +40,6 @@ function Popover({
     }
   };
 
-  const blurActiveElement = () => {
-    setTimeout(() => {
-      const activeElement = document.activeElement as HTMLElement;
-      if (activeElement?.blur) {
-        activeElement.blur();
-      }
-    }, 0);
-  };
-
   const handleMouseEnter = () => {
     // Cancel any pending close
     if (closeTimeoutRef.current) {
@@ -90,11 +81,9 @@ function Popover({
       if (hoverCloseDelay > 0) {
         closeTimeoutRef.current = setTimeout(() => {
           handleOpenChange?.(false);
-          blurActiveElement();
         }, hoverCloseDelay);
       } else {
         handleOpenChange?.(false);
-        blurActiveElement();
       }
     }
   };


### PR DESCRIPTION
Closes #2291

When cursor is moved to popover the cursor lose focus as the blur function in the handleMouseLeave get triggered. 

### Screenrecording

https://github.com/user-attachments/assets/c0e28740-96c7-4134-9dbc-b9cf42a6c0ab

