### PR TITLE
Fix (Bug): Profile page crops descender letters in username  #2287

### DIFF
--- a/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
+++ b/src/components/organisms/ProfilePageHeader/ProfilePageHeader.tsx
@@ -151,7 +151,7 @@ export function ProfilePageHeader({ profile, actions, isOwnProfile = true, userI
             data-cy="profile-username-header"
             as="h1"
             size="lg"
-            className="max-width-profile-page-header w-full truncate text-2xl leading-8 text-white sm:max-w-xl lg:max-w-full lg:text-6xl lg:leading-none"
+            className="max-width-profile-page-header w-full truncate text-2xl leading-8 text-white sm:max-w-xl lg:max-w-full lg:text-6xl lg:leading-normal"
           >
             {name}
           </Typography>


### PR DESCRIPTION
Closes #2287

update line height for username for descender letters:

### Screenshot:

<img width="1597" height="383" alt="Screenshot 2026-08-12 130028" src="https://github.com/user-attachments/assets/eba73847-2e34-4588-8657-9f5b98d71750" />
