### PR TITLE
fix (Bug): Unable to view 'Links' at bottom of Profile page on some mobile displays  #2274

### DIFF
--- a/src/components/molecules/ProfilePageLayoutWrapper/ProfilePageLayoutWrapper.tsx
+++ b/src/components/molecules/ProfilePageLayoutWrapper/ProfilePageLayoutWrapper.tsx
@@ -8,7 +8,7 @@ export function ProfilePageLayoutWrapper({ children }: ProfilePageLayoutWrapperP
   return (
     <Container
       overrideDefaults={true}
-      className="mx-auto mt-6 w-full max-w-(--container-max-width) px-6 pt-0 lg:mt-0 xl:px-0"
+      className="mx-auto mt-6 w-full max-w-(--container-max-width) px-6 pt-0 pb-20 lg:mt-0 lg:pb-2 xl:px-0"
     >
       {children}
     </Container>


### PR DESCRIPTION
Closes #2274

add padding at the bottom for profile page layout wrapper to display view links at the bottom. Also added a little bit of padding (8px) for the large screen sizes.  

### Screen recording

https://github.com/user-attachments/assets/039d7e4d-cbea-47d6-a212-47ca808a47d9

