### PR TITLE
fix(ui): expand truncated post text in place

### DIFF
--- a/cypress/e2e/posts.cy.ts
+++ b/cypress/e2e/posts.cy.ts
@@ -95,8 +95,11 @@ describe('posts', () => {
 
     cy.findFirstPostInFeed().within(() => {
       cy.get('[data-cy="post-text"]').should('contain.text', prefix.trim());
-      cy.contains('Show more').should('be.visible');
+      cy.contains('Show more').should('be.visible').click();
+      cy.contains('Show more').should('not.exist');
+      cy.get('[data-cy="post-text"]').should('contain.text', postContent);
     });
+    cy.location('pathname').should('eq', '/home');
   });
 
   it('can post with emojis', () => {

--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -947,27 +947,42 @@ describe('PostText', () => {
       render(<PostText content={longContent} />);
 
       const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
-      expect(showMoreButton).toHaveAttribute('data-allow-post-navigation');
+      expect(showMoreButton).not.toHaveAttribute('data-allow-post-navigation');
+      expect(showMoreButton).toHaveAttribute('type', 'button');
       expect(showMoreButton).toHaveClass('cursor-pointer');
       expect(showMoreButton).toHaveClass('text-brand');
       expect(showMoreButton).toHaveClass('mt-4');
     });
 
-    it('does not stop event propagation on "Show more" button click', () => {
+    it('expands truncated content in place and stops event propagation on "Show more" click', () => {
       const handleParentClick = vi.fn();
-      const longContent = generateContent(600);
-
-      render(
+      const uniqueTail = ' UNIQUE_EXPAND_TAIL_MARKER';
+      const longContent = `${generateContent(600)}${uniqueTail}`;
+      const { container } = render(
         <div onClick={handleParentClick}>
           <PostText content={longContent} />
         </div>,
       );
 
-      const showMoreButton = screen.getByRole('button', { name: 'Show full post content' });
-      fireEvent.click(showMoreButton);
+      expect(container.textContent).not.toContain(uniqueTail);
 
-      // Click should propagate to parent (unlike regular links)
-      expect(handleParentClick).toHaveBeenCalled();
+      fireEvent.click(screen.getByRole('button', { name: 'Show full post content' }));
+
+      expect(handleParentClick).not.toHaveBeenCalled();
+      expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+      expect(container.textContent).toContain(uniqueTail);
+    });
+
+    it('expands line-truncated content in place on "Show more" click', () => {
+      const content = ['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5', 'Line 6', 'Line 7'].join('\n');
+      const { container } = render(<PostText content={content} />);
+
+      expect(container.textContent).not.toContain('Line 7');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show full post content' }));
+
+      expect(screen.queryByRole('button', { name: 'Show full post content' })).not.toBeInTheDocument();
+      expect(container.textContent).toContain('Line 7');
     });
 
     it('truncates content exactly at TRUNCATION_LIMIT characters plus ellipsis', () => {

--- a/src/components/molecules/PostText/PostText.test.tsx.snap
+++ b/src/components/molecules/PostText/PostText.test.tsx.snap
@@ -1013,8 +1013,8 @@ exports[`PostText - Snapshots > matches snapshot for truncated content with Show
   <button
     aria-label="Show full post content"
     class="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
-    data-allow-post-navigation="true"
     data-override-defaults="true"
+    type="button"
   >
     Show more
   </button>

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -34,7 +34,7 @@ import {
  * - Hashtag parsing (#tag → clickable search link)
  * - Mention parsing (pk:... or pubky... → clickable profile link)
  * - URL detection and linking
- * - Content truncation with "Show more" on non-post pages
+ * - Content truncation with in-place "Show more" on non-post pages
  *
  * Memoization prevents unnecessary re-renders when TTL refreshes update IndexedDB records
  * without changes to the actual post content.
@@ -42,8 +42,9 @@ import {
 export const PostText = memo(function PostText({ content, isArticle, onLinkClick, className }: PostTextProps) {
   const pathname = usePathname();
   const onPostPage = pathname.startsWith(POST_ROUTES.POST);
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  const contentTruncated = !isArticle && !onPostPage ? truncatePostPreviewText(content) : null;
+  const contentTruncated = !isArticle && !onPostPage && !isExpanded ? truncatePostPreviewText(content) : null;
   const showMoreButton = Boolean(contentTruncated);
 
   const remarkPlugins = [
@@ -204,13 +205,16 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
         {contentTruncated || content}
       </Markdown>
 
-      {/* No stopPropagation on this element therefore click takes user to post via parent element */}
       {showMoreButton && (
         <Button
           overrideDefaults
+          type="button"
           aria-label="Show full post content"
-          data-allow-post-navigation
           className="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsExpanded(true);
+          }}
         >
           Show more
         </Button>

--- a/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
+++ b/src/components/organisms/PostContentBase/PostContentBase.test.tsx.snap
@@ -102,8 +102,8 @@ exports[`PostContentBase - Snapshots > matches snapshot with very long content 1
     <button
       aria-label="Show full post content"
       class="mt-4 cursor-pointer text-brand transition-colors hover:text-brand/80"
-      data-allow-post-navigation="true"
       data-testid="button"
+      type="button"
     >
       Show more
     </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #764

## Summary

Long posts in feeds currently show a green **Show more** control that navigates to the post page. Clicking it now expands the truncated text in place so the user can keep scrolling the feed, matching X-style behavior.

Card click (outside links/buttons) still opens the post page. There is no Show less — after expand, the button is hidden.

## Changes

- `PostText` keeps local expanded state and skips truncation while expanded
- Show more stops event propagation and no longer uses `data-allow-post-navigation`
- Unit tests cover expand-in-place and that the click does not bubble to the card
- Cypress max-length post spec asserts expand stays on `/home`


https://github.com/user-attachments/assets/9ccd48db-e461-40d9-8837-1338c2a658fa


## Out of scope

- Truncation limits (300 chars / 6 lines)
- Articles, list-layout snippets, visual timeline overlays
- i18n for the Show more label

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb53c595-037f-415b-8cb7-1c76f859b683?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb53c595-037f-415b-8cb7-1c76f859b683&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

