### PR TITLE
refactor: use pubkyring auth handler until multiple apps are supported

### DIFF
--- a/src/components/organisms/Scan/Scan.test.tsx.snap
+++ b/src/components/organisms/Scan/Scan.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`Scan Components - Snapshots > ScanFooter - Snapshots > matches snapshot
   >
     Pubky Ring
   </a>
-   or any other 
+  , powered by 
   <a
     data-testid="link"
     href="https://pubky.org"
@@ -94,7 +94,7 @@ exports[`Scan Components - Snapshots > ScanFooter - Snapshots > matches snapshot
   >
     Pubky Core
   </a>
-  –powered keychain.
+  .
 </div>
 `;
 

--- a/src/components/organisms/Scan/Scan.tsx
+++ b/src/components/organisms/Scan/Scan.tsx
@@ -121,11 +121,11 @@ export const ScanFooter = () => {
       <Link href={getPubkyRingLink()} target="_blank">
         {'Pubky Ring'}
       </Link>
-      {' or any other '}
+      {', powered by '}
       <Link href={getPubkyCoreLink()} target="_blank">
         {'Pubky Core'}
       </Link>
-      {'–powered keychain.'}
+      {'.'}
     </FooterLinks>
   );
 };

--- a/src/hooks/useAuthUrl/useAuthUrl.test.tsx
+++ b/src/hooks/useAuthUrl/useAuthUrl.test.tsx
@@ -65,7 +65,7 @@ describe('useAuthUrl', () => {
   const createCancelAuthFlow = (): (() => void) => vi.fn();
 
   it('fetches auth URL on mount when autoFetch is enabled', async () => {
-    const mockAuthUrl = 'pubkyring://authorize?token=test123';
+    const mockAuthUrl = 'pubkyauth://signin?token=test123';
     const mockAwaitApproval = new Promise<Session>(() => {});
 
     mockGetAuthUrl.mockResolvedValue({
@@ -80,11 +80,27 @@ describe('useAuthUrl', () => {
     expect(result.current.url).toBe('');
 
     await waitFor(() => {
-      expect(result.current.url).toBe(mockAuthUrl);
+      expect(result.current.url).toBe('pubkyring://signin?token=test123');
       expect(result.current.isLoading).toBe(false);
     });
 
     expect(mockGetAuthUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('converts pubkyauth:// authorization URLs to Pubky Ring deeplinks', async () => {
+    mockGetAuthUrl.mockResolvedValue({
+      authorizationUrl: 'pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https%3A%2F%2Frelay.example&secret=abc',
+      awaitApproval: new Promise<Session>(() => {}),
+      cancelAuthFlow: createCancelAuthFlow(),
+    });
+
+    const { result } = renderHook(() => useAuthUrl());
+
+    await waitFor(() => {
+      expect(result.current.url).toBe(
+        'pubkyring://signin?caps=/pub/pubky.app/:rw&relay=https%3A%2F%2Frelay.example&secret=abc',
+      );
+    });
   });
 
   it('does not auto-fetch when autoFetch is false', () => {
@@ -97,7 +113,7 @@ describe('useAuthUrl', () => {
 
   it('allows manual fetchUrl calls', async () => {
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=manual',
+      authorizationUrl: 'pubkyauth://signin?token=manual',
       awaitApproval: new Promise<Session>(() => {}),
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -109,7 +125,7 @@ describe('useAuthUrl', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.url).toBe('pubkyring://authorize?token=manual');
+      expect(result.current.url).toBe('pubkyring://signin?token=manual');
       expect(result.current.isLoading).toBe(false);
     });
   });
@@ -123,7 +139,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=approval',
+      authorizationUrl: 'pubkyauth://signin?token=approval',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -148,7 +164,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=rejection',
+      authorizationUrl: 'pubkyauth://signin?token=rejection',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -176,7 +192,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=canceled',
+      authorizationUrl: 'pubkyauth://signin?token=canceled',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -202,7 +218,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=session-expired',
+      authorizationUrl: 'pubkyauth://signin?token=session-expired',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -237,7 +253,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=timeout',
+      authorizationUrl: 'pubkyauth://signin?token=timeout',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -274,7 +290,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=init-failure',
+      authorizationUrl: 'pubkyauth://signin?token=init-failure',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -312,7 +328,7 @@ describe('useAuthUrl', () => {
 
   it('does not cancel active auth flow on unmount', async () => {
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=unmount',
+      authorizationUrl: 'pubkyauth://signin?token=unmount',
       awaitApproval: new Promise<Session>(() => {}),
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -336,7 +352,7 @@ describe('useAuthUrl', () => {
     });
 
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=post-unmount',
+      authorizationUrl: 'pubkyauth://signin?token=post-unmount',
       awaitApproval: mockAwaitApproval,
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -356,7 +372,7 @@ describe('useAuthUrl', () => {
   });
 
   it('calls AuthController.getSignupAuthUrl when type is signup with inviteCode', async () => {
-    const mockAuthUrl = 'pubkyring://authorize?token=signup';
+    const mockAuthUrl = 'pubkyauth://signup?token=signup';
 
     mockGetSignupAuthUrl.mockResolvedValue({
       authorizationUrl: mockAuthUrl,
@@ -367,7 +383,7 @@ describe('useAuthUrl', () => {
     const { result } = renderHook(() => useAuthUrl({ type: 'signup', inviteCode: 'A9KM-7MJP-ERM9' }));
 
     await waitFor(() => {
-      expect(result.current.url).toBe(mockAuthUrl);
+      expect(result.current.url).toBe('pubkyring://signup?token=signup');
       expect(result.current.isLoading).toBe(false);
     });
 
@@ -377,7 +393,7 @@ describe('useAuthUrl', () => {
 
   it('copyAuthUrl copies url to clipboard', async () => {
     mockGetAuthUrl.mockResolvedValue({
-      authorizationUrl: 'pubkyring://authorize?token=copy',
+      authorizationUrl: 'pubkyauth://signin?token=copy',
       awaitApproval: new Promise<Session>(() => {}),
       cancelAuthFlow: createCancelAuthFlow(),
     });
@@ -385,14 +401,14 @@ describe('useAuthUrl', () => {
     const { result } = renderHook(() => useAuthUrl());
 
     await waitFor(() => {
-      expect(result.current.url).toBe('pubkyring://authorize?token=copy');
+      expect(result.current.url).toBe('pubkyring://signin?token=copy');
     });
 
     await act(async () => {
       await result.current.copyAuthUrl();
     });
 
-    expect(mockCopyToClipboard).toHaveBeenCalledWith({ text: 'pubkyring://authorize?token=copy' });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith({ text: 'pubkyring://signin?token=copy' });
   });
 
   it('copyAuthUrl does nothing when url is empty', async () => {

--- a/src/hooks/useAuthUrl/useAuthUrl.tsx
+++ b/src/hooks/useAuthUrl/useAuthUrl.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Session } from '@synonymdev/pubky';
 import { AuthController } from '@/controllers/auth/auth';
+import { generatePubkyRingAuthDeeplink } from '@/libs/deeplink/deeplink';
 import { AuthErrorCode } from '@/libs/error/error.codes';
 import { isAppError, isAuthError, isTimeoutError } from '@/libs/error/error.utils';
 import { Logger } from '@/libs/logger/logger';
@@ -85,7 +86,10 @@ export function useAuthUrl(options: UseAuthUrlOptions = {}): UseAuthUrlReturn {
         });
 
       if (!isMountedRef.current) return;
-      setUrl(authorizationUrl ?? '');
+      // Expose the Pubky-Ring-targeted deeplink everywhere (QR, copy, tap-to-open): the
+      // generic pubkyauth:// scheme is also registered by other apps (e.g. Bitkit), so OS
+      // scheme resolution can route it away from Ring. Revisit if other signers are supported.
+      setUrl(generatePubkyRingAuthDeeplink(authorizationUrl ?? ''));
     } catch (error) {
       Logger.error('Failed to generate auth URL:', error);
       if (!isMountedRef.current) return;

--- a/src/hooks/useAuthUrl/useAuthUrl.types.ts
+++ b/src/hooks/useAuthUrl/useAuthUrl.types.ts
@@ -16,7 +16,11 @@ export type UseAuthUrlOptions =
     };
 
 export interface UseAuthUrlReturn {
-  /** The authorization URL for QR code or deeplink */
+  /**
+   * The authorization deeplink for QR code, copy, and tap-to-open. `pubkyauth://` URLs are
+   * rewritten to the Pubky-Ring-targeted `pubkyring://` scheme; any other shape the controller
+   * returns passes through unchanged. Empty until fetched or after the flow expires.
+   */
   url: string;
   /** Whether the auth URL is currently being generated */
   isLoading: boolean;

--- a/src/hooks/useMobileAuth/useMobileAuth.test.tsx
+++ b/src/hooks/useMobileAuth/useMobileAuth.test.tsx
@@ -12,7 +12,7 @@ vi.mock('../useAuthUrl/useAuthUrl', () => ({
 
 describe('useMobileAuth', () => {
   const defaultAuthUrlReturn = {
-    url: 'pubkyauth://signin?token=test123',
+    url: 'pubkyring://signin?token=test123',
     isLoading: false,
     isExpired: false,
     fetchUrl: mockFetchUrl,
@@ -27,7 +27,7 @@ describe('useMobileAuth', () => {
   it('returns useAuthUrl data plus hook values', () => {
     const { result } = renderHook(() => useMobileAuth());
 
-    expect(result.current.url).toBe('pubkyauth://signin?token=test123');
+    expect(result.current.url).toBe('pubkyring://signin?token=test123');
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isExpired).toBe(false);
     expect(result.current.fetchUrl).toBe(mockFetchUrl);
@@ -79,7 +79,7 @@ describe('useMobileAuth', () => {
     });
 
     expect(result.current.isOpeningRing).toBe(true);
-    expect(mockLocation.href).toBe('pubkyauth://signin?token=test123');
+    expect(mockLocation.href).toBe('pubkyring://signin?token=test123');
 
     Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
   });

--- a/src/libs/deeplink/deeplink.test.ts
+++ b/src/libs/deeplink/deeplink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { GenerateDeeplinkOptions, generatePubkyRingDeeplink } from './deeplink';
+import { GenerateDeeplinkOptions, generatePubkyRingAuthDeeplink, generatePubkyRingDeeplink } from './deeplink';
 
 describe('generatePubkyRingDeeplink', () => {
   describe('basic functionality', () => {
@@ -159,5 +159,40 @@ describe('generatePubkyRingDeeplink', () => {
 
       expect(result).toBe('pubkyring://test');
     });
+  });
+});
+
+describe('generatePubkyRingAuthDeeplink', () => {
+  // Fixtures mirror the real URL shapes: the SDK emits signin URLs with an unencoded query,
+  // while HomeserverService.generateSignupAuthUrl re-serializes the query via URLSearchParams,
+  // percent-encoding caps and relay.
+  it('should replace the pubkyauth scheme on signin URLs', () => {
+    const authUrl = 'pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/link/&secret=abc123';
+    const result = generatePubkyRingAuthDeeplink(authUrl);
+
+    expect(result).toBe(
+      'pubkyring://signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/link/&secret=abc123',
+    );
+  });
+
+  it('should replace the pubkyauth scheme on signup URLs', () => {
+    const authUrl =
+      'pubkyauth://signup?caps=%2Fpub%2Fpubky.app%2F%3Arw&relay=https%3A%2F%2Fhttprelay.pubky.app%2Flink%2F&secret=abc123&hs=homeserver-z32&st=ABCD-1234-WXYZ';
+    const result = generatePubkyRingAuthDeeplink(authUrl);
+
+    expect(result).toBe(
+      'pubkyring://signup?caps=%2Fpub%2Fpubky.app%2F%3Arw&relay=https%3A%2F%2Fhttprelay.pubky.app%2Flink%2F&secret=abc123&hs=homeserver-z32&st=ABCD-1234-WXYZ',
+    );
+  });
+
+  it('should not nest schemes', () => {
+    const result = generatePubkyRingAuthDeeplink('pubkyauth://signin?secret=abc');
+
+    expect(result).toBe('pubkyring://signin?secret=abc');
+  });
+
+  it('should return non-pubkyauth URLs unchanged', () => {
+    expect(generatePubkyRingAuthDeeplink('https://example.com/auth')).toBe('https://example.com/auth');
+    expect(generatePubkyRingAuthDeeplink('')).toBe('');
   });
 });

--- a/src/libs/deeplink/deeplink.ts
+++ b/src/libs/deeplink/deeplink.ts
@@ -7,3 +7,18 @@ export const generatePubkyRingDeeplink = (value: string, options: GenerateDeepli
   const payload = encode ? encodeURIComponent(value) : value;
   return `pubkyring://${payload}`;
 };
+
+const PUBKYAUTH_PREFIX = 'pubkyauth://';
+
+/**
+ * Converts a `pubkyauth://signin?...` or `pubkyauth://signup?...` authorization URL into a
+ * deeplink targeting Pubky Ring exclusively (`pubkyring://signin?...` / `pubkyring://signup?...`),
+ * since other apps (e.g. Bitkit) also register the generic `pubkyauth` scheme.
+ *
+ * The scheme is replaced, not prefixed: a nested `pubkyring://pubkyauth://...` URL gets the inner
+ * colon stripped by Android URI normalization into a form Pubky Ring cannot parse (see #748).
+ */
+export const generatePubkyRingAuthDeeplink = (authUrl: string): string => {
+  if (!authUrl.startsWith(PUBKYAUTH_PREFIX)) return authUrl;
+  return `pubkyring://${authUrl.slice(PUBKYAUTH_PREFIX.length)}`;
+};


### PR DESCRIPTION
# fix(auth): target Pubky Ring exclusively for auth deeplinks and QR codes

## 🐛 Problem

On Android, tapping **"Authorize with Pubky Ring"** could open **Bitkit** instead of Pubky Ring. The button (and the sign-in/signup QR codes) handed the generic `pubkyauth://` URL to the OS, and Bitkit also registers that scheme in its Android manifest. Worse, Bitkit's deeplink handler silently drops `pubkyauth://` URIs when its Paykit feature flag is off (the default), so affected users landed on Bitkit's home screen with **no error and no auth sheet** — a complete dead end. The same ambiguity applied to scanning our QR codes with the system camera app.

The Bitkit team has been notified about their side of this (unconditional scheme registration + silent drop).

## 🔧 Fix

Convert the SDK's authorization URL to a **Pubky-Ring-exclusive deeplink** at the single point where it enters UI state (`useAuthUrl`):

```
pubkyauth://signin?caps=...  →  pubkyring://signin?caps=...
pubkyauth://signup?caps=...  →  pubkyring://signup?caps=...
```

Only Pubky Ring registers the `pubkyring` scheme, so OS scheme resolution can no longer route the link elsewhere. Because the conversion happens at the source, every surface inherits it consistently: the tap-to-open button, both QR codes (desktop sign-in + onboarding signup), and copy-link.

### Why scheme *replacement* instead of a `pubkyring://` prefix

A prefix wrapper was tried before and reverted in #748: Android URI normalization strips the inner colon of a nested scheme (`pubkyring://pubkyauth://signin?...` → `pubkyring://pubkyauth//signin?...`), which Pubky Ring cannot parse. Scheme replacement produces the exact deeplink forms Ring's input parser explicitly supports and unit-tests (`pubkyring://signin?...` / `pubkyring://signup?...`) — there is no nested scheme left to mangle.

## ✅ Verification

- **Bitkit collision confirmed**: both Pubky Ring and Bitkit register `pubkyauth` in their Android manifests; Bitkit's `processDeeplink` silently returns when `isPaykitEnabled` is false (default).
- **SDK URL shape confirmed**: `@synonymdev/pubky` 0.8.0 emits `pubkyauth://signin?caps=` / `pubkyauth://signup?caps=` (verified against the WASM binary).
- **Ring compatibility confirmed**: Ring's parser normalizes `pubkyring://signin|signup?...` and `pubkyauth://signin|signup?...` onto the same code path with byte-identical query parsing, for all input sources (deeplink, QR scan, clipboard paste). Support predates January 2026, so no minimum-app-version concern.
- **The relay handshake is untouched**: internal layers still produce and use the canonical `pubkyauth://` URL; only the user-facing string changes.
- Adversarial code review completed; findings addressed in this PR (test pinning, doc contract, stale copy) or deferred with rationale (see below).

## 📝 Changes

- `src/libs/deeplink/deeplink.ts` — new `generatePubkyRingAuthDeeplink()` helper (scheme replacement, pass-through for non-`pubkyauth://` input)
- `src/hooks/useAuthUrl/useAuthUrl.tsx` — apply the conversion where the URL enters React state
- `src/hooks/useAuthUrl/useAuthUrl.types.ts` — document the actual `url` contract
- `src/components/organisms/Scan/Scan.tsx` — footer copy updated: the QR is Ring-targeted now, so it no longer claims "any other Pubky Core–powered keychain" support (+ regenerated text snapshot)
- Tests — fixtures now mirror the real SDK/service URL shapes (signin unencoded, signup percent-encoded), and the conversion is pinned across mount-fetch, manual fetch, signup, and clipboard-copy paths

## 📌 Notes

- **Behavior when Ring is not installed**: nothing opens (the scheme has exactly one possible handler). The pre-existing "Opening Pubky Ring…" spinner without a timeout fallback is a known issue and will be addressed separately — it predates this change.
- The `OnboardingScanPage` VRT baseline will regenerate in CI (footer copy change).
- If broader signer support ships later, the conversion is one presentation-layer call site to revisit.

_This pull request summary was generated, for full implementation details please reference the file changes._
