### PR TITLE
fix(ui): restore post header popover hover target

### DIFF
--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx
@@ -534,24 +534,26 @@ describe('PostHeaderUserInfo - Navigation', () => {
       'items-center',
     );
     expect(usernameLink.parentElement).toHaveClass('max-w-full', 'min-w-0');
-    expect(usernameLink).toHaveClass('block', 'w-full', 'min-w-0', 'max-w-full', 'overflow-hidden');
+    expect(usernameLink).toHaveClass('block', 'w-fit', 'min-w-0', 'max-w-full', 'overflow-hidden');
     expect(screen.getByText(longName)).toHaveClass('w-full', 'truncate', 'max-w-full');
   });
 
-  it('keeps the popover hover target constrained with max-w-full', () => {
+  it('keeps the popover hover target hugging the user info instead of the whole header row', () => {
     render(<PostHeaderUserInfo userId="testuser123" userName="Test User" />);
 
     const userInfoRoot = screen.getByTestId('popover-trigger').firstElementChild;
 
-    expect(userInfoRoot).toHaveClass('w-full', 'max-w-full', 'min-w-0');
+    expect(userInfoRoot).toHaveClass('w-fit', 'max-w-full', 'min-w-0');
+    expect(userInfoRoot).not.toHaveClass('w-full');
   });
 
-  it('keeps the username link constrained so long names truncate', () => {
+  it('keeps the username link hugging its text so it is not clickable across the header row', () => {
     render(<PostHeaderUserInfo userId="testuser123" userName="Test User" showPopover={false} />);
 
     const usernameLink = screen.getAllByTestId('profile-link')[1];
 
-    expect(usernameLink).toHaveClass('w-full', 'max-w-full', 'min-w-0', 'overflow-hidden');
+    expect(usernameLink).toHaveClass('w-fit', 'max-w-full', 'min-w-0', 'overflow-hidden');
+    expect(usernameLink).not.toHaveClass('w-full');
   });
 });
 

--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx.snap
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot for current user (no 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -36,7 +36,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot for current user (no 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile"
         >
@@ -94,7 +94,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot when following 1`] = 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -120,7 +120,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot when following 1`] = 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/otherUser123"
         >
@@ -170,7 +170,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot when following 1`] = 
 
 exports[`PostHeaderUserInfo - Snapshots > matches snapshot with a visually hidden avatar 1`] = `
 <div
-  class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+  class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-full gap-3"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -201,7 +201,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with a visually hidde
     data-testid="container"
   >
     <a
-      class="block w-full max-w-full min-w-0 overflow-hidden"
+      class="block w-fit max-w-full min-w-0 overflow-hidden"
       data-testid="profile-link"
       href="/profile/snapshotUserKey"
     >
@@ -238,7 +238,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all new props 1`
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-5"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-5"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -269,7 +269,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all new props 1`
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -332,7 +332,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all props 1`] = 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -363,7 +363,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with all props 1`] = 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -445,7 +445,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with bio 1`] = `
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -471,7 +471,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with bio 1`] = `
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -521,7 +521,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with bio 1`] = `
 
 exports[`PostHeaderUserInfo - Snapshots > matches snapshot with character count in the metadata row 1`] = `
 <div
-  class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+  class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-full gap-3"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -547,7 +547,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with character count 
     data-testid="container"
   >
     <a
-      class="block w-full max-w-full min-w-0 overflow-hidden"
+      class="block w-fit max-w-full min-w-0 overflow-hidden"
       data-testid="profile-link"
       href="/profile/snapshotUserKey"
     >
@@ -584,7 +584,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with character count 
 
 exports[`PostHeaderUserInfo - Snapshots > matches snapshot with character count in the name row 1`] = `
 <div
-  class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+  class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-full gap-3"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -615,7 +615,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with character count 
       data-testid="container"
     >
       <a
-        class="block w-full max-w-full min-w-0 overflow-hidden"
+        class="block w-fit max-w-full min-w-0 overflow-hidden"
         data-testid="profile-link"
         href="/profile/snapshotUserKey"
       >
@@ -661,7 +661,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with extraLarge size 
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-5"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-5"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -687,7 +687,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with extraLarge size 
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -745,7 +745,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with large size 1`] =
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-4"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-4"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -771,7 +771,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with large size 1`] =
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -829,7 +829,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with minimal props 1`
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -855,7 +855,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with minimal props 1`
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/user123"
         >
@@ -913,7 +913,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with timeAgo 1`] = `
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -939,7 +939,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot with timeAgo 1`] = `
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >
@@ -1002,7 +1002,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot without avatarUrl 1`]
     data-testid="popover-trigger"
   >
     <div
-      class="grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      class="grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center w-fit gap-3"
       data-override-defaults="true"
       data-testid="container"
     >
@@ -1028,7 +1028,7 @@ exports[`PostHeaderUserInfo - Snapshots > matches snapshot without avatarUrl 1`]
         data-testid="container"
       >
         <a
-          class="block w-full max-w-full min-w-0 overflow-hidden"
+          class="block w-fit max-w-full min-w-0 overflow-hidden"
           data-testid="profile-link"
           href="/profile/snapshotUserKey"
         >

--- a/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
+++ b/src/components/molecules/PostHeaderUserInfo/PostHeaderUserInfo.tsx
@@ -88,7 +88,7 @@ export function PostHeaderUserInfo({
   );
 
   const userNameContent = (
-    <Link href={profileUrl} onClick={handleLinkClick} className="block w-full max-w-full min-w-0 overflow-hidden">
+    <Link href={profileUrl} onClick={handleLinkClick} className="block w-fit max-w-full min-w-0 overflow-hidden">
       <Typography
         className={cn(
           'block w-full max-w-full cursor-pointer truncate font-bold text-foreground',
@@ -101,14 +101,17 @@ export function PostHeaderUserInfo({
     </Link>
   );
 
-  // This container is also the UserInfoPopover hover target, so it must hug the avatar and
-  // name instead of stretching across the header row — otherwise the empty space next to the
-  // timestamp opens the popover. `max-w-full` keeps long names truncating inside tight layouts.
+  // This container is also the UserInfoPopover hover target when showPopover is true, so it
+  // must hug the avatar and name (`w-fit`) instead of stretching across the header row —
+  // otherwise the empty space next to the timestamp opens the popover. Keep `w-full` when the
+  // popover is off (composer) so the character count can sit on the trailing edge. `max-w-full`
+  // keeps long names truncating inside tight layouts.
   const content = (
     <Container
       overrideDefaults
       className={cn(
-        'grid w-full max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center',
+        'grid max-w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center',
+        showPopover ? 'w-fit' : 'w-full',
         GAP_CLASS_BY_HEADER_SIZE[size],
       )}
     >


### PR DESCRIPTION
## Summary
- Restore the #2304 post-header popover hover target after #2285 stretched it across the full header row.
- Feed posts use `w-fit` on the trigger so the profile card opens only over the avatar and name, not empty space next to the timestamp.
- Composer headers keep `w-full` (`showPopover={false}`) so the character count still sits on the trailing edge.
- Restore the regression tests that assert the trigger and username link are not full-width.

## Test plan
- [ ] Hover a feed post header in the gap next to the timestamp — the profile popover should not open
- [ ] Hover the avatar and display name — the profile popover should still open
- [ ] Click empty space in the header row — it should not navigate to the author's profile
- [ ] Confirm long display names still truncate without overflowing the header
- [ ] Confirm the composer character count still aligns to the trailing edge when expanded