### PR TITLE
feat(ui): refine article previews in feed

### DIFF
--- a/src/components/molecules/PostText/PostText.test.tsx
+++ b/src/components/molecules/PostText/PostText.test.tsx
@@ -400,6 +400,13 @@ describe('PostText', () => {
   });
 
   describe('Article mode (isArticle prop)', () => {
+    it('renders feed preview copy with the secondary foreground color', () => {
+      render(<PostText content="Article preview copy" isArticle />);
+
+      expect(screen.getByTestId('container')).toHaveClass('text-secondary-foreground');
+      expect(screen.getByTestId('container')).not.toHaveClass('text-muted-foreground');
+    });
+
     it('renders h1 heading when isArticle is true', () => {
       render(<PostText content="# Heading 1" isArticle />);
 

--- a/src/components/molecules/PostText/PostText.test.tsx.snap
+++ b/src/components/molecules/PostText/PostText.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PostText - Snapshots > matches snapshot for article preview with headings and paragraphs 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-muted-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -33,7 +33,7 @@ exports[`PostText - Snapshots > matches snapshot for article preview with headin
 
 exports[`PostText - Snapshots > matches snapshot for article preview with long content 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-muted-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -45,7 +45,7 @@ exports[`PostText - Snapshots > matches snapshot for article preview with long c
 
 exports[`PostText - Snapshots > matches snapshot for article preview with multiple headings 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-muted-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >
@@ -121,7 +121,7 @@ exports[`PostText - Snapshots > matches snapshot for article showing full conten
 
 exports[`PostText - Snapshots > matches snapshot for article with h1 heading 1`] = `
 <div
-  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-muted-foreground"
+  class="text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground"
   data-override-defaults="true"
   data-testid="container"
 >

--- a/src/components/molecules/PostText/PostText.tsx
+++ b/src/components/molecules/PostText/PostText.tsx
@@ -83,7 +83,6 @@ export const PostText = memo(function PostText({ content, isArticle, onLinkClick
       overrideDefaults
       className={cn(
         'text-base leading-6 font-medium wrap-anywhere whitespace-pre-line text-secondary-foreground',
-        isArticle && !onPostPage ? 'text-muted-foreground' : 'text-secondary-foreground',
         className,
       )}
     >

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx
@@ -193,6 +193,12 @@ describe('PostArticle', () => {
       expect(postText).toHaveAttribute('data-is-article', 'true');
     });
 
+    it('limits article preview copy to three lines', () => {
+      render(<PostArticle {...defaultProps} />);
+
+      expect(screen.getByTestId('post-text')).toHaveClass('line-clamp-3');
+    });
+
     it('passes onLinkClick handler to PostText', () => {
       render(<PostArticle {...defaultProps} />);
 
@@ -208,11 +214,16 @@ describe('PostArticle', () => {
       expect(dialog).toHaveAttribute('data-open', 'false');
     });
 
-    it('renders typography with large size', () => {
+    it('renders an xl title with a size-5 newspaper icon and gap-2', () => {
       render(<PostArticle {...defaultProps} />);
 
       const typography = screen.getByTestId('typography');
-      expect(typography).toHaveAttribute('data-size', 'lg');
+      const titleRow = typography.parentElement;
+      const newspaperIcon = titleRow?.querySelector('.lucide-newspaper');
+
+      expect(typography).toHaveClass('text-xl');
+      expect(titleRow).toHaveClass('gap-2');
+      expect(newspaperIcon).toHaveClass('size-5');
     });
   });
 
@@ -324,11 +335,18 @@ describe('PostArticle', () => {
       render(<PostArticle {...defaultProps} />);
 
       const image = screen.getByTestId('cover-image');
-      expect(image).toHaveClass('h-25');
-      expect(image).toHaveClass('w-45');
+      expect(image).toHaveClass('aspect-video');
+      expect(image).toHaveClass('h-auto');
+      expect(image).toHaveClass('w-full');
       expect(image).toHaveClass('rounded-md');
       expect(image).toHaveClass('object-cover');
       expect(image).toHaveClass('object-center');
+      expect(image).toHaveClass('lg:aspect-auto');
+      expect(image).toHaveClass('lg:h-25');
+      expect(image).toHaveClass('lg:w-45');
+      expect(image).toHaveClass('@max-xl/grid:aspect-video!');
+      expect(image).toHaveClass('@max-xl/grid:h-auto!');
+      expect(image).toHaveClass('@max-xl/grid:w-full!');
     });
   });
 

--- a/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
+++ b/src/components/organisms/PostArticle/PostArticle.test.tsx.snap
@@ -10,14 +10,50 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        Test Article Title
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          Test Article Title
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
@@ -27,7 +63,7 @@ exports[`PostArticle > Snapshots > matches snapshot with cover image 1`] = `
     </div>
     <img
       alt="Cover Image"
-      class="h-25 w-45 rounded-md object-cover object-center"
+      class="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
       data-testid="cover-image"
       height="100"
       src="https://example.com/cover-image.jpg"
@@ -58,14 +94,50 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        Test Article Title
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          Test Article Title
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
@@ -75,7 +147,7 @@ exports[`PostArticle > Snapshots > matches snapshot with custom className 1`] = 
     </div>
     <img
       alt="Cover Image"
-      class="h-25 w-45 rounded-md object-cover object-center"
+      class="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
       data-testid="cover-image"
       height="100"
       src="https://example.com/cover-image.jpg"
@@ -106,14 +178,50 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        Test Article Title
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          Test Article Title
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
@@ -123,7 +231,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local cover image 1`] =
     </div>
     <img
       alt="Local Cover Image"
-      class="h-25 w-45 rounded-md object-cover object-center"
+      class="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
       data-testid="cover-image"
       height="100"
       src="blob:http://localhost/local-cover-image"
@@ -154,14 +262,50 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        Test Article Title
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          Test Article Title
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
@@ -171,7 +315,7 @@ exports[`PostArticle > Snapshots > matches snapshot with local video attachment 
     </div>
     <img
       alt="Cover Image"
-      class="h-25 w-45 rounded-md object-cover object-center"
+      class="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
       data-testid="cover-image"
       height="100"
       src="https://example.com/cover-image.jpg"
@@ -202,14 +346,50 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        This is a very long article title that might wrap to multiple lines in the UI
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          This is a very long article title that might wrap to multiple lines in the UI
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"
@@ -219,7 +399,7 @@ exports[`PostArticle > Snapshots > matches snapshot with long title and body 1`]
     </div>
     <img
       alt="Cover Image"
-      class="h-25 w-45 rounded-md object-cover object-center"
+      class="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
       data-testid="cover-image"
       height="100"
       src="https://example.com/cover-image.jpg"
@@ -250,14 +430,50 @@ exports[`PostArticle > Snapshots > matches snapshot without cover image 1`] = `
       class="gap-y-1"
       data-testid="container"
     >
-      <span
-        class="wrap-anywhere"
-        data-size="lg"
-        data-testid="typography"
-      >
-        Test Article Title
-      </span>
       <div
+        class="flex-row items-start gap-2"
+        data-testid="container"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-newspaper mt-1 size-5 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 18h-5"
+          />
+          <path
+            d="M18 14h-8"
+          />
+          <path
+            d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"
+          />
+          <rect
+            height="4"
+            rx="1"
+            width="8"
+            x="10"
+            y="6"
+          />
+        </svg>
+        <span
+          class="min-w-0 text-xl wrap-anywhere"
+          data-size="lg"
+          data-testid="typography"
+        >
+          Test Article Title
+        </span>
+      </div>
+      <div
+        class="line-clamp-3"
         data-has-link-click="true"
         data-is-article="true"
         data-testid="post-text"

--- a/src/components/organisms/PostArticle/PostArticle.tsx
+++ b/src/components/organisms/PostArticle/PostArticle.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Newspaper } from 'lucide-react';
 import { Container } from '@/atoms/Container/Container';
 import { Image } from '@/atoms/Image/Image';
 import { Typography } from '@/atoms/Typography/Typography';
@@ -38,18 +39,21 @@ export const PostArticle = ({ content, attachments, localAttachments, className 
     <>
       <Container className={cn('justify-between gap-6 lg:flex-row @max-xl/grid:flex-col!', className)}>
         <Container className="gap-y-1">
-          <Typography size="lg" className="wrap-anywhere">
-            {title}
-          </Typography>
+          <Container className="flex-row items-start gap-2">
+            <Newspaper aria-hidden="true" className="mt-1 size-5 shrink-0" />
+            <Typography size="lg" className="min-w-0 text-xl wrap-anywhere">
+              {title}
+            </Typography>
+          </Container>
 
-          <PostText content={body} isArticle onLinkClick={handleLinkClick} />
+          <PostText content={body} isArticle onLinkClick={handleLinkClick} className="line-clamp-3" />
         </Container>
 
         {finalCoverImage && (
           <Image
             src={finalCoverImage.src}
             alt={finalCoverImage.alt}
-            className="h-25 w-45 rounded-md object-cover object-center"
+            className="aspect-video h-auto w-full rounded-md object-cover object-center lg:aspect-auto lg:h-25 lg:w-45 @max-xl/grid:aspect-video! @max-xl/grid:h-auto! @max-xl/grid:w-full!"
             width={180}
             height={100}
           />


### PR DESCRIPTION
Title: feat(ui): refine article previews in feed

## Summary

- use the secondary foreground color and a three-line clamp for article preview copy
- render article titles at `text-xl` with a `size-5` newspaper icon and `gap-2`
- display cover images full-width at 16:9 on mobile and stacked grid cards
- retain the compact cover thumbnail in wide desktop layouts
- add focused assertions and update component snapshots

## Why

Article previews now have clearer hierarchy, more predictable text length, match the intended design and layout better, align cleaner with the article image, and article images make better use of available space on narrow layouts.

## Validation

- `npm test -- src/components/molecules/PostText/PostText.test.tsx src/components/organisms/PostArticle/PostArticle.test.tsx` — 178 tests passed
- focused ESLint checks passed
- focused Prettier checks passed
- `npm run typecheck`