### PR TITLE
fix(posts): improves article tags rendering in column view

### DIFF
--- a/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx
+++ b/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx
@@ -149,6 +149,29 @@ vi.mock('../PostTagsPanel/PostTagsPanel', () => ({
   ),
 }));
 
+vi.mock('../PostInlineTagsActions/PostInlineTagsActions', () => ({
+  PostInlineTagsActions: ({
+    postId,
+    onReplyClick,
+    onRepostClick,
+    className,
+  }: {
+    postId: string;
+    onReplyClick: () => void;
+    onRepostClick: () => void;
+    className?: string;
+  }) => (
+    <div data-testid="post-inline-tags-actions" data-post-id={postId} className={className}>
+      <button data-testid="inline-reply-button" onClick={onReplyClick}>
+        Reply
+      </button>
+      <button data-testid="inline-repost-button" onClick={onRepostClick}>
+        Repost
+      </button>
+    </div>
+  ),
+}));
+
 const mockUsePostArticle = vi.mocked(usePostArticle);
 const mockUseLocalFilesStore = vi.mocked(useLocalFilesStore);
 
@@ -181,13 +204,15 @@ describe('PostArticleDetail', () => {
     mockUseLocalFilesStore.mockImplementation((selector) => selector(createMockLocalFilesStore()));
   });
 
-  it('renders article detail content and both tag panels', () => {
+  it('renders article detail content with inline tags and actions in columns layout', () => {
     render(<PostArticleDetail {...defaultProps} />);
 
     expect(screen.getByText('Test Article Title')).toBeInTheDocument();
     expect(screen.getByTestId('post-header')).toHaveAttribute('data-post-id', 'user123:post456');
     expect(screen.getByTestId('post-text')).toHaveTextContent('Test article body content');
-    expect(screen.getAllByTestId('post-tags-panel')).toHaveLength(2);
+    expect(screen.getByTestId('post-inline-tags-actions')).toHaveAttribute('data-post-id', 'user123:post456');
+    expect(screen.queryByTestId('post-tags-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('post-actions-bar')).not.toBeInTheDocument();
     expect(screen.queryByText('Replies')).not.toBeInTheDocument();
   });
 
@@ -197,7 +222,7 @@ describe('PostArticleDetail', () => {
     const containers = screen.getAllByTestId('container');
     expect(containers.some((el) => el.className.includes('mb-6 gap-6'))).toBe(true);
     expect(containers.some((el) => el.className.includes('lg:grid-cols-3'))).toBe(false);
-    expect(containers.some((el) => el.className.includes('max-w-2/4'))).toBe(true);
+    expect(screen.getByTestId('post-inline-tags-actions')).toHaveClass('mt-3', 'mb-6');
   });
 
   it('keeps the side tags grid layout in wide mode', () => {
@@ -207,7 +232,9 @@ describe('PostArticleDetail', () => {
 
     const containers = screen.getAllByTestId('container');
     expect(containers.some((el) => el.className.includes('lg:grid-cols-3'))).toBe(true);
-    expect(containers.some((el) => el.className.includes('max-w-2/4'))).toBe(false);
+    expect(screen.getAllByTestId('post-tags-panel')).toHaveLength(2);
+    expect(screen.getByTestId('post-actions-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-inline-tags-actions')).not.toBeInTheDocument();
   });
 
   it('renders the article title as h1', () => {
@@ -253,6 +280,23 @@ describe('PostArticleDetail', () => {
 
     expect(screen.getByTestId('cover-image')).toHaveAttribute('src', 'https://example.com/image.jpg');
     expect(screen.getByTestId('cover-image')).toHaveAttribute('alt', 'Cover image');
+  });
+
+  it('places inline tags and actions between the user header and cover image in columns layout', () => {
+    mockUsePostArticle.mockReturnValue({
+      title: 'Test Title',
+      body: 'Test body',
+      coverImage: {
+        src: 'https://example.com/image.jpg',
+        alt: 'Cover image',
+      },
+    });
+
+    render(<PostArticleDetail {...defaultProps} />);
+
+    const inlineTagsActions = screen.getByTestId('post-inline-tags-actions');
+    expect(screen.getByTestId('post-header').nextElementSibling).toBe(inlineTagsActions);
+    expect(inlineTagsActions.nextElementSibling).toBe(screen.getByTestId('cover-image'));
   });
 
   it('renders the cover image at a 16:9 ratio filling the frame', () => {
@@ -423,20 +467,20 @@ describe('PostArticleDetail', () => {
     expect(screen.queryByTestId('post-text')).not.toBeInTheDocument();
   });
 
-  it('opens reply and repost dialogs from the actions bar', () => {
+  it('opens reply and repost dialogs from the inline column actions', () => {
     render(<PostArticleDetail {...defaultProps} />);
 
-    fireEvent.click(screen.getByTestId('reply-button'));
+    fireEvent.click(screen.getByTestId('inline-reply-button'));
     expect(screen.getByTestId('dialog-reply')).toHaveAttribute('data-open', 'true');
 
-    fireEvent.click(screen.getByTestId('repost-button'));
+    fireEvent.click(screen.getByTestId('inline-repost-button'));
     expect(screen.getByTestId('dialog-repost')).toHaveAttribute('data-open', 'true');
   });
 
   it('closes reply dialog when the dialog open state changes', () => {
     render(<PostArticleDetail {...defaultProps} />);
 
-    fireEvent.click(screen.getByTestId('reply-button'));
+    fireEvent.click(screen.getByTestId('inline-reply-button'));
     expect(screen.getByTestId('dialog-reply')).toHaveAttribute('data-open', 'true');
 
     fireEvent.click(screen.getByTestId('close-reply-dialog'));
@@ -446,7 +490,7 @@ describe('PostArticleDetail', () => {
   it('closes repost dialog when the dialog open state changes', () => {
     render(<PostArticleDetail {...defaultProps} />);
 
-    fireEvent.click(screen.getByTestId('repost-button'));
+    fireEvent.click(screen.getByTestId('inline-repost-button'));
     expect(screen.getByTestId('dialog-repost')).toHaveAttribute('data-open', 'true');
 
     fireEvent.click(screen.getByTestId('close-repost-dialog'));

--- a/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx.snap
+++ b/src/components/organisms/PostArticleDetail/PostArticleDetail.test.tsx.snap
@@ -86,42 +86,22 @@ exports[`PostArticleDetail > matches snapshot when blurred 1`] = `
     <div
       class="mt-3 mb-6"
       data-post-id="user123:post456"
-      data-testid="post-actions-bar"
+      data-testid="post-inline-tags-actions"
     >
       <button
-        data-testid="tag-button"
-      >
-        Tag
-      </button>
-      <button
-        data-testid="reply-button"
+        data-testid="inline-reply-button"
       >
         Reply
       </button>
       <button
-        data-testid="repost-button"
+        data-testid="inline-repost-button"
       >
         Repost
       </button>
     </div>
     <div
-      class="mx-0 mb-6 max-w-2/4"
-      data-testid="container"
-    >
-      <div
-        class="mx-0 hidden lg:flex"
-        data-post-id="user123:post456"
-        data-testid="post-tags-panel"
-      />
-    </div>
-    <div
       data-post-id="user123:post456"
       data-testid="post-content-blurred"
-    />
-    <div
-      class="mt-6 flex lg:hidden"
-      data-post-id="user123:post456"
-      data-testid="post-tags-panel"
     />
   </div>
 </div>
@@ -151,33 +131,18 @@ exports[`PostArticleDetail > matches snapshot with cover image 1`] = `
     <div
       class="mt-3 mb-6"
       data-post-id="snapshot-user:cover-post"
-      data-testid="post-actions-bar"
+      data-testid="post-inline-tags-actions"
     >
       <button
-        data-testid="tag-button"
-      >
-        Tag
-      </button>
-      <button
-        data-testid="reply-button"
+        data-testid="inline-reply-button"
       >
         Reply
       </button>
       <button
-        data-testid="repost-button"
+        data-testid="inline-repost-button"
       >
         Repost
       </button>
-    </div>
-    <div
-      class="mx-0 mb-6 max-w-2/4"
-      data-testid="container"
-    >
-      <div
-        class="mx-0 hidden lg:flex"
-        data-post-id="snapshot-user:cover-post"
-        data-testid="post-tags-panel"
-      />
     </div>
     <img
       alt="Article cover"
@@ -191,11 +156,6 @@ exports[`PostArticleDetail > matches snapshot with cover image 1`] = `
     >
       Article body with cover image
     </div>
-    <div
-      class="mt-6 flex lg:hidden"
-      data-post-id="snapshot-user:cover-post"
-      data-testid="post-tags-panel"
-    />
   </div>
 </div>
 `;
@@ -224,33 +184,18 @@ exports[`PostArticleDetail > matches snapshot with default props 1`] = `
     <div
       class="mt-3 mb-6"
       data-post-id="user123:post456"
-      data-testid="post-actions-bar"
+      data-testid="post-inline-tags-actions"
     >
       <button
-        data-testid="tag-button"
-      >
-        Tag
-      </button>
-      <button
-        data-testid="reply-button"
+        data-testid="inline-reply-button"
       >
         Reply
       </button>
       <button
-        data-testid="repost-button"
+        data-testid="inline-repost-button"
       >
         Repost
       </button>
-    </div>
-    <div
-      class="mx-0 mb-6 max-w-2/4"
-      data-testid="container"
-    >
-      <div
-        class="mx-0 hidden lg:flex"
-        data-post-id="user123:post456"
-        data-testid="post-tags-panel"
-      />
     </div>
     <div
       data-is-article="true"
@@ -258,11 +203,6 @@ exports[`PostArticleDetail > matches snapshot with default props 1`] = `
     >
       Test article body content
     </div>
-    <div
-      class="mt-6 flex lg:hidden"
-      data-post-id="user123:post456"
-      data-testid="post-tags-panel"
-    />
   </div>
 </div>
 `;

--- a/src/components/organisms/PostArticleDetail/PostArticleDetail.tsx
+++ b/src/components/organisms/PostArticleDetail/PostArticleDetail.tsx
@@ -18,6 +18,7 @@ import { DialogCheckLink } from '../DialogCheckLink/DialogCheckLink';
 import { PostActionsBar } from '../PostActionsBar/PostActionsBar';
 import { PostContentBlurred } from '../PostContentBlurred/PostContentBlurred';
 import { PostHeader } from '../PostHeader/PostHeader';
+import { PostInlineTagsActions } from '../PostInlineTagsActions/PostInlineTagsActions';
 import { PostTagsPanel } from '../PostTagsPanel/PostTagsPanel';
 import type { PostTagsPanelHandle } from '../PostTagsPanel/PostTagsPanel.types';
 
@@ -29,8 +30,8 @@ interface PostArticleDetailProps {
 }
 
 /**
- * Displays an article post detail page with tags always visible on mobile and desktop.
- * Columns places desktop tags under the header (max-w-2/4); other layouts use a side tags column.
+ * Displays an article post detail page.
+ * Columns reuses the regular post inline tags/actions; other layouts use a side tags column.
  */
 export const PostArticleDetail = ({ postId, content, attachments, isBlurred }: PostArticleDetailProps) => {
   const layout = useHomeStore((state) => state.layout);
@@ -68,13 +69,22 @@ export const PostArticleDetail = ({ postId, content, attachments, isBlurred }: P
 
       <PostHeader postId={postId} size="extraLarge" timeAgoPlacement="bottom-left" />
 
-      <PostActionsBar
-        postId={postId}
-        onTagClick={handleTagClick}
-        onReplyClick={openReplyDialog}
-        onRepostClick={openRepostDialog}
-        className="mt-3 mb-6"
-      />
+      {isColumnsLayout ? (
+        <PostInlineTagsActions
+          postId={postId}
+          onReplyClick={openReplyDialog}
+          onRepostClick={openRepostDialog}
+          className="mt-3 mb-6"
+        />
+      ) : (
+        <PostActionsBar
+          postId={postId}
+          onTagClick={handleTagClick}
+          onReplyClick={openReplyDialog}
+          onRepostClick={openRepostDialog}
+          className="mt-3 mb-6"
+        />
+      )}
     </>
   );
 
@@ -99,18 +109,10 @@ export const PostArticleDetail = ({ postId, content, attachments, isBlurred }: P
       <Container className={cn('mb-6 gap-6', !isColumnsLayout && 'grid grid-cols-1 lg:grid-cols-3')}>
         <Container className={cn(!isColumnsLayout && 'lg:col-span-2')}>
           {articleHeader}
-          {isColumnsLayout && (
-            <Container overrideDefaults className="mx-0 mb-6 max-w-2/4">
-              <PostTagsPanel
-                ref={desktopTagsPanelRef}
-                postId={postId}
-                widthMode="full"
-                className="mx-0 hidden lg:flex"
-              />
-            </Container>
-          )}
           {articleBody}
-          <PostTagsPanel ref={mobileTagsPanelRef} postId={postId} widthMode="full" className="mt-6 flex lg:hidden" />
+          {!isColumnsLayout && (
+            <PostTagsPanel ref={mobileTagsPanelRef} postId={postId} widthMode="full" className="mt-6 flex lg:hidden" />
+          )}
         </Container>
 
         {!isColumnsLayout && (


### PR DESCRIPTION
## Summary

**Improves visual rendering and layout of actions and tags for Articles in Columns layout.**
- Reuses the shared inline post tags and actions for article details in Columns layout.
- Places tags and actions directly below the user header and before the article cover image or body.
- Preserves the existing side tags panel in Wide view.
- Updates focused tests and snapshots for the new rendering.

## Why

Article details in Columns view used an always-expanded tags panel and behaved differently from regular post pages. This change makes both surfaces consistent while reusing the existing tag interaction logic.

## Validation

- 31 focused unit tests passed
- ESLint passed
- TypeScript typecheck passed
- Git diff hygiene check passed

## Before
<img width="829" height="608" alt="image" src="https://github.com/user-attachments/assets/5f215034-44c6-4455-9d4f-5be36fefb4ba" />


## After
<img width="838" height="483" alt="image" src="https://github.com/user-attachments/assets/ceb7e366-084a-419b-8acb-691242974fb8" />
