### PR TITLE
feat(posts): serve raw markdown at post url .md

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,19 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return {
+      // beforeFiles: `.md` must not be treated as a static-file miss before the
+      // App Router `[postId]` page can run. `\\.` is a literal dot — without it
+      // `:postId.md` is a param named `postId.md`.
+      beforeFiles: [
+        {
+          source: '/post/:userId/:postId\\.md',
+          destination: '/api/post/:userId/:postId/markdown',
+        },
+      ],
+    };
+  },
   webpack: (config, { isServer }) => {
     if (isServer) {
       config.externals.push('@synonymdev/pubky');

--- a/src/app/api/post/[userId]/[postId]/markdown/route.test.ts
+++ b/src/app/api/post/[userId]/[postId]/markdown/route.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClientErrorCode } from '@/libs/error/error.codes';
+import { Err } from '@/libs/error/error.factories';
+import { ErrorService } from '@/libs/error/error.types';
+import { HttpStatusCode } from '@/libs/http/http.types';
+import type { NexusPost, NexusPostDetails } from '@/services/nexus/nexus.types';
+import { POST_ID_STAGING_FIXTURE, PUBKY_52_STAGING_FIXTURE } from '@/test-utils/pubky';
+import { GET } from './route';
+
+const mocks = vi.hoisted(() => ({
+  fetchPostViewForServer: vi.fn(),
+  fetchPostDetailsForServer: vi.fn(),
+}));
+
+vi.mock('@/libs/post/postMetadata', () => ({
+  fetchPostViewForServer: mocks.fetchPostViewForServer,
+  fetchPostDetailsForServer: mocks.fetchPostDetailsForServer,
+}));
+
+const USER_ID = PUBKY_52_STAGING_FIXTURE;
+const POST_ID = POST_ID_STAGING_FIXTURE;
+
+function details(overrides: Partial<NexusPostDetails> = {}): NexusPostDetails {
+  return {
+    id: POST_ID,
+    content: 'hello **world**',
+    indexed_at: 1_700_000_000_000,
+    author: USER_ID,
+    kind: 'short',
+    uri: `pubky://${USER_ID}/pub/pubky.app/posts/${POST_ID}`,
+    attachments: null,
+    ...overrides,
+  };
+}
+
+function context(userId = USER_ID, postId = POST_ID) {
+  return { params: Promise.resolve({ userId, postId }) };
+}
+
+function view(
+  detailOverrides: Partial<NexusPostDetails> = {},
+  relationships: NexusPost['relationships'] = { replied: null, reposted: null, mentioned: [] },
+): NexusPost {
+  return {
+    details: details(detailOverrides),
+    counts: { tags: 0, unique_tags: 0, replies: 0, reposts: 0 },
+    tags: [],
+    relationships,
+    bookmark: null,
+  };
+}
+
+describe('API Route: /api/post/[userId]/[postId]/markdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for an invalid pubky without fetching', async () => {
+    const response = await GET(new Request('http://localhost/api/post/nope/abc/markdown'), context('nope', POST_ID));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(await response.text()).toBe('Invalid post');
+    expect(mocks.fetchPostViewForServer).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a post id that is not 13 characters without fetching', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/post/x/doesnotexist/markdown'),
+      context(USER_ID, 'doesnotexist'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid post');
+    expect(mocks.fetchPostViewForServer).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the post is missing', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(null);
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+    expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+  });
+
+  it('returns 404 for a deleted post', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(view({ content: '[DELETED]' }));
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+  });
+
+  it('returns 200 with markdown headers and stored content for a short post', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(view());
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('hello **world**');
+    expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(response.headers.get('Content-Disposition')).toBe(`inline; filename="${POST_ID}.md"`);
+    expect(response.headers.get('Cache-Control')).toBe('public, s-maxage=3600, stale-while-revalidate=86400');
+  });
+
+  it('does not cache markdown for more than 1 hour', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(view());
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+    const cacheControl = response.headers.get('Cache-Control') ?? '';
+    const match = cacheControl.match(/s-maxage=(\d+)/);
+    const sMaxAge = match ? Number(match[1]) : 0;
+
+    expect(sMaxAge).toBeLessThanOrEqual(3600);
+  });
+
+  it('unwraps a long article to heading plus body', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view({ kind: 'long', content: JSON.stringify({ title: 'Title', body: 'Body text' }) }),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('# Title\n\nBody text');
+  });
+
+  it('renders a collection as heading and description without items', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view({
+        kind: 'collection',
+        content: JSON.stringify({
+          name: 'Favs',
+          description: 'Stuff I like',
+          items: ['pubky://author/pub/pubky.app/posts/abc'],
+        }),
+      }),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('# Favs\n\nStuff I like');
+  });
+
+  it('includes image attachments as markdown after the caption', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view({
+        kind: 'image',
+        content: 'sunset',
+        attachments: [`pubky://${USER_ID}/pub/pubky.app/files/img1`],
+      }),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body.startsWith('sunset\n\n![](')).toBe(true);
+    expect(body).toContain('/img1/main');
+  });
+
+  it('returns 200 with an empty body for empty content', async () => {
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(view({ content: '' }));
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+  });
+
+  it('returns text/plain (not JSON) when Nexus fails', async () => {
+    mocks.fetchPostViewForServer.mockRejectedValueOnce(new Error('Nexus down'));
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(await response.text()).toBe('Post unavailable');
+  });
+
+  it('maps a Nexus 400 to Invalid post rather than 502', async () => {
+    mocks.fetchPostViewForServer.mockRejectedValueOnce(
+      Err.client(ClientErrorCode.BAD_REQUEST, 'Bad Request', {
+        service: ErrorService.Nexus,
+        operation: 'fetchPostDetails',
+        context: { statusCode: HttpStatusCode.BAD_REQUEST },
+      }),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid post');
+  });
+
+  it('includes the original post as a blockquote for a quote', async () => {
+    const originalId = '0035ORIGINAL1';
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view(
+        { content: 'my take' },
+        {
+          replied: null,
+          reposted: `pubky://${USER_ID}/pub/pubky.app/posts/${originalId}`,
+          mentioned: [],
+        },
+      ),
+    );
+    mocks.fetchPostDetailsForServer.mockResolvedValueOnce(
+      details({ id: originalId, content: 'the original', uri: `pubky://${USER_ID}/pub/pubky.app/posts/${originalId}` }),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(await response.text()).toBe(`my take\n\n> the original\n>\n> — /post/${USER_ID}/${originalId}.md`);
+    expect(mocks.fetchPostDetailsForServer).toHaveBeenCalledWith(USER_ID, originalId);
+  });
+
+  it('prefixes a reply with a link to the parent and does not fetch it', async () => {
+    const parentId = '0035PARENT000';
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view(
+        { content: 'agreed' },
+        {
+          replied: `pubky://${USER_ID}/pub/pubky.app/posts/${parentId}`,
+          reposted: null,
+          mentioned: [],
+        },
+      ),
+    );
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(await response.text()).toBe(`In reply to: /post/${USER_ID}/${parentId}.md\n\nagreed`);
+    expect(mocks.fetchPostDetailsForServer).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/post/[userId]/[postId]/markdown/route.test.ts
+++ b/src/app/api/post/[userId]/[postId]/markdown/route.test.ts
@@ -219,6 +219,26 @@ describe('API Route: /api/post/[userId]/[postId]/markdown', () => {
     expect(mocks.fetchPostDetailsForServer).toHaveBeenCalledWith(USER_ID, originalId);
   });
 
+  it('omits the quote and still returns 200 when the original fetch fails', async () => {
+    const originalId = '0035ORIGINAL1';
+    mocks.fetchPostViewForServer.mockResolvedValueOnce(
+      view(
+        { content: 'my take' },
+        {
+          replied: null,
+          reposted: `pubky://${USER_ID}/pub/pubky.app/posts/${originalId}`,
+          mentioned: [],
+        },
+      ),
+    );
+    mocks.fetchPostDetailsForServer.mockRejectedValueOnce(new Error('Nexus down'));
+
+    const response = await GET(new Request('http://localhost/api/post/x/y/markdown'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('my take');
+  });
+
   it('prefixes a reply with a link to the parent and does not fetch it', async () => {
     const parentId = '0035PARENT000';
     mocks.fetchPostViewForServer.mockResolvedValueOnce(

--- a/src/app/api/post/[userId]/[postId]/markdown/route.ts
+++ b/src/app/api/post/[userId]/[postId]/markdown/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { POST_ROUTES } from '@/app/routes';
+import { AppError } from '@/libs/error/error';
+import { ErrorCategory } from '@/libs/error/error.types';
+import { HttpStatusCode } from '@/libs/http/http.types';
+import { fetchPostDetailsForServer, fetchPostViewForServer } from '@/libs/post/postMetadata';
+import { type MarkdownQuotedPost, postToMarkdown } from '@/libs/post/postToMarkdown';
+import { isPubkyIdentifier } from '@/libs/utils/utils';
+import { CompositeIdDomain, type Pubky } from '@/models/models.types';
+import { buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
+
+/**
+ * Internal handler for `/post/:userId/:postId.md` (rewritten in next.config).
+ * Returns the post as a markdown document — errors stay text/plain, not JSON.
+ */
+
+const MARKDOWN_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';
+/** Nexus rejects post ids that are not exactly 13 characters. */
+const NEXUS_POST_ID_LENGTH = 13;
+
+type MarkdownRouteContext = {
+  params: Promise<{
+    userId: string;
+    postId: string;
+  }>;
+};
+
+function plain(status: number, body: string): NextResponse {
+  return new NextResponse(body, {
+    status,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}
+
+export async function GET(_request: Request, { params }: MarkdownRouteContext) {
+  const { userId, postId } = await params;
+  if (!isPubkyIdentifier(userId) || postId.length !== NEXUS_POST_ID_LENGTH) {
+    return plain(HttpStatusCode.BAD_REQUEST, 'Invalid post');
+  }
+
+  try {
+    const view = await fetchPostViewForServer(userId, postId);
+    if (!view) {
+      return plain(HttpStatusCode.NOT_FOUND, 'Not found');
+    }
+
+    const markdown = postToMarkdown({
+      ...view.details,
+      quoted: await loadQuotedPost(view.relationships.reposted),
+      replyHref: markdownHrefForPostUri(view.relationships.replied),
+    });
+    if (markdown === null) {
+      return plain(HttpStatusCode.NOT_FOUND, 'Not found');
+    }
+
+    return new NextResponse(markdown, {
+      status: HttpStatusCode.OK,
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Content-Disposition': `inline; filename="${postId}.md"`,
+        'Cache-Control': MARKDOWN_CACHE_CONTROL,
+      },
+    });
+  } catch (error) {
+    if (error instanceof AppError && error.category === ErrorCategory.Client) {
+      const status = error.context?.statusCode;
+      if (status === HttpStatusCode.BAD_REQUEST) {
+        return plain(HttpStatusCode.BAD_REQUEST, 'Invalid post');
+      }
+      return plain(HttpStatusCode.NOT_FOUND, 'Not found');
+    }
+    return plain(HttpStatusCode.BAD_GATEWAY, 'Post unavailable');
+  }
+}
+
+function parsePostUri(uri: string | null | undefined): { userId: string; postId: string } | null {
+  if (!uri) return null;
+  const compositeId = buildCompositeIdFromPubkyUri({ uri: uri as Pubky, domain: CompositeIdDomain.POSTS });
+  if (!compositeId) return null;
+  try {
+    const { pubky, id } = parseCompositeId(compositeId);
+    return { userId: pubky, postId: id };
+  } catch {
+    return null;
+  }
+}
+
+function markdownHrefForPostUri(uri: string | null | undefined): string | null {
+  const parsed = parsePostUri(uri);
+  if (!parsed) return null;
+  return `${POST_ROUTES.POST}/${parsed.userId}/${parsed.postId}.md`;
+}
+
+async function loadQuotedPost(repostedUri: string | null): Promise<MarkdownQuotedPost | undefined> {
+  const parsed = parsePostUri(repostedUri);
+  if (!parsed) return undefined;
+  const post = await fetchPostDetailsForServer(parsed.userId, parsed.postId);
+  if (!post) return undefined;
+  return {
+    kind: post.kind,
+    content: post.content,
+    attachments: post.attachments,
+    href: `${POST_ROUTES.POST}/${parsed.userId}/${parsed.postId}.md`,
+  };
+}

--- a/src/app/api/post/[userId]/[postId]/markdown/route.ts
+++ b/src/app/api/post/[userId]/[postId]/markdown/route.ts
@@ -96,12 +96,17 @@ function markdownHrefForPostUri(uri: string | null | undefined): string | null {
 async function loadQuotedPost(repostedUri: string | null): Promise<MarkdownQuotedPost | undefined> {
   const parsed = parsePostUri(repostedUri);
   if (!parsed) return undefined;
-  const post = await fetchPostDetailsForServer(parsed.userId, parsed.postId);
-  if (!post) return undefined;
-  return {
-    kind: post.kind,
-    content: post.content,
-    attachments: post.attachments,
-    href: `${POST_ROUTES.POST}/${parsed.userId}/${parsed.postId}.md`,
-  };
+  try {
+    const post = await fetchPostDetailsForServer(parsed.userId, parsed.postId);
+    if (!post) return undefined;
+    return {
+      kind: post.kind,
+      content: post.content,
+      attachments: post.attachments,
+      href: `${POST_ROUTES.POST}/${parsed.userId}/${parsed.postId}.md`,
+    };
+  } catch {
+    // Quote lookup is optional. A Nexus blip on the original must not 502 the current post.
+    return undefined;
+  }
 }

--- a/src/libs/file/resolvePostAttachmentUrl.test.ts
+++ b/src/libs/file/resolvePostAttachmentUrl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FileVariant } from '@/services/nexus/file/file.types';
+
+vi.mock('@/services/nexus/file/file.api', () => ({
+  filesApi: {
+    getFileUrl: vi.fn(
+      ({ pubky, file_id, variant }: { pubky: string; file_id: string; variant: string }) =>
+        `https://cdn.test/files/${pubky}/${file_id}/${variant}`,
+    ),
+  },
+}));
+
+const { resolvePostAttachmentUrl } = await import('./resolvePostAttachmentUrl');
+
+describe('resolvePostAttachmentUrl', () => {
+  it('returns null for empty / whitespace / nullish input', () => {
+    expect(resolvePostAttachmentUrl(null)).toBeNull();
+    expect(resolvePostAttachmentUrl(undefined)).toBeNull();
+    expect(resolvePostAttachmentUrl('')).toBeNull();
+    expect(resolvePostAttachmentUrl('   ')).toBeNull();
+  });
+
+  it('rejects any non-pubky:// reference (SSRF guard — only CDN file URIs are used)', () => {
+    expect(resolvePostAttachmentUrl('https://example.com/img.png')).toBeNull();
+    expect(resolvePostAttachmentUrl('http://169.254.169.254/latest/meta-data')).toBeNull();
+    expect(resolvePostAttachmentUrl('http://localhost:6379')).toBeNull();
+    expect(resolvePostAttachmentUrl('data:image/png;base64,AAAA')).toBeNull();
+    expect(resolvePostAttachmentUrl('file:///etc/passwd')).toBeNull();
+    expect(resolvePostAttachmentUrl('not a url')).toBeNull();
+  });
+
+  it('resolves a pubky:// files URI to a CDN URL (default FEED variant)', () => {
+    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/files/file123')).toBe(
+      'https://cdn.test/files/userpk/file123/feed',
+    );
+  });
+
+  it('resolves a pubky:// files URI with an explicit variant', () => {
+    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/files/file123', FileVariant.MAIN)).toBe(
+      'https://cdn.test/files/userpk/file123/main',
+    );
+  });
+
+  it('returns null for a pubky:// URI without a files segment', () => {
+    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/posts/post123')).toBeNull();
+  });
+});

--- a/src/libs/file/resolvePostAttachmentUrl.ts
+++ b/src/libs/file/resolvePostAttachmentUrl.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@/libs/logger/logger';
+import { CompositeIdDomain, type Pubky } from '@/models/models.types';
+import { buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
+import { filesApi } from '@/services/nexus/file/file.api';
+import { FileVariant } from '@/services/nexus/file/file.types';
+
+/**
+ * Resolves a post attachment into an absolute CDN URL.
+ * Only `pubky://<user>/pub/pubky.app/files/<fileId>` URIs are accepted — they
+ * resolve to our own CDN. Anything else (including absolute `http(s)` URLs) is
+ * rejected so callers that fetch the result cannot be pointed at an arbitrary
+ * host (SSRF). In practice every post attachment is a homeserver file URI.
+ *
+ * Uses only pure primitives (avoids the Dexie-tainted `FileController.getFileUrl`).
+ * Returns `null` on any empty / non-pubky / malformed input.
+ */
+export function resolvePostAttachmentUrl(
+  attachmentUri: string | null | undefined,
+  variant: FileVariant = FileVariant.FEED,
+): string | null {
+  const trimmed = attachmentUri?.trim();
+  if (!trimmed) return null;
+
+  if (!trimmed.startsWith('pubky://')) {
+    Logger.warn('[resolvePostAttachmentUrl] Rejected non-pubky attachment (only CDN file URIs are used)', {
+      uri: trimmed,
+    });
+    return null;
+  }
+
+  try {
+    const compositeId = buildCompositeIdFromPubkyUri({
+      uri: trimmed as Pubky,
+      domain: CompositeIdDomain.FILES,
+    });
+    if (!compositeId) return null;
+    const { pubky, id } = parseCompositeId(compositeId);
+    return filesApi.getFileUrl({ pubky, file_id: id, variant });
+  } catch (error) {
+    Logger.warn('[resolvePostAttachmentUrl] Failed to resolve attachment pubky URI', { uri: trimmed, error });
+    return null;
+  }
+}

--- a/src/libs/og/ogData.test.ts
+++ b/src/libs/og/ogData.test.ts
@@ -1,6 +1,5 @@
 import sharp from 'sharp';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FileVariant } from '@/services/nexus/file/file.types';
 
 vi.mock('@/services/nexus/file/file.api', () => ({
   filesApi: {
@@ -14,47 +13,10 @@ vi.mock('@/services/nexus/file/file.api', () => ({
   },
 }));
 
-const { buildAvatarUrl, fetchImageAsDataUri, fetchPostTags, fetchProfileForMetadata, resolvePostAttachmentUrl } =
-  await import('./ogData');
+const { buildAvatarUrl, fetchImageAsDataUri, fetchPostTags, fetchProfileForMetadata } = await import('./ogData');
 
 const jsonResponse = (body: unknown) =>
   new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
-
-describe('resolvePostAttachmentUrl', () => {
-  it('returns null for empty / whitespace / nullish input', () => {
-    expect(resolvePostAttachmentUrl(null)).toBeNull();
-    expect(resolvePostAttachmentUrl(undefined)).toBeNull();
-    expect(resolvePostAttachmentUrl('')).toBeNull();
-    expect(resolvePostAttachmentUrl('   ')).toBeNull();
-  });
-
-  it('rejects any non-pubky:// reference (SSRF guard — only CDN file URIs are fetched)', () => {
-    // Absolute URLs (even http(s)) are NOT fetched — this prevents pointing the
-    // server-side image fetch at arbitrary/internal hosts.
-    expect(resolvePostAttachmentUrl('https://example.com/img.png')).toBeNull();
-    expect(resolvePostAttachmentUrl('http://169.254.169.254/latest/meta-data')).toBeNull();
-    expect(resolvePostAttachmentUrl('http://localhost:6379')).toBeNull();
-    expect(resolvePostAttachmentUrl('data:image/png;base64,AAAA')).toBeNull();
-    expect(resolvePostAttachmentUrl('file:///etc/passwd')).toBeNull();
-    expect(resolvePostAttachmentUrl('not a url')).toBeNull();
-  });
-
-  it('resolves a pubky:// files URI to a CDN URL (default FEED variant)', () => {
-    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/files/file123')).toBe(
-      'https://cdn.test/files/userpk/file123/feed',
-    );
-  });
-
-  it('resolves a pubky:// files URI with an explicit variant', () => {
-    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/files/file123', FileVariant.MAIN)).toBe(
-      'https://cdn.test/files/userpk/file123/main',
-    );
-  });
-
-  it('returns null for a pubky:// URI without a files segment', () => {
-    expect(resolvePostAttachmentUrl('pubky://userpk/pub/pubky.app/posts/post123')).toBeNull();
-  });
-});
 
 describe('buildAvatarUrl', () => {
   it('returns null when the user has no avatar (falsy image flag)', () => {

--- a/src/libs/og/ogData.ts
+++ b/src/libs/og/ogData.ts
@@ -1,15 +1,15 @@
 import sharp from 'sharp';
+import { resolvePostAttachmentUrl } from '@/libs/file/resolvePostAttachmentUrl';
 import { Logger } from '@/libs/logger/logger';
 import { fetchWithValidation } from '@/libs/post/postMetadata';
 import { stripPubkyPrefix } from '@/libs/utils/utils';
-import { CompositeIdDomain, type Pubky } from '@/models/models.types';
-import { buildCompositeIdFromPubkyUri, parseCompositeId } from '@/models/models.utils';
 import { filesApi } from '@/services/nexus/file/file.api';
-import { FileVariant } from '@/services/nexus/file/file.types';
 import type { NexusTag, NexusUserCounts, NexusUserDetails } from '@/services/nexus/nexus.types';
 import { postApi } from '@/services/nexus/post/post.api';
 import { userApi } from '@/services/nexus/user/user.api';
 import { OG_REVALIDATE } from './ogConstants';
+
+export { resolvePostAttachmentUrl };
 
 /**
  * Server-only data helpers for dynamic OG image generation.
@@ -68,44 +68,6 @@ export async function fetchPostTags(userId: string, postId: string, limit: numbe
   } catch (error) {
     Logger.warn('[ogData] Failed to fetch post tags for OG', { userId, postId, error });
     return [];
-  }
-}
-
-/**
- * Resolves a post attachment reference into an absolute CDN URL the OG image
- * renderer can load. Only `pubky://<user>/pub/pubky.app/files/<fileId>` URIs are
- * accepted — they resolve to our own CDN. Anything else (including absolute
- * `http(s)` URLs) is rejected, so the server-side image fetch can never be
- * pointed at an arbitrary/internal host (SSRF). In practice every post attachment
- * is a homeserver file URI, so this reflects reality rather than restricting it.
- *
- * Uses only pure primitives (avoids the Dexie-tainted `FileController.getFileUrl`).
- * Returns `null` on any empty / non-pubky / malformed input so the caller can
- * fall back gracefully.
- */
-export function resolvePostAttachmentUrl(
-  attachmentUri: string | null | undefined,
-  variant: FileVariant = FileVariant.FEED,
-): string | null {
-  const trimmed = attachmentUri?.trim();
-  if (!trimmed) return null;
-
-  if (!trimmed.startsWith('pubky://')) {
-    Logger.warn('[ogData] Rejected non-pubky attachment (only CDN file URIs are fetched)', { uri: trimmed });
-    return null;
-  }
-
-  try {
-    const compositeId = buildCompositeIdFromPubkyUri({
-      uri: trimmed as Pubky,
-      domain: CompositeIdDomain.FILES,
-    });
-    if (!compositeId) return null;
-    const { pubky, id } = parseCompositeId(compositeId);
-    return filesApi.getFileUrl({ pubky, file_id: id, variant });
-  } catch (error) {
-    Logger.warn('[ogData] Failed to resolve attachment pubky URI', { uri: trimmed, error });
-    return null;
   }
 }
 

--- a/src/libs/og/ogData.ts
+++ b/src/libs/og/ogData.ts
@@ -1,5 +1,4 @@
 import sharp from 'sharp';
-import { resolvePostAttachmentUrl } from '@/libs/file/resolvePostAttachmentUrl';
 import { Logger } from '@/libs/logger/logger';
 import { fetchWithValidation } from '@/libs/post/postMetadata';
 import { stripPubkyPrefix } from '@/libs/utils/utils';
@@ -8,8 +7,6 @@ import type { NexusTag, NexusUserCounts, NexusUserDetails } from '@/services/nex
 import { postApi } from '@/services/nexus/post/post.api';
 import { userApi } from '@/services/nexus/user/user.api';
 import { OG_REVALIDATE } from './ogConstants';
-
-export { resolvePostAttachmentUrl };
 
 /**
  * Server-only data helpers for dynamic OG image generation.

--- a/src/libs/og/renderCollectionOg.tsx
+++ b/src/libs/og/renderCollectionOg.tsx
@@ -1,3 +1,4 @@
+import { resolvePostAttachmentUrl } from '@/libs/file/resolvePostAttachmentUrl';
 import { Logger } from '@/libs/logger/logger';
 import { parseCollectionContent } from '@/libs/post/collectionContent';
 import { fetchUserAndPostForMetadata } from '@/libs/post/postMetadata';
@@ -6,7 +7,7 @@ import { generateRandomColor, getDisplayTags, isPostDeleted, resolveDisplayName 
 import { FileVariant } from '@/services/nexus/file/file.types';
 import { OgAvatar, OgFrame, OgHeader } from './OgComponents';
 import { OG_SIZE, OG_TOKENS, OG_TRUNCATE } from './ogConstants';
-import { buildAvatarUrl, fetchImageAsDataUri, fetchPostTags, resolvePostAttachmentUrl } from './ogData';
+import { buildAvatarUrl, fetchImageAsDataUri, fetchPostTags } from './ogData';
 import { LibraryIcon, StickyNoteIcon } from './OgIcons';
 import { ogImageResponse } from './ogImageResponse';
 import { renderFallbackOg } from './renderFallbackOg';

--- a/src/libs/og/renderPostOg.tsx
+++ b/src/libs/og/renderPostOg.tsx
@@ -1,3 +1,4 @@
+import { resolvePostAttachmentUrl } from '@/libs/file/resolvePostAttachmentUrl';
 import { Logger } from '@/libs/logger/logger';
 import { parseArticleContent } from '@/libs/post/articleContent';
 import { markdownToText } from '@/libs/post/markdownToText';
@@ -8,7 +9,7 @@ import { isPostDeleted, resolveDisplayName } from '@/libs/utils/utils';
 import { FileVariant } from '@/services/nexus/file/file.types';
 import { OgFrame, OgHeader } from './OgComponents';
 import { OG_TOKENS, OG_TRUNCATE } from './ogConstants';
-import { buildAvatarUrl, fetchImageAsDataUri, resolvePostAttachmentUrl } from './ogData';
+import { buildAvatarUrl, fetchImageAsDataUri } from './ogData';
 import { NewspaperIcon } from './OgIcons';
 import { ogImageResponse } from './ogImageResponse';
 import { renderCollectionOg } from './renderCollectionOg';

--- a/src/libs/post/postMetadata.ts
+++ b/src/libs/post/postMetadata.ts
@@ -1,7 +1,7 @@
 import { httpResponseToError } from '@/libs/error/error.http';
 import { ErrorService } from '@/libs/error/error.types';
 import { HttpStatusCode } from '@/libs/http/http.types';
-import type { NexusPostDetails, NexusUserDetails } from '@/services/nexus/nexus.types';
+import type { NexusPost, NexusPostDetails, NexusUserDetails } from '@/services/nexus/nexus.types';
 import { postApi } from '@/services/nexus/post/post.api';
 import { userApi } from '@/services/nexus/user/user.api';
 
@@ -24,6 +24,22 @@ export async function fetchWithValidation<T>(url: string, operation: string): Pr
 }
 
 /**
+ * Server-only post details fetch (Nexus + Next Data Cache). Does not touch Dexie.
+ * Used by the `/{postId}.md` route, which must not go through PostController.
+ */
+export async function fetchPostDetailsForServer(userId: string, postId: string): Promise<NexusPostDetails | null> {
+  return fetchWithValidation<NexusPostDetails>(
+    postApi.details({ author_id: userId, post_id: postId }),
+    'fetchPostDetails',
+  );
+}
+
+/** Full post view (details + relationships). Used by `/{postId}.md` for quotes/replies. */
+export async function fetchPostViewForServer(userId: string, postId: string): Promise<NexusPost | null> {
+  return fetchWithValidation<NexusPost>(postApi.view({ author_id: userId, post_id: postId }), 'fetchPostView');
+}
+
+/**
  * Concurrently fetches user and post details for use in `generateMetadata`.
  * Returns `null` when either resource is missing so callers can fall back to
  * empty metadata in a single guard.
@@ -34,7 +50,7 @@ export async function fetchUserAndPostForMetadata(
 ): Promise<{ user: NexusUserDetails; post: NexusPostDetails } | null> {
   const [user, post] = await Promise.all([
     fetchWithValidation<NexusUserDetails>(userApi.details({ user_id: userId }), 'fetchUserDetails'),
-    fetchWithValidation<NexusPostDetails>(postApi.details({ author_id: userId, post_id: postId }), 'fetchPostDetails'),
+    fetchPostDetailsForServer(userId, postId),
   ]);
 
   if (!user || !post) return null;

--- a/src/libs/post/postToMarkdown.test.ts
+++ b/src/libs/post/postToMarkdown.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/nexus/file/file.api', () => ({
+  filesApi: {
+    getFileUrl: ({ pubky, file_id, variant }: { pubky: string; file_id: string; variant: string }) =>
+      `https://cdn.test/files/${pubky}/${file_id}/${variant}`,
+  },
+}));
+
+const { postToMarkdown } = await import('./postToMarkdown');
+
+const IMAGE_URI = 'pubky://userpk/pub/pubky.app/files/img1';
+const VIDEO_URI = 'pubky://userpk/pub/pubky.app/files/vid1';
+const FILE_URI = 'pubky://userpk/pub/pubky.app/files/doc1';
+
+describe('postToMarkdown', () => {
+  it('returns null for a deleted post regardless of kind', () => {
+    expect(postToMarkdown({ kind: 'short', content: '[DELETED]' })).toBeNull();
+    expect(postToMarkdown({ kind: 'long', content: '[DELETED]' })).toBeNull();
+    expect(postToMarkdown({ kind: 'collection', content: '[DELETED]' })).toBeNull();
+    expect(postToMarkdown({ kind: 'image', content: '[DELETED]', attachments: [IMAGE_URI] })).toBeNull();
+  });
+
+  it('returns stored content for short, reply, link, and media kinds', () => {
+    expect(postToMarkdown({ kind: 'short', content: 'hello **world**' })).toBe('hello **world**');
+    expect(postToMarkdown({ kind: 'reply', content: 'a reply' })).toBe('a reply');
+    expect(postToMarkdown({ kind: 'link', content: 'https://x.test' })).toBe('https://x.test');
+    expect(postToMarkdown({ kind: 'image', content: 'caption' })).toBe('caption');
+    expect(postToMarkdown({ kind: 'video', content: '' })).toBe('');
+    expect(postToMarkdown({ kind: 'file', content: '' })).toBe('');
+  });
+
+  it('unwraps a long article to a heading plus body', () => {
+    const content = JSON.stringify({ title: 'My Article', body: 'The body *here*.' });
+    expect(postToMarkdown({ kind: 'long', content })).toBe('# My Article\n\nThe body *here*.');
+  });
+
+  it('falls back to raw content for an unparseable long post', () => {
+    expect(postToMarkdown({ kind: 'long', content: 'plain text' })).toBe('plain text');
+  });
+
+  it('renders a collection as a heading and description, omitting items', () => {
+    const content = JSON.stringify({
+      name: 'Based Bitcoin',
+      description: 'A bit of Bitcoin purity.',
+      items: ['pubky://author/pub/pubky.app/posts/abc'],
+    });
+    expect(postToMarkdown({ kind: 'collection', content })).toBe('# Based Bitcoin\n\nA bit of Bitcoin purity.');
+  });
+
+  it('renders a collection with only a name as a heading', () => {
+    const content = JSON.stringify({ name: 'Empty collection' });
+    expect(postToMarkdown({ kind: 'collection', content })).toBe('# Empty collection');
+  });
+
+  it('falls back to raw content for an unparseable collection', () => {
+    expect(postToMarkdown({ kind: 'collection', content: 'not json' })).toBe('not json');
+  });
+
+  it('appends image attachments as markdown images after the caption', () => {
+    expect(postToMarkdown({ kind: 'image', content: 'sunset', attachments: [IMAGE_URI] })).toBe(
+      'sunset\n\n![](https://cdn.test/files/userpk/img1/main)',
+    );
+  });
+
+  it('emits only the image embed for an image-only post', () => {
+    expect(postToMarkdown({ kind: 'image', content: '', attachments: [IMAGE_URI] })).toBe(
+      '![](https://cdn.test/files/userpk/img1/main)',
+    );
+  });
+
+  it('appends each image attachment on its own block', () => {
+    const second = 'pubky://userpk/pub/pubky.app/files/img2';
+    expect(postToMarkdown({ kind: 'image', content: '', attachments: [IMAGE_URI, second] })).toBe(
+      '![](https://cdn.test/files/userpk/img1/main)\n\n![](https://cdn.test/files/userpk/img2/main)',
+    );
+  });
+
+  it('appends video attachments as markdown links', () => {
+    expect(postToMarkdown({ kind: 'video', content: 'clip', attachments: [VIDEO_URI] })).toBe(
+      'clip\n\n[video](https://cdn.test/files/userpk/vid1/main)',
+    );
+  });
+
+  it('appends file attachments as markdown links', () => {
+    expect(postToMarkdown({ kind: 'file', content: '', attachments: [FILE_URI] })).toBe(
+      '[file](https://cdn.test/files/userpk/doc1/main)',
+    );
+  });
+
+  it('skips malformed attachment URIs', () => {
+    expect(
+      postToMarkdown({
+        kind: 'image',
+        content: 'ok',
+        attachments: ['https://evil.example/x.png', IMAGE_URI, 'not-a-uri'],
+      }),
+    ).toBe('ok\n\n![](https://cdn.test/files/userpk/img1/main)');
+  });
+
+  it('appends article attachments after the unwrapped body', () => {
+    const content = JSON.stringify({ title: 'Title', body: 'Body' });
+    expect(postToMarkdown({ kind: 'long', content, attachments: [IMAGE_URI] })).toBe(
+      '# Title\n\nBody\n\n![](https://cdn.test/files/userpk/img1/main)',
+    );
+  });
+
+  it('renders a quote comment above the original as a blockquote', () => {
+    expect(
+      postToMarkdown({
+        kind: 'short',
+        content: 'my take',
+        quoted: {
+          kind: 'short',
+          content: 'original line\nstill original',
+          href: '/post/author/0035ORIGINAL.md',
+        },
+      }),
+    ).toBe('my take\n\n> original line\n> still original\n>\n> — /post/author/0035ORIGINAL.md');
+  });
+
+  it('renders a bare repost as only the original blockquote', () => {
+    expect(
+      postToMarkdown({
+        kind: 'short',
+        content: '',
+        quoted: { kind: 'short', content: 'just the original', href: '/post/a/b.md' },
+      }),
+    ).toBe('> just the original\n>\n> — /post/a/b.md');
+  });
+
+  it('includes quoted attachments inside the blockquote', () => {
+    expect(
+      postToMarkdown({
+        kind: 'short',
+        content: 'nice pic',
+        quoted: {
+          kind: 'image',
+          content: 'sunset',
+          attachments: [IMAGE_URI],
+          href: '/post/a/b.md',
+        },
+      }),
+    ).toBe('nice pic\n\n> sunset\n>\n> ![](https://cdn.test/files/userpk/img1/main)\n>\n> — /post/a/b.md');
+  });
+
+  it('omits a deleted quoted original', () => {
+    expect(
+      postToMarkdown({
+        kind: 'short',
+        content: 'still here',
+        quoted: { kind: 'short', content: '[DELETED]', href: '/post/a/b.md' },
+      }),
+    ).toBe('still here');
+  });
+
+  it('prefixes a reply with a link to the parent .md', () => {
+    expect(postToMarkdown({ kind: 'short', content: 'agreed', replyHref: '/post/a/b.md' })).toBe(
+      'In reply to: /post/a/b.md\n\nagreed',
+    );
+  });
+});

--- a/src/libs/post/postToMarkdown.ts
+++ b/src/libs/post/postToMarkdown.ts
@@ -1,0 +1,88 @@
+import { resolvePostAttachmentUrl } from '@/libs/file/resolvePostAttachmentUrl';
+import { isPostDeleted } from '@/libs/utils/utils';
+import { FileVariant } from '@/services/nexus/file/file.types';
+import { parseArticleContent } from './articleContent';
+import { parseCollectionContent } from './collectionContent';
+
+export type MarkdownQuotedPost = {
+  kind: string;
+  content: string;
+  attachments?: string[] | null;
+  href: string;
+};
+
+type MarkdownPost = {
+  kind: string;
+  content: string;
+  attachments?: string[] | null;
+  quoted?: MarkdownQuotedPost;
+  replyHref?: string | null;
+};
+
+/**
+ * Turns stored post details into the body for `/{postId}.md`.
+ * Returns `null` for tombstones so the route can 404 instead of emitting `[DELETED]`.
+ * Homeserver file attachments are appended as markdown image or link syntax
+ * pointing at the CDN `main` variant — they are not part of `content`.
+ * Quoted/reposted originals are a blockquote (depth 1). Replies get a link, not the parent body.
+ */
+export function postToMarkdown(post: MarkdownPost): string | null {
+  if (isPostDeleted(post.content)) return null;
+
+  const reply = post.replyHref ? `In reply to: ${post.replyHref}` : '';
+  const body = contentToMarkdown(post);
+  const media = attachmentsToMarkdown(post.attachments, post.kind);
+  const quoted = post.quoted ? quotedToMarkdown(post.quoted) : '';
+  return [reply, body, media, quoted].filter((section) => section.length > 0).join('\n\n');
+}
+
+function contentToMarkdown(post: MarkdownPost): string {
+  if (post.kind === 'long') {
+    const article = parseArticleContent(post.content);
+    if (article) return `# ${article.title}\n\n${article.body}`;
+  }
+
+  if (post.kind === 'collection') {
+    const collection = parseCollectionContent(post.content);
+    if (collection) {
+      return [`# ${collection.name}`, collection.description].filter(Boolean).join('\n\n');
+    }
+  }
+
+  return post.content;
+}
+
+function attachmentsToMarkdown(uris: string[] | null | undefined, kind: string): string {
+  if (!uris?.length) return '';
+
+  const lines: string[] = [];
+  for (const uri of uris) {
+    const url = resolvePostAttachmentUrl(uri, FileVariant.MAIN);
+    if (!url) continue;
+    lines.push(embedForKind(url, kind));
+  }
+  return lines.join('\n\n');
+}
+
+function embedForKind(url: string, kind: string): string {
+  if (kind === 'video') return `[video](${url})`;
+  if (kind === 'file') return `[file](${url})`;
+  return `![](${url})`;
+}
+
+function quotedToMarkdown(quoted: MarkdownQuotedPost): string {
+  const inner = postToMarkdown({
+    kind: quoted.kind,
+    content: quoted.content,
+    attachments: quoted.attachments,
+  });
+  if (!inner) return '';
+  return `${asBlockquote(inner)}\n>\n> — ${quoted.href}`;
+}
+
+function asBlockquote(markdown: string): string {
+  return markdown
+    .split('\n')
+    .map((line) => (line.length === 0 ? '>' : `> ${line}`))
+    .join('\n');
+}


### PR DESCRIPTION
`/post/{userId}/{postId}.md` returns that post as `text/markdown`. Same path as the UI, `.md` on the end. No app chrome.

```
https://pubky.app/post/{userId}/{postId}
https://pubky.app/post/{userId}/{postId}.md
```

Shares, crawlers, and chat already carry `pubky.app/post/…` links. This formats the same Nexus read we already do for OG images and `generateMetadata`. Graph queries stay on [nexus-scout](https://github.com/pubky/nexus-scout) / `llms.txt`.

| Kind | Markdown |
| --- | --- |
| short / reply / link | composer markdown |
| article | `# title` plus body, not the JSON envelope |
| collection | `# name` plus description. Item list is not expanded. |
| image | caption plus `![](cdn/main)` |
| video | caption plus `[video](cdn/main)` |
| file | caption plus `[file](cdn/main)` |
| quote / repost | comment if any, then the original as a one-level blockquote with a link to its `.md` |
| reply | `In reply to: /post/….md` plus the reply. Parent body is not inlined. |
| deleted / missing | 404 |

Attachments live on `pubky://` file URIs, not in `content`. They resolve to CDN `main` URLs. Quotes stop at one level. If the original quote fetch fails, the current post still returns.

Wiring:
- `beforeFiles` rewrite `/post/:userId/:postId.md` → `/api/post/:userId/:postId/markdown`
- Route Handler, so root layout, Dexie, and route guard never run
- Nexus `view`, plus original `details` when the post is a quote or repost

Not in this PR:
- in-app "view markdown" button
- `/collections/{user}/{id}.md`
- expanding collection items or reply threads
- `middleware.ts`

Tested:
- unit: kinds, attachments, quotes, replies, deleted
- unit: 200/400/404/502, Content-Type, cache bound
- unit: quote original fetch failure still 200
- live: image CDN jpeg, quote blockquote, empty repost is not empty, article unwrap, UI URL unchanged